### PR TITLE
feat: include mutation error items in error message

### DIFF
--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,5 +1,7 @@
 import type {Any, ErrorProps, MutationError} from '../types'
 
+const MAX_ITEMS_IN_ERROR_MESSAGE = 5
+
 /** @public */
 export class ClientError extends Error {
   response: ErrorProps['response']
@@ -48,12 +50,12 @@ function extractErrorProps(res: Any): ErrorProps {
   if (isMutationError(body)) {
     const allItems = body.error.items || []
     const items = allItems
-      .slice(0, 5)
+      .slice(0, MAX_ITEMS_IN_ERROR_MESSAGE)
       .map((item) => item.error?.description)
       .filter(Boolean)
     let itemsStr = items.length ? `:\n- ${items.join('\n- ')}` : ''
-    if (allItems.length > 5) {
-      itemsStr += `\n...and ${allItems.length - 5} more`
+    if (allItems.length > MAX_ITEMS_IN_ERROR_MESSAGE) {
+      itemsStr += `\n...and ${allItems.length - MAX_ITEMS_IN_ERROR_MESSAGE} more`
     }
     props.message = `${body.error.description}${itemsStr}`
     props.details = body.error

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,4 +1,4 @@
-import type {Any, ErrorProps} from '../types'
+import type {Any, ErrorProps, MutationError} from '../types'
 
 /** @public */
 export class ClientError extends Error {
@@ -44,6 +44,22 @@ function extractErrorProps(res: Any): ErrorProps {
     return props
   }
 
+  // Mutation errors (specifically)
+  if (isMutationError(body)) {
+    const allItems = body.error.items || []
+    const items = allItems
+      .slice(0, 5)
+      .map((item) => item.error?.description)
+      .filter(Boolean)
+    let itemsStr = items.length ? `:\n- ${items.join('\n- ')}` : ''
+    if (allItems.length > 5) {
+      itemsStr += `\n...and ${allItems.length - 5} more`
+    }
+    props.message = `${body.error.description}${itemsStr}`
+    props.details = body.error
+    return props
+  }
+
   // Query/database errors ({error: {description, other, arb, props}})
   if (body.error && body.error.description) {
     props.message = body.error.description
@@ -54,6 +70,19 @@ function extractErrorProps(res: Any): ErrorProps {
   // Other, more arbitrary errors
   props.message = body.error || body.message || httpErrorMessage(res)
   return props
+}
+
+function isMutationError(body: Any): body is MutationError {
+  return (
+    isPlainObject(body) &&
+    isPlainObject(body.error) &&
+    body.error.type === 'mutationError' &&
+    typeof body.error.description === 'string'
+  )
+}
+
+function isPlainObject(obj: Any): obj is Record<string, unknown> {
+  return typeof obj === 'object' && obj !== null && !Array.isArray(obj)
 }
 
 function httpErrorMessage(res: Any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -566,3 +566,28 @@ export interface RawRequestOptions {
   body?: Any
   maxRedirects?: number
 }
+
+/** @internal */
+export interface ApiError {
+  error: string
+  message: string
+  statusCode: number
+}
+
+/** @internal */
+export interface MutationError {
+  error: {
+    type: 'mutationError'
+    description: string
+    items?: MutationErrorItem[]
+  }
+}
+
+/** @internal */
+export interface MutationErrorItem {
+  error: {
+    type: string
+    description: string
+    value?: unknown
+  }
+}


### PR DESCRIPTION
When you encounter mutation errors, the error message/staack from the client can be less than helpful:

```
ClientError: Mutation(s) failed with 1 error(s)
    at onResponse (/my/app/node_modules/@sanity/client/dist/index.cjs:78:13)
    at applyMiddleware (/my/app/node_modules/get-it/dist/index.cjs:60:15)
    ...
```

The response body does usually contain more information, but holds it in an `items` array. It is not obvious that this is available - you can technically get it at `error.details`, but it's typed as `any` and not documented. Ideally we'd introduce a new `MutationError` class with better typing, but that would be a breaking change (people may be relying on `instanceof ClientError` checks or similar), so will leave that for a later PR.

This PR provides a slight improvement on the situation, in a way that should be backwards compatible:
- It extracts the `description` property of the first 5 error items and includes them in the error message
- Includes the number of additional errors there were

So the resulting error might look like the following:

```
ClientError: Mutation(s) failed with 6 error(s):
- Malformed document ID: "#some_invalid-id!"
- Malformed document ID: "@ruby_bird@"
- Malformed document ID: "!cant_contain_that"
- Malformed document ID: "what$about!this?"
- Malformed document ID: "%so_many_percent%"
...and 1 more
    at onResponse (/my/app/node_modules/@sanity/client/dist/index.cjs:78:13)
    at applyMiddleware (/my/app/node_modules/get-it/dist/index.cjs:60:15)
    ...
```
