### PR TITLE
fix: prevent crash when using `url` option instead of `uri`

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -66,7 +66,8 @@ function shouldRetry(err: any, attempt: number, options: any) {
   // By default `retry.shouldRetry` doesn't retry on server errors so we add our own logic.
 
   const isSafe = options.method === 'GET' || options.method === 'HEAD'
-  const isQuery = options.uri.startsWith('/data/query')
+  const uri = options.uri || options.url
+  const isQuery = uri.startsWith('/data/query')
   const isRetriableResponse =
     err.response &&
     (err.response.statusCode === 429 ||


### PR DESCRIPTION
The client supports using both `uri` and `url` (why, I am not sure) - but the retry logic added recently explicitly checks for `.uri`. This PR ensures that we support either. Important fix since it currently can crash the CLI tool when attempting to retry.