### PR TITLE
fix(typings): add missing `timeout` config option

### DIFF
--- a/sanityClient.d.ts
+++ b/sanityClient.d.ts
@@ -503,6 +503,7 @@ export interface ClientConfig {
   requestTagPrefix?: string
   ignoreBrowserTokenWarning?: boolean
   withCredentials?: boolean
+  timeout?: number
 
   /**
    * @deprecated Don't use


### PR DESCRIPTION
I have a React Native project running on Android. The console is filled with warnings relating to timers with long timeout periods, which are triggered by requests in Sanity client.

Example:
```
Setting a timer for a long period of time, i.e. multiple minutes, is a performance and correctness issue on Android as it keeps the timer module awake, and timers can only be called when the app is in the foreground. See https://github.com/facebook/react-native/issues/12981 for more info.
(Saw setTimeout with duration 300000ms)
at /***/node_modules/@sanity/client/node_modules/get-it/lib/request/browser-request.js:155:28 in setTimeout$argument_0
```

From looking at [requestOptions.js](https://github.com/sanity-io/client/blob/main/src/http/requestOptions.js#L23), `timeout` is an available property for the client configuration, and I can confirm setting it (down to 60 seconds) works as expected (i.e. no more warnings).

It is however missing from the type information for ClientConfig.