### PR TITLE
fix(listen): lazy init event source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "5.4.0",
+  "version": "5.4.1-lazy-event-source.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "5.4.0",
+      "version": "5.4.1-lazy-event-source.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "5.4.0",
+  "version": "5.4.1-lazy-event-source.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -8,6 +8,8 @@ module.exports = {
     file: 'umd/sanityClient.js',
     format: 'umd',
     name: 'SanityClient',
+    dynamicImportInCjs: false,
+    inlineDynamicImports: true,
   },
   plugins: [nodeResolve({browser: true}), commonjs()],
 }

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -21,6 +21,7 @@
     "skipLibCheck": true,
 
     // Module resolution
+    "module": "esnext",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Reduces bundle size for environments which doesn't use `client.listen`.
Also helps cases like #177.

Can be tested using: `npm i --save-exact @sanity/client@lazy-event-source`.

Build output diff: https://app.renovatebot.com/package-diff?name=@sanity/client&from=5.4.0&to=5.4.1-lazy-event-source.0