### PR TITLE
doc: add missing info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ const client = sanityClient({
   token: 'sanity-auth-token', // or leave blank for unauthenticated usage
   useCdn: true, // `false` if you want to ensure fresh data
 })
+
+export default client
 ```
 
 `const client = sanityClient(options)`


### PR DESCRIPTION
`client` must be exported before it can be used elsewhere. 