### PR TITLE
feat!: Add automatic retrying of 429/502/503

### DIFF
--- a/src/http/nodeMiddleware.ts
+++ b/src/http/nodeMiddleware.ts
@@ -1,11 +1,10 @@
-import {debug, headers, retry} from 'get-it/middleware'
+import {debug, headers} from 'get-it/middleware'
 
 import {name, version} from '../../package.json'
 
 const middleware = [
   debug({verbose: true, namespace: 'sanity:client'}),
   headers({'User-Agent': `${name} ${version}`}),
-  retry({maxRetries: 3}),
 ]
 
 export default middleware

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,5 +1,5 @@
 import {getIt, type Middlewares} from 'get-it'
-import {jsonRequest, jsonResponse, observable, progress} from 'get-it/middleware'
+import {jsonRequest, jsonResponse, observable, progress, retry} from 'get-it/middleware'
 import {Observable} from 'rxjs'
 
 import type {Any, HttpRequest, RequestOptions} from '../types'
@@ -27,8 +27,22 @@ const printWarnings = {
 }
 
 /** @internal */
-export function defineHttpRequest(envMiddleware: Middlewares): HttpRequest {
+export function defineHttpRequest(
+  envMiddleware: Middlewares,
+  {
+    maxRetries = 5,
+    retryDelay,
+  }: {maxRetries?: number; retryDelay?: (attemptNumber: number) => number}
+): HttpRequest {
   const request = getIt([
+    maxRetries > 0
+      ? retry({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          retryDelay: retryDelay as any, // This option is typed incorrectly in get-it.
+          maxRetries,
+          shouldRetry,
+        })
+      : {},
     ...envMiddleware,
     printWarnings,
     jsonRequest(),
@@ -45,4 +59,30 @@ export function defineHttpRequest(envMiddleware: Middlewares): HttpRequest {
   httpRequest.defaultRequester = request
 
   return httpRequest
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function shouldRetry(err: any, attempt: number, options: any) {
+  // By default `retry.shouldRetry` doesn't retry on server errors so we add our own logic.
+
+  const isSafe = options.method === 'GET' || options.method === 'HEAD'
+  const isQuery = options.uri.startsWith('/data/query')
+  const isRetriableResponse =
+    err.response &&
+    (err.response.statusCode === 429 ||
+      err.response.statusCode === 502 ||
+      err.response.statusCode === 503)
+
+  // We retry the following errors:
+  // - 429 means that the request was rate limited. It's a bit difficult
+  //   to know exactly how long it makes sense to wait and/or how many
+  //   attempts we should retry, but the backoff should alleviate the
+  //   additional load.
+  // - 502/503 can occur when certain components struggle to talk to their
+  //   upstream dependencies. This is most likely a temporary problem
+  //   and retrying makes sense.
+
+  if ((isSafe || isQuery) && isRetriableResponse) return true
+
+  return retry.shouldRetry(err, attempt, options)
 }

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -11,12 +11,19 @@ export * from './SanityClient'
 export * from './types'
 
 // Set the http client to use for requests, and its environment specific middleware
-const httpRequest = defineHttpRequest(envMiddleware)
+const httpRequest = defineHttpRequest(envMiddleware, {maxRetries: 0})
 /** @public */
 export const requester = httpRequest.defaultRequester
 
 /** @public */
-export const createClient = (config: ClientConfig) => new SanityClient(httpRequest, config)
+export const createClient = (config: ClientConfig) =>
+  new SanityClient(
+    defineHttpRequest(envMiddleware, {
+      maxRetries: config.maxRetries || 5,
+      retryDelay: config.retryDelay,
+    }),
+    config
+  )
 
 /**
  * @public

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -11,7 +11,7 @@ export * from './SanityClient'
 export * from './types'
 
 // Set the http client to use for requests, and its environment specific middleware
-const httpRequest = defineHttpRequest(envMiddleware, {maxRetries: 0})
+const httpRequest = defineHttpRequest(envMiddleware, {})
 /** @public */
 export const requester = httpRequest.defaultRequester
 
@@ -19,7 +19,7 @@ export const requester = httpRequest.defaultRequester
 export const createClient = (config: ClientConfig) =>
   new SanityClient(
     defineHttpRequest(envMiddleware, {
-      maxRetries: config.maxRetries || 5,
+      maxRetries: config.maxRetries,
       retryDelay: config.retryDelay,
     }),
     config

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,19 @@ export * from './SanityClient'
 export * from './types'
 
 // Set the http client to use for requests, and its environment specific middleware
-const httpRequest = defineHttpRequest(envMiddleware)
+const httpRequest = defineHttpRequest(envMiddleware, {})
 /** @public */
 export const requester = httpRequest.defaultRequester
 
 /** @public */
-export const createClient = (config: ClientConfig) => new SanityClient(httpRequest, config)
+export const createClient = (config: ClientConfig) =>
+  new SanityClient(
+    defineHttpRequest(envMiddleware, {
+      maxRetries: config.maxRetries,
+      retryDelay: config.retryDelay,
+    }),
+    config
+  )
 
 /**
  * @public

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,19 @@ export interface ClientConfig {
   allowReconfigure?: boolean
   timeout?: number
 
+  /** Number of retries for requests. Defaults to 5. */
+  maxRetries?: number
+
+  /**
+   * The amount of time, in milliseconds, to wait before retrying, given an attemptNumber (starting at 0).
+   *
+   * Defaults to exponential back-off, starting at 100ms, doubling for each attempt, together with random
+   * jitter between 0 and 100 milliseconds. More specifically the following algorithm is used:
+   *
+   *   Delay = 100 * 2^attemptNumber + randomNumberBetween0and100
+   */
+  retryDelay?: (attemptNumber: number) => number
+
   /**
    * @deprecated Don't use
    */


### PR DESCRIPTION
This is a bit of a bigger, and technically breaking, change which introduces automatic retrying of 429 errors (i.e. rate limited). I'm opening it here to start a discussion about how to progress this forward. I believe this would be very useful for the majority of the users of the client and should be enabled by default.