### PR TITLE
fix: validate `perspective` config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import {generateHelpUrl} from './generateHelpUrl'
-import type {ClientConfig, InitializedClientConfig} from './types'
+import type {ClientConfig, ClientPerspective, InitializedClientConfig} from './types'
 import * as validate from './validators'
 import * as warnings from './warnings'
 
@@ -27,6 +27,19 @@ export const validateApiVersion = function validateApiVersion(apiVersion: string
   }
 }
 
+export const validateApiPerspective = function validateApiPerspective(perspective: string) {
+  switch (perspective as ClientPerspective) {
+    case 'previewDrafts':
+    case 'published':
+    case 'raw':
+      return
+    default:
+      throw new TypeError(
+        'Invalid API perspective string, expected `published`, `previewDrafts` or `raw`'
+      )
+  }
+}
+
 export const initConfig = (
   config: Partial<ClientConfig>,
   prevConfig: Partial<ClientConfig>
@@ -46,6 +59,10 @@ export const initConfig = (
 
   if (projectBased && !newConfig.projectId) {
     throw new Error('Configuration must contain `projectId`')
+  }
+
+  if (typeof newConfig.perspective === 'string') {
+    validateApiPerspective(newConfig.perspective)
   }
 
   if (

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -161,6 +161,22 @@ describe('client', async () => {
       expect(() => createClient({projectId: 'abc123', logger: console})).toThrow(/logger/)
     })
 
+    test('throws on invalid perspective', () => {
+      expect(() => createClient({projectId: 'abc123', perspective: 'published'})).not.toThrow(
+        /Invalid API perspective/
+      )
+      expect(() => createClient({projectId: 'abc123', perspective: 'previewDrafts'})).not.toThrow(
+        /Invalid API perspective/
+      )
+      expect(() => createClient({projectId: 'abc123', perspective: 'raw'})).not.toThrow(
+        /Invalid API perspective/
+      )
+      // @ts-expect-error -- we want to test that it throws an error
+      expect(() => createClient({projectId: 'abc123', perspective: 'preview drafts'})).toThrow(
+        /Invalid API perspective/
+      )
+    })
+
     test('throws on invalid project ids', () => {
       expect(() => createClient({projectId: '*foo*'})).toThrow(/projectId.*?can only contain/i)
     })


### PR DESCRIPTION
@snorrees do you know how we can widen the `perspective` type to allow strings, without losing IDE autocomplete?