### PR TITLE
fix(typings): missing class extend of `ObservableTransaction` in #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file. See
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- fix(typings): missing class extend in #22
+
 ## [3.3.5]
 
 - fix: regression introduced in #24. Partially exporting ESM breaks environments that bundle for the browser, such as Next.js. Remove `pkg.exports` until what we ship there is 100% compatible with the ecosystem.

--- a/sanityClient.d.ts
+++ b/sanityClient.d.ts
@@ -545,7 +545,7 @@ export class Transaction extends BaseTransaction {
   commit(options?: BaseMutationOptions): Promise<MultipleMutationResult>
 }
 
-export class ObservableTransaction {
+export class ObservableTransaction extends BaseTransaction {
   constructor(operations?: Mutation[], client?: ObservableSanityClient, transactionId?: string)
 
   /**


### PR DESCRIPTION
It looks like #22 intended to extend `ObservableTransaction` from `BaseTransaction`, but the change wasn't included in the commit. This broke type checks in the studio monorepo, where calling any methods like `versionedClient.observable.transaction().delete` would give you errors like:

```
packages/@sanity/base/src/datastores/document/document-pair/operations/discardChanges.ts:17:8 - error TS2339: Property 'delete' does not exist on type 'ObservableTransaction'.

17       .delete(idPair.draftId)
```

Fixes #25 