### PR TITLE
fix: undeprecate `request()`

### DIFF
--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -1210,22 +1210,25 @@ export class SanityClient {
   }
 
   /**
-   * DEPRECATED: Perform an HTTP request against the Sanity API
+   * Perform a request against the Sanity API
+   * NOTE: Only use this for Sanity API endpoints, not for your own APIs!
    *
-   * @deprecated Use your own request library!
    * @param options - Request options
+   * @returns Promise resolving to the response body
    */
   request<R = Any>(options: RawRequestOptions): Promise<R> {
     return lastValueFrom(dataMethods._request<R>(this, this.#httpRequest, options))
   }
 
   /**
-   * DEPRECATED: Perform an HTTP request a `/data` sub-endpoint
+   * Perform an HTTP request a `/data` sub-endpoint
+   * NOTE: Considered internal, thus marked as deprecated. Use `request` instead.
    *
-   * @deprecated Use your own request library!
+   * @deprecated - Use `request()` or your own HTTP library instead
    * @param endpoint - Endpoint to hit (mutate, query etc)
    * @param body - Request body
    * @param options - Request options
+   * @internal
    */
   dataRequest(endpoint: string, body: unknown, options?: BaseMutationOptions): Promise<Any> {
     return lastValueFrom(dataMethods._dataRequest(this, this.#httpRequest, endpoint, body, options))


### PR DESCRIPTION
The reason it was marked as deprecated was to steer users away from it in favor or using their own request library, since we didn't want the maintenance burden of having to keep request options/behavior compatible between releases. However, after seeing a number of real-world use cases where users want to reuse the client to do requests against Sanity API endpoints that do not have their own built-in method (scheduled publishing, webhook APIs etc), and the complexity of figuring out the authentication part (cookie? auth token?), we decided it is a reasonable ask to allow using the method.

The `dataRequest()` is more of an internal convenience method on top of `request()`, and should still be considered deprecated, since the same tasks can easily be achieved using `request()`. However, I did clarify it a bit in the deprecated note.