### PR TITLE
Fix test which incorrect called createClient() with no params

### DIFF
--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -134,7 +134,7 @@ describe('client', async () => {
     })
 
     test('throws if no projectId is set', () => {
-      expect(createClient).toThrow(/projectId/)
+      expect(() => createClient({})).toThrow(/projectId/)
     })
 
     test('throws on invalid project ids', () => {


### PR DESCRIPTION
`createClient` has one required parameter. This ends up calling it with _zero_. It may work today, but we don't really guarantee it. (If so, we should make the parameter optional in the type.)