### PR TITLE
feat: add `perspective` parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.0.1",
+  "version": "6.1.0-perspective.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.0.1",
+      "version": "6.1.0-perspective.2",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.0.1",
+  "version": "6.1.0-perspective.2",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -307,6 +307,9 @@ export function _requestObservable<R>(
     if (config.resultSourceMap) {
       options.query = {resultSourceMap: true, ...options.query}
     }
+    if (typeof config.perspective === 'string' && config.perspective !== 'all') {
+      options.query = {perspective: config.perspective, ...options.query}
+    }
   }
 
   const reqOptions = requestOptions(

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -302,8 +302,11 @@ export function _requestObservable<R>(
     options.query = {tag: validate.requestTag(tag), ...options.query}
   }
 
-  if (config.resultSourceMap) {
-    options.query = {resultSourceMap: true, ...options.query}
+  // GROQ query-only parameters
+  if (['GET', 'HEAD'].indexOf(options.method || 'GET') >= 0 && uri.indexOf('/data/query/') === 0) {
+    if (config.resultSourceMap) {
+      options.query = {resultSourceMap: true, ...options.query}
+    }
   }
 
   const reqOptions = requestOptions(

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface ClientConfig {
   /** @defaultValue true */
   useCdn?: boolean
   token?: string
+  perspective?: 'previewDrafts' | 'published' | 'all'
   apiHost?: string
   apiVersion?: string
   proxy?: string
@@ -67,6 +68,9 @@ export interface ClientConfig {
    */
   requester?: Requester
 
+  /**
+   * Adds a `resultSourceMap` key to the API response, with the type `ContentSourceMap`
+   */
   resultSourceMap?: boolean
 }
 


### PR DESCRIPTION
Can be tested using `npm i @sanity/client@perspective`.