### PR TITLE
fix: Add params to MutationSelection

### DIFF
--- a/sanityClient.d.ts
+++ b/sanityClient.d.ts
@@ -35,7 +35,7 @@ export interface ProgressEvent {
 
 type AttributeSet = {[key: string]: any}
 type QueryParams = {[key: string]: any}
-type MutationSelection = {query: string} | {id: string}
+type MutationSelection = {query: string, params?: QueryParams} | {id: string}
 type SanityReference = {_ref: string}
 
 interface RawRequestOptions {


### PR DESCRIPTION
Fixes: #31 

This PR simply adds `params?: QueryParams` to the `MutationSelection` type so that it matches the documentation.

The change should be fine as it both matches the documentation, and every method that uses this type uses the utility function `getSelection` which supports every case that the `MutationSelection` type now supports.