### PR TITLE
fix(mutate): reflect support for providing transaction id in typings

### DIFF
--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -187,7 +187,7 @@ export function _mutate<R extends Record<string, Any>>(
   }
 
   const muts = Array.isArray(mut) ? mut : [mut]
-  const transactionId = options && (options as Any).transactionId
+  const transactionId = (options && options.transactionId) || undefined
   return _dataRequest(client, httpRequest, 'mutate', {mutations: muts, transactionId}, options)
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -481,6 +481,7 @@ export type BaseMutationOptions = RequestOptions & {
   dryRun?: boolean
   autoGenerateArrayKeys?: boolean
   skipCrossDatasetReferenceValidation?: boolean
+  transactionId?: string
 }
 
 /** @internal */

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -917,6 +917,24 @@ describe('client', async () => {
       await expect(getClient().mutate(mutations, {tag: 'foobar'})).resolves.not.toThrow()
     })
 
+    test.skipIf(isEdge)('mutate() accepts transaction id', async () => {
+      const mutations = [{delete: {id: 'abc123'}}]
+
+      nock(projectHost())
+        .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync', {
+          mutations,
+          transactionId: 'spec-ific',
+        })
+        .reply(200, {
+          transactionId: 'spec-ific',
+          results: [{id: 'abc123', operation: 'delete', document: {_id: 'abc123'}}],
+        })
+
+      await expect(
+        getClient().mutate(mutations, {transactionId: 'spec-ific'})
+      ).resolves.not.toThrow()
+    })
+
     test.skipIf(isEdge)('mutate() accepts `autoGenerateArrayKeys`', async () => {
       const mutations = [
         {


### PR DESCRIPTION
The `mutate()` method takes a `transactionId` option and passes it along to the request body - but this was not reflected in the typings. This PR ensures the typings are up to date, and removes the use of a now unnecessary `as any` cast.