### PR TITLE
refactor: use built-in typings for `@sanity/eventsource`

### DIFF
--- a/modules.d.ts
+++ b/modules.d.ts
@@ -1,9 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-declare module '@sanity/eventsource' {
-  // re-exports default window.EventSource
-  export default window.EventSource
-}
-
 declare module 'sse-channel' {
   export default class SseChannel {
     constructor(options?: {jsonEncode?: boolean})

--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -130,10 +130,10 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
     }
 
     function unsubscribe() {
-      es.removeEventListener('error', onError, false)
-      es.removeEventListener('channelError', onChannelError, false)
-      es.removeEventListener('disconnect', onDisconnect, false)
-      listenFor.forEach((type: string) => es.removeEventListener(type, onMessage, false))
+      es.removeEventListener('error', onError)
+      es.removeEventListener('channelError', onChannelError)
+      es.removeEventListener('disconnect', onDisconnect)
+      listenFor.forEach((type: string) => es.removeEventListener(type, onMessage))
       es.close()
     }
 
@@ -145,10 +145,10 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
 
     function getEventSource() {
       const evs = new EventSource(uri, esOptions)
-      evs.addEventListener('error', onError, false)
-      evs.addEventListener('channelError', onChannelError, false)
-      evs.addEventListener('disconnect', onDisconnect, false)
-      listenFor.forEach((type: string) => evs.addEventListener(type, onMessage, false))
+      evs.addEventListener('error', onError)
+      evs.addEventListener('channelError', onChannelError)
+      evs.addEventListener('disconnect', onDisconnect)
+      listenFor.forEach((type: string) => evs.addEventListener(type, onMessage))
       return evs
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,6 @@ import GithubActionsReporter from 'vitest-github-actions-reporter'
 import pkg from './package.json'
 
 export const sharedConfig: UserConfig['test'] = {
-  // interopDefault is required for the CJS-only packages we still rely on, like @sanity/eventsource
-  deps: {interopDefault: true},
   // don't use vitest to run Bun and Deno tests
   exclude: [...configDefaults.exclude, 'runtimes/**'],
   // Enable rich PR failed test annotation on the CI


### PR DESCRIPTION
It seems like it's fine to change `addEventListener` and removing the third arg since neither `eventsource` nor `event-source-polyfill` implements them:

https://github.com/Yaffle/EventSource/blob/03e44c8ea3d83012c3f27da2a2052061b4b4cdd8/src/eventsource.js#L607

https://github.com/EventSource/eventsource/blob/79dacfa860751438c116df76f9c5fdb9a2a3d69f/lib/eventsource.js#LL405