### PR TITLE
feat: add new polyfill for event source 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "3.0.6",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.6",
       "license": "MIT",
       "dependencies": {
-        "@sanity/eventsource": "^2.23.0",
+        "@sanity/eventsource": "^3.0.1",
         "@sanity/generate-help-url": "^2.18.0",
         "get-it": "^6.0.0",
         "make-error": "^1.3.0",
@@ -1750,17 +1750,12 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/@rexxars/eventsource-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
-      "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw=="
-    },
     "node_modules/@sanity/eventsource": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.23.0.tgz",
-      "integrity": "sha512-MpQoV8FqnwnfBPQ29qcI1WA6MPZI1Z8rACFky5yU/8hol/Vv9g38PJbvHsGXsDkDartRXN5Wx5OjFk2imG4QPQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-3.0.1.tgz",
+      "integrity": "sha512-xeMzr0wK/1+lawSicDg8yA7mdoNY3SKtr70CCsb1ltWbtYtsgZWjKeqNivNAWofxSU2GN7yU23HPzyk6Tx9fkA==",
       "dependencies": {
-        "@rexxars/eventsource-polyfill": "^1.0.0",
+        "event-source-polyfill": "^1.0.25",
         "eventsource": "^1.0.6"
       }
     },
@@ -3402,6 +3397,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3546,9 +3546,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "funding": [
         {
           "type": "individual",
@@ -6569,9 +6569,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
+      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -8017,17 +8017,12 @@
       "dev": true,
       "optional": true
     },
-    "@rexxars/eventsource-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
-      "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw=="
-    },
     "@sanity/eventsource": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-2.23.0.tgz",
-      "integrity": "sha512-MpQoV8FqnwnfBPQ29qcI1WA6MPZI1Z8rACFky5yU/8hol/Vv9g38PJbvHsGXsDkDartRXN5Wx5OjFk2imG4QPQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-3.0.1.tgz",
+      "integrity": "sha512-xeMzr0wK/1+lawSicDg8yA7mdoNY3SKtr70CCsb1ltWbtYtsgZWjKeqNivNAWofxSU2GN7yU23HPzyk6Tx9fkA==",
       "requires": {
-        "@rexxars/eventsource-polyfill": "^1.0.0",
+        "event-source-polyfill": "^1.0.25",
         "eventsource": "^1.0.6"
       }
     },
@@ -9363,6 +9358,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-source-polyfill": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz",
+      "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -9479,9 +9479,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -11827,9 +11827,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
+      "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@sanity/eventsource": "^2.23.0",
+    "@sanity/eventsource": "^3.0.1",
     "@sanity/generate-help-url": "^2.18.0",
     "get-it": "^6.0.0",
     "make-error": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "main": "lib/sanityClient.js",
   "umd": "umd/sanityClient.min.js",

--- a/src/data/listen.js
+++ b/src/data/listen.js
@@ -1,9 +1,7 @@
 const assign = require('object-assign')
 const {Observable} = require('../util/observable')
 const polyfilledEventSource = require('@sanity/eventsource')
-const generateHelpUrl = require('@sanity/generate-help-url')
 const pick = require('../util/pick')
-const once = require('../util/once')
 const defaults = require('../util/defaults')
 const encodeQueryString = require('./encodeQueryString')
 
@@ -11,18 +9,7 @@ const encodeQueryString = require('./encodeQueryString')
 // unknown range of headers, but an average EventSource request from Chrome seems
 // to have around 700 bytes of cruft, so let us account for 1.2K to be "safe"
 const MAX_URL_LENGTH = 16000 - 1200
-
-const tokenWarning = [
-  'Using token with listeners is not supported in browsers. ',
-  `For more info, see ${generateHelpUrl('js-client-listener-tokens-browser')}.`,
-]
-// eslint-disable-next-line no-console
-const printTokenWarning = once(() => console.warn(tokenWarning.join(' ')))
-
-const isWindowEventSource = Boolean(typeof window !== 'undefined' && window.EventSource)
-const EventSource = isWindowEventSource
-  ? window.EventSource // Native browser EventSource
-  : polyfilledEventSource // Node.js, IE etc
+const EventSource = polyfilledEventSource
 
 const possibleOptions = [
   'includePreviousRevision',
@@ -50,10 +37,6 @@ module.exports = function listen(query, params, opts = {}) {
 
   const listenFor = options.events ? options.events : ['mutation']
   const shouldEmitReconnect = listenFor.indexOf('reconnect') !== -1
-
-  if (token && isWindowEventSource) {
-    printTokenWarning()
-  }
 
   const esOptions = {}
   if (token || withCredentials) {


### PR DESCRIPTION
EventSource/SSE which we are using for listeners in the Studio will not accept headers, and thus can't be used with token auth.

We need to use a polyfill for this. The client was already using one, however, the polyfill wasn't working well for Safari so we had to change it.

This PR is the end result of a spike that was done, and tried to use https://github.com/EventSource/eventsource and it works very well! 

We changed polyfill from the first one we had considered because it caused a lot of conflicts with the listener tests that were already set up.

We've made the decision to only ever use the polyfil (vs checking if the browser has a default EventSource) so that it will be more consistent in the future and easier to debug.
