### PR TITLE
fix: apply `resultSourceMap` parameter only to queries

### DIFF
--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -302,8 +302,11 @@ export function _requestObservable<R>(
     options.query = {tag: validate.requestTag(tag), ...options.query}
   }
 
-  if (config.resultSourceMap) {
-    options.query = {resultSourceMap: true, ...options.query}
+  // GROQ query-only parameters
+  if (['GET', 'HEAD'].indexOf(options.method || 'GET') >= 0 && uri.indexOf('/data/query/') === 0) {
+    if (config.resultSourceMap) {
+      options.query = {resultSourceMap: true, ...options.query}
+    }
   }
 
   const reqOptions = requestOptions(


### PR DESCRIPTION
When `resultSourceMap` is used it should only be applied to calls made to `/data/queries`, like `client.fetch` calls.

It shouldn't be added to calls like `client.getDocument` or `client.listen` as it throws errors.