### PR TITLE
fix: show a migration error when using the default export

### DIFF
--- a/runtimes/node/test.cjs
+++ b/runtimes/node/test.cjs
@@ -29,4 +29,30 @@ test('top-level imports', async (t) => {
     const esm = Object.keys(await import('@sanity/client'))
     assert.deepEqual(cjs, esm)
   })
+
+  await t.test('throws a deprecation error on the default export', () => {
+    const {default: createClient} = require('@sanity/client')
+
+    assert.throws(
+      () => {
+        createClient()
+      },
+      {
+        name: /^TypeError$/,
+        message: /deprecated/,
+      }
+    )
+
+    const {default: SanityClient} = require('@sanity/client')
+
+    assert.throws(
+      () => {
+        new SanityClient()
+      },
+      {
+        name: /^TypeError$/,
+        message: /deprecated/,
+      }
+    )
+  })
 })

--- a/runtimes/node/test.mjs
+++ b/runtimes/node/test.mjs
@@ -1,7 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import {createClient, Patch, Transaction, ClientError, ServerError, requester} from '@sanity/client'
+import deprecatedClient, {
+  createClient,
+  Patch,
+  Transaction,
+  ClientError,
+  ServerError,
+  requester,
+} from '@sanity/client'
 import pkg from '@sanity/client/package.json' assert {type: 'json'}
 
 test('top-level imports', async (t) => {
@@ -17,5 +24,27 @@ test('top-level imports', async (t) => {
   await t.test('@sanity/client/package.json', () => {
     const {version} = pkg
     assert.equal(typeof version, 'string')
+  })
+
+  await t.test('throws a deprecation error on the default export', () => {
+    assert.throws(
+      () => {
+        deprecatedClient()
+      },
+      {
+        name: /^TypeError$/,
+        message: /deprecated/,
+      }
+    )
+
+    assert.throws(
+      () => {
+        new deprecatedClient()
+      },
+      {
+        name: /^TypeError$/,
+        message: /deprecated/,
+      }
+    )
   })
 })

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -16,3 +16,5 @@ export const requester = httpRequest.defaultRequester
 
 /** @public */
 export const createClient = (config: ClientConfig) => new SanityClient(httpRequest, config)
+
+export {migrationNotice as default} from './migrationNotice'

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,5 @@ export const requester = httpRequest.defaultRequester
 
 /** @public */
 export const createClient = (config: ClientConfig) => new SanityClient(httpRequest, config)
+
+export {migrationNotice as default} from './migrationNotice'

--- a/src/migrationNotice.ts
+++ b/src/migrationNotice.ts
@@ -1,0 +1,9 @@
+/**
+ * @public
+ * @deprecated Use the named export `createClient` instead of the `default` export
+ */
+export function migrationNotice() {
+  throw new TypeError(
+    'The default export of @sanity/client has been deprecated. Use the named export `createClient` instead'
+  )
+}

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -14,7 +14,9 @@ describe('pkg.exports["."]', () => {
     const browser = await import('../src/index.browser')
     expect(Object.keys(source)).toEqual(Object.keys(browser))
   })
-  test('default exports should not be used', async () => {
+  // eslint-disable-next-line no-warning-comments
+  // @TODO disabling this test until we no longer have the migrationNotice.ts
+  test.skip('default exports should not be used', async () => {
     await expect(
       import('../src/index'),
       `src/index.ts shouldn't have a default export`


### PR DESCRIPTION
This improves the migration experience, instead of a generic error if attempting to use the default export it'll show a specific error:

```ts
import sanityClient from '@sanity/client'

const client = sanityClient()
// throws: TypeError: The default export of @sanity/client has been deprecated. Use the named export `createClient` instead
```
```ts
import SanityClient from '@sanity/client'

const client = new SanityClient()
// throws: TypeError: The default export of @sanity/client has been deprecated. Use the named export `createClient` instead
```
```ts
const {default: sanityClient} = require('@sanity/client')
const {default: SanityClient} = require('@sanity/client')

const client = sanityClient()
const client = new SanityClient()
// throws: TypeError: The default export of @sanity/client has been deprecated. Use the named export `createClient` instead
```

Unable to make this work without risking weird side-effects:
```ts
const sanityClient = require('@sanity/client')

const client = sanityClient()
// throws: Uncaught TypeError: sanityClient is not a function
```

And in TypeScript instead of a `@sanity/client doesn't have a default export` you'll see:
<img width="550" alt="image" src="https://user-images.githubusercontent.com/81981/216341560-06c5d67a-7e0c-4f69-b1e6-36a4f978594a.png">


