### PR TITLE
feat: add `scope` parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.0.1",
+  "version": "6.1.0-scope.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.0.1",
+      "version": "6.1.0-scope.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.0.1",
+  "version": "6.1.0-scope.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -306,6 +306,10 @@ export function _requestObservable<R>(
     options.query = {resultSourceMap: true, ...options.query}
   }
 
+  if (config.scope) {
+    options.query = {scope: config.scope, ...options.query}
+  }
+
   const reqOptions = requestOptions(
     config,
     Object.assign({}, options, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,16 @@ export interface ClientConfig {
    */
   requester?: Requester
 
+  /**
+   * Adds a `resultSourceMap` key to the API response, with the type `ContentSourceMap`
+   */
   resultSourceMap?: boolean
+
+  /**
+   * Experimental, requires apiHost: 'https://api.sanity.work'.
+   * @alpha
+   */
+  scope?: 'published' | 'previewDrafts'
 }
 
 /** @public */


### PR DESCRIPTION
Can be tested using `npm i @sanity/client@scope`. Requires `apiVersion: 'X'` and shouldn't be used in production!