### PR TITLE
docs: replaced a broken link with a new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Assets can be uploaded using the `client.assets.upload(...)` method.
 client.assets.upload(type: 'file' | image', body: File | Blob | Buffer | NodeStream, options = {}): Promise<AssetDocument>
 ```
 
-👉 Read more about [assets in Sanity](https://sanity.io/docs/http-api/assets)
+👉 Read more about [assets in Sanity](https://sanity.io/docs/assets)
 
 #### Examples: Uploading assets from Node.js
 


### PR DESCRIPTION
replace `https://sanity.io/docs/http-api/assets` with `https://sanity.io/docs/assets`