### PR TITLE
fix(mutate): serialize clientless patches correctly

### DIFF
--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -177,13 +177,14 @@ export function _mutate<R extends Record<string, Any>>(
 ): Observable<
   SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
 > {
-  const mut =
-    mutations instanceof Patch ||
-    mutations instanceof ObservablePatch ||
-    mutations instanceof Transaction ||
-    mutations instanceof ObservableTransaction
-      ? mutations.serialize()
-      : mutations
+  let mut: Mutation | Mutation[]
+  if (mutations instanceof Patch || mutations instanceof ObservablePatch) {
+    mut = {patch: mutations.serialize()}
+  } else if (mutations instanceof Transaction || mutations instanceof ObservableTransaction) {
+    mut = mutations.serialize()
+  } else {
+    mut = mutations
+  }
 
   const muts = Array.isArray(mut) ? mut : [mut]
   const transactionId = options && (options as Any).transactionId

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1458,6 +1458,19 @@ describe('client', async () => {
       expect(() => patch.dec({bar: 2}).commit()).toThrow(/client.*mutate/i)
     })
 
+    test.skipIf(isEdge)('patch can be created without client and passed to mutate()', async () => {
+      const patch = new Patch('foo').dec({count: 1})
+
+      const mutations = [{patch: {id: 'foo', dec: {count: 1}}}]
+      nock(projectHost())
+        .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync', {
+          mutations,
+        })
+        .reply(200, {results: [{id: 'foo', operation: 'update'}]})
+
+      await expect(getClient().mutate(patch)).resolves.not.toThrow()
+    })
+
     // eslint-disable-next-line no-warning-comments
     // @TODO investigate why this fails on Edge Runtime
     test.skipIf(isEdge)('can manually call clone on patch', () => {


### PR DESCRIPTION
This PR fixes an issue where passing a clientless patch (`new Patch('doc-id')`) will result in the mutation getting incorrectly serialized when passed to `mutate()`.

Actually serialized body:

```js
{mutations: [{id: 'doc-id', set: {foo: 'bar'}]}
```

Expected body:

```js
{mutations: [{patch: {id: 'doc-id', set: {foo: 'bar'}]}}
```
