### PR TITLE
fix: correct document ID validation

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -30,7 +30,7 @@ export const validateObject = (op: string, val: Any) => {
 }
 
 export const validateDocumentId = (op: string, id: string) => {
-  if (typeof id !== 'string' || !/^[a-z0-9_.-]+$/i.test(id)) {
+  if (typeof id !== 'string' || !/^[a-z0-9_][a-z0-9_.-]{0,127}$/i.test(id) || id.includes('..')) {
     throw new Error(`${op}(): "${id}" is not a valid document ID`)
   }
 }

--- a/test/validators.test.ts
+++ b/test/validators.test.ts
@@ -6,18 +6,47 @@ describe('validators', async () => {
   test('validateDocumentId', () => {
     expect(
       () => validators.validateDocumentId('op', 'barfoo'),
+      'does not throw on valid ID (simple)'
+    ).not.toThrow()
 
-      'does not throw on valid ID'
-    ).not.toThrow(/document ID in format/)
     expect(
       () => validators.validateDocumentId('op', 'bar.foo.baz'),
+      'does not throw on valid ID (pathed)'
+    ).not.toThrow()
 
-      'does not throw on valid ID'
-    ).not.toThrow(/document ID in format/)
+    expect(
+      () => validators.validateDocumentId('op', 'all.allowed-chars_used'),
+      'does not throw on valid ID (all allowed characters)'
+    ).not.toThrow()
+
+    expect(
+      () => validators.validateDocumentId('op', '_underscored'),
+      'does not throw on valid ID (underscore-first)'
+    ).not.toThrow()
+
+    expect(
+      () => validators.validateDocumentId('op', '3abcdef'),
+      'does not throw on valid ID (digit-first)'
+    ).not.toThrow()
+
     expect(
       () => validators.validateDocumentId('op', 'blah#blah'),
+      'throws on invalid ID (disallowed character)'
+    ).toThrow(/not a valid document ID/)
 
-      'throws on invalid ID'
+    expect(
+      () => validators.validateDocumentId('op', '-not-allowed'),
+      'throws on invalid ID (dash-first)'
+    ).toThrow(/not a valid document ID/)
+
+    expect(
+      () => validators.validateDocumentId('op', 'some..path'),
+      'throws on invalid ID (double-dot)'
+    ).toThrow(/not a valid document ID/)
+
+    expect(
+      () => validators.validateDocumentId('op', 'a'.repeat(129)),
+      'throws on invalid ID (too long)'
     ).toThrow(/not a valid document ID/)
   })
 })


### PR DESCRIPTION
The current document ID validation is a little too lenient:

- Allows IDs that start with a dash
- Allows double-dots (`some..path`)
- Allows long IDs (max length is 128)

This PR fixes these issues.