### PR TITLE
fix(deps): upgrade rxjs to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sanity/eventsource": "^4.0.0",
         "get-it": "^7.0.2",
         "make-error": "^1.3.6",
-        "rxjs": "^6.6.7"
+        "rxjs": "^7.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.20.7",
@@ -10526,14 +10526,11 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -11447,9 +11444,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@sanity/eventsource": "^4.0.0",
     "get-it": "^7.0.2",
     "make-error": "^1.3.6",
-    "rxjs": "^6.6.7"
+    "rxjs": "^7.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",

--- a/src/assets/assetsClient.js
+++ b/src/assets/assetsClient.js
@@ -1,6 +1,6 @@
-import {map, filter} from '../util/observable'
 import queryString from '../http/queryString'
 import * as validators from '../validators'
+import {filter, map} from 'rxjs/operators'
 
 function AssetsClient(client) {
   this.client = client

--- a/src/data/dataMethods.js
+++ b/src/data/dataMethods.js
@@ -1,10 +1,10 @@
-import {map, filter} from '../util/observable'
 import * as validators from '../validators'
 import getSelection from '../util/getSelection'
 import encodeQueryString from './encodeQueryString'
 import Transaction from './transaction'
 import Patch from './patch'
 import listen from './listen'
+import {filter, map} from 'rxjs/operators'
 
 const excludeFalsey = (param, defValue) => {
   const value = typeof param === 'undefined' ? defValue : param

--- a/src/data/listen.js
+++ b/src/data/listen.js
@@ -1,8 +1,8 @@
-import {Observable} from '../util/observable'
 import polyfilledEventSource from '@sanity/eventsource'
 import pick from '../util/pick'
 import defaults from '../util/defaults'
 import encodeQueryString from './encodeQueryString'
+import {Observable} from 'rxjs'
 
 // Limit is 16K for a _request_, eg including headers. Have to account for an
 // unknown range of headers, but an average EventSource request from Chrome seems

--- a/src/http/request.js
+++ b/src/http/request.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-empty-function, no-process-env */
 import getIt from 'get-it'
 import {observable, jsonRequest, jsonResponse, progress} from 'get-it/middleware'
-import {Observable} from '../util/observable'
 import {ClientError, ServerError} from './errors'
 import envMiddleware from './nodeMiddleware'
+import {Observable} from 'rxjs'
 
 const httpError = {
   onResponse: (res) => {

--- a/src/sanityClient.js
+++ b/src/sanityClient.js
@@ -1,4 +1,3 @@
-import {Observable, map, filter} from './util/observable'
 import Patch from './data/patch'
 import Transaction from './data/transaction'
 import dataMethods from './data/dataMethods'
@@ -11,6 +10,8 @@ import httpRequest from './http/request'
 import getRequestOptions from './http/requestOptions'
 import {defaultConfig, initConfig} from './config'
 import * as validate from './validators'
+import {Observable} from 'rxjs'
+import {filter, map} from 'rxjs/operators'
 
 const toPromise = (observable) => observable.toPromise()
 

--- a/src/sanityClient.js
+++ b/src/sanityClient.js
@@ -10,10 +10,8 @@ import httpRequest from './http/request'
 import getRequestOptions from './http/requestOptions'
 import {defaultConfig, initConfig} from './config'
 import * as validate from './validators'
-import {Observable} from 'rxjs'
+import {lastValueFrom, Observable} from 'rxjs'
 import {filter, map} from 'rxjs/operators'
-
-const toPromise = (observable) => observable.toPromise()
 
 function SanityClient(config = defaultConfig) {
   if (!(this instanceof SanityClient)) {
@@ -112,7 +110,7 @@ Object.assign(SanityClient.prototype, {
       map((event) => event.body)
     )
 
-    return this.isPromiseAPI() ? toPromise(observable) : observable
+    return this.isPromiseAPI() ? lastValueFrom(observable) : observable
   },
 })
 

--- a/src/util/observable.js
+++ b/src/util/observable.js
@@ -1,7 +1,0 @@
-//  Since `@sanity/client` doesn't offer ESM exports (yet) const {filter} = require('rxjs/operators') will cause the the whole of rxjs to be included in the bundle.
-//  The internal import paths here is a stop-gap measure and will become less of a problem when @sanity/client export tree-shakeable esm bundles
-import {Observable} from 'rxjs/internal/Observable'
-import {filter} from 'rxjs/internal/operators/filter'
-import {map} from 'rxjs/internal/operators/map'
-
-export {Observable, filter, map}


### PR DESCRIPTION
This upgrades rxjs from v6 to v7. This means that the observable instance returned from various client methods will now be an rxjs@v7 `Observable`. This *should* be a non-breaking since the `Observable` interface and behavior is from what I can tell largely kept intact  between v6 => v7 (except for undocumented methods and a couple of minor type signature changes). In other words: a v6 Observable should be interoperable with a v7 Observable.

I set the range of the `rxjs` dependency to `^7.0.0` to aid deduping, and verified that the test suite passes against every minor of rxjs from `v7.0.0` to `v7.8.0`.

Note: would prefer if the PR was rebase-merged since each individual commit makes sense on their own :)