### PR TITLE
fix: update `RawQueryResponse` response type properties

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -489,10 +489,10 @@ export type UnfilteredResponseQueryOptions = RequestOptions & {
 
 /** @public */
 export interface RawQueryResponse<R> {
-  q: string
+  query: string
   ms: number
   result: R
-  resultSourceMap: ContentSourceMap
+  resultSourceMap?: ContentSourceMap
 }
 
 /** @internal */

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -402,7 +402,7 @@ describe('client', async () => {
         .get(`/v1/data/query/foo?query=${qs}`)
         .reply(200, {
           ms: 123,
-          q: query,
+          query: query,
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
@@ -421,13 +421,13 @@ describe('client', async () => {
         .get(`/v1/data/query/foo?query=${qs}`)
         .reply(200, {
           ms: 123,
-          q: query,
+          query: query,
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
       const res = await getClient().fetch(query, params, {filterResponse: false})
       expect(res.ms, 'should include timing info').toBe(123)
-      expect(res.q, 'should include query').toBe(query)
+      expect(res.query, 'should include query').toBe(query)
       expect(res.result.length, 'length should match').toBe(1)
       expect(res.result[0].rating, 'data should match').toBe(5)
     })
@@ -437,7 +437,7 @@ describe('client', async () => {
         .get(`/v1/data/query/foo?query=*&tag=mycompany.syncjob`)
         .reply(200, {
           ms: 123,
-          q: '*',
+          query: '*',
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
@@ -451,7 +451,7 @@ describe('client', async () => {
         .get(`/v1/data/query/foo?query=*&tag=mycompany.syncjob`)
         .reply(200, {
           ms: 123,
-          q: '*',
+          query: '*',
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
@@ -465,7 +465,7 @@ describe('client', async () => {
         .get(`/v1/data/query/foo?query=*&tag=mycompany.syncjob`)
         .reply(200, {
           ms: 123,
-          q: '*',
+          query: '*',
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
@@ -532,7 +532,7 @@ describe('client', async () => {
 
         nock(projectHost()).get(`/v1/data/query/foo?query=*`).delay(100).reply(200, {
           ms: 123,
-          q: '*',
+          query: '*',
           result: [],
         })
 
@@ -1122,7 +1122,7 @@ describe('client', async () => {
         .query({query, ...qParams})
         .reply(200, {
           ms: 123,
-          q: query,
+          query: query,
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
@@ -1148,7 +1148,7 @@ describe('client', async () => {
         .post('/v1/data/query/foo', '*')
         .reply(200, {
           ms: 123,
-          q: query,
+          query: query,
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
@@ -1179,7 +1179,7 @@ describe('client', async () => {
         .post('/v1/data/query/foo', '*')
         .reply(200, {
           ms: 123,
-          q: query,
+          query: query,
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 
@@ -1206,7 +1206,7 @@ describe('client', async () => {
           .post('/v1/data/query/foo?tag=myapp.silly-query', '*')
           .reply(200, {
             ms: 123,
-            q: query,
+            query: query,
             result: [{_id: 'njgNkngskjg', rating: 5}],
           })
 
@@ -1233,7 +1233,7 @@ describe('client', async () => {
         .post('/v1/data/query/foo', '*')
         .reply(200, {
           ms: 123,
-          q: query,
+          query: query,
           result: [{_id: 'njgNkngskjg', rating: 5}],
         })
 


### PR DESCRIPTION
Hello everyone 👋 

I've noticed a type definition issue while utilizing the `fetch` method on `@sanity/client`. The response returned from the API seems to have a slight discrepancy from what's defined in the `RawQueryResponse` type.

On the `RawQueryResponse`:

- Rather than receiving `q`, I'm receiving `query`.
- The `resultSourceMap` is optional and doesn't appear as a property unless it's part of the input parameters.

![CleanShot 2023-05-23 at 11 31 53](https://github.com/sanity-io/client/assets/5302071/89feb206-f4b7-4b95-85bb-fdb5f6e37476)

The URL structure produced by the `fetch` method  adheres to the standard format from the Sanity API:

```
https://[projectId].api.sanity.io/[apiVersion]/data/query/[dataset]?query=[groqString]
```

I've also attempted to test this with varying API versions, and both with and without the CDN.

***

Could I possibly be doing something incorrectly or using the wrong type? If that's the case, feel free to close this discussion.

Thank you very much for maintaining this package!