### PR TITLE
feat: support passing custom headers to http methods

### DIFF
--- a/sanityClient.d.ts
+++ b/sanityClient.d.ts
@@ -532,6 +532,7 @@ export interface RequestOptions {
   timeout?: number
   token?: string
   tag?: string
+  headers?: Record<string, string>
 }
 
 type BaseMutationOptions = RequestOptions & {

--- a/src/data/dataMethods.js
+++ b/src/data/dataMethods.js
@@ -130,7 +130,7 @@ module.exports = {
     const useGet = !isMutation && strQuery.length < getQuerySizeLimit
     const stringQuery = useGet ? strQuery : ''
     const returnFirst = options.returnFirst
-    const {timeout, token, tag} = options
+    const {timeout, token, tag, headers} = options
 
     const uri = this.getDataUrl(endpoint, stringQuery)
 
@@ -141,6 +141,7 @@ module.exports = {
       body: useGet ? undefined : body,
       query: isMutation && getMutationQuery(options),
       timeout,
+      headers,
       token,
       tag,
       canUseCdn: isQuery,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2248,6 +2248,23 @@ test('will use cdn for queries even when with token specified', (t) => {
   client.fetch('*').then(noop).catch(t.ifError).then(t.end)
 })
 
+test('allows overriding headers', (t) => {
+
+  const client = sanityClient({
+    projectId: 'abc123',
+    dataset: 'foo',
+    token: 'foo',
+  })
+
+  const reqheaders = {foo: 'bar'}
+  nock('https://abc123.api.sanity.io', {reqheaders})
+    .get('/v1/data/query/foo?query=*')
+    .reply(200, {result: []})
+
+  client.fetch('*', {}, {headers: {foo: 'bar'}}).then(noop).catch(t.ifError).then(t.end)
+
+})
+
 test('will use live API if withCredentials is set to true', (t) => {
   const client = sanityClient({
     withCredentials: true,


### PR DESCRIPTION
This adds support for passing custom http headers to client http methods, e.g.

```js
client.fetch('...', {}, {headers: {'some-custom-header': 'blah'}})
```