### PR TITLE
feat: add support for abort controller

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface RequestOptions {
   method?: string
   query?: FIXME
   body?: FIXME
+  signal?: AbortSignal
 }
 
 /** @public */


### PR DESCRIPTION
**Status**:  Approved, waiting for #86 to land before merging

This adds support for passing an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to all the request methods exposed by the client. It will also work for the APIs that returns an observable as well. Although less useful since observables natively supports cancellation, I can't see the problem in having support for it, but would love to hear your thoughts.

Note: I've copied the approach [ky](https://github.com/sindresorhus/ky/blob/740732c78aad97e9aec199e9871bdbf0ae29b805/source/errors/DOMException.ts) uses when it comes to creating an AbortError that works in Node < v18

Example usage:

```js
const abortController = new AbortController()
const request = client.fetch('*', {}, {signal: abortController.signal})

// this will abort the request and reject the `request` promise with an AbortError
abortController.abort()
```