### PR TITLE
feat: add `dryRun`, `autoGenerateArrayKeys` mutation options

### DIFF
--- a/sanityClient.d.ts
+++ b/sanityClient.d.ts
@@ -540,6 +540,8 @@ type BaseMutationOptions = RequestOptions & {
   visibility?: 'sync' | 'async' | 'deferred'
   returnDocuments?: boolean
   returnFirst?: boolean
+  dryRun?: boolean
+  autoGenerateArrayKeys?: boolean
   skipCrossDatasetReferenceValidation?: boolean
 }
 

--- a/src/data/dataMethods.js
+++ b/src/data/dataMethods.js
@@ -14,12 +14,12 @@ const excludeFalsey = (param, defValue) => {
 
 const getMutationQuery = (options = {}) => {
   return {
+    dryRun: options.dryRun,
     returnIds: true,
     returnDocuments: excludeFalsey(options.returnDocuments, true),
     visibility: options.visibility || 'sync',
-    ...(options.skipCrossDatasetReferenceValidation && {
-      skipCrossDatasetReferenceValidation: options.skipCrossDatasetReferenceValidation,
-    }),
+    autoGenerateArrayKeys: options.autoGenerateArrayKeys,
+    skipCrossDatasetReferenceValidation: options.skipCrossDatasetReferenceValidation,
   }
 }
 


### PR DESCRIPTION
This PR adds two missing mutation options to the client mutation options:
 
- `dryRun` (`true|false`) - default `false`. If true, the mutation will be a dry run - the response will be identical to the one returned had this property been omitted or false (including error responses) but no documents will be affected.
- `autoGenerateArrayKeys` (`true|false`) - default `false`. If true, the mutation API will automatically add `_key` attributes to objects in arrays that is missing them. This makes array operations more robust by having a unique key within the array available for selections, which helps prevent race conditions in real-time, collaborative editing.

Also slightly tightens up the readme to be a bit clearer on the availability of the mutation options.

Closes #6