### PR TITLE
feat: add `skipCrossDatasetReferenceValidation` flag to mutations

### DIFF
--- a/sanityClient.d.ts
+++ b/sanityClient.d.ts
@@ -538,6 +538,7 @@ type BaseMutationOptions = RequestOptions & {
   visibility?: 'sync' | 'async' | 'deferred'
   returnDocuments?: boolean
   returnFirst?: boolean
+  skipCrossDatasetReferenceValidation?: boolean
 }
 
 export type MutationEvent<R = any> = {

--- a/src/data/dataMethods.js
+++ b/src/data/dataMethods.js
@@ -17,6 +17,9 @@ const getMutationQuery = (options = {}) => {
     returnIds: true,
     returnDocuments: excludeFalsey(options.returnDocuments, true),
     visibility: options.visibility || 'sync',
+    ...(options.skipCrossDatasetReferenceValidation && {
+      skipCrossDatasetReferenceValidation: options.skipCrossDatasetReferenceValidation,
+    }),
   }
 }
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -940,6 +940,25 @@ test('mutate() accepts request tag', (t) => {
     .then(() => t.end())
 })
 
+test('mutate() accepts skipCrossDatasetReferenceValidation', (t) => {
+  const mutations = [{delete: {id: 'abc123'}}]
+
+  nock(projectHost())
+    .post(
+      '/v1/data/mutate/foo?tag=foobar&returnIds=true&returnDocuments=true&visibility=sync&skipCrossDatasetReferenceValidation=true',
+      {mutations}
+    )
+    .reply(200, {
+      transactionId: 'foo',
+      results: [{id: 'abc123', operation: 'delete', document: {_id: 'abc123'}}],
+    })
+
+  getClient()
+    .mutate(mutations, {tag: 'foobar', skipCrossDatasetReferenceValidation: true})
+    .catch(t.ifError)
+    .then(() => t.end())
+})
+
 test('uses GET for queries below limit', (t) => {
   // Please dont ever do this. Just... don't.
   const clause = []


### PR DESCRIPTION
Adds the `skipCrossDatasetReferenceValidation` flag required for https://github.com/sanity-io/sanity/pull/3117