### PR TITLE
chore: let robots maintain `bun.lockb`

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -1,0 +1,21 @@
+name: Maintain bun.lockb
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package-lock.json'
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: bun install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: antongolub/action-setup-bun@v1
+      - run: bun install
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: 'chore(bun): update bun lockfile'
+          default_author: github_actions


### PR DESCRIPTION
> I'm guessing we need to remember to update the bun lockfile whenever dependencies are updated?
> https://github.com/sanity-io/client/pull/19#pullrequestreview-1084438726

Let's not need to remember doing that 😌 