### PR TITLE
fix: restore React Native compatibility

### DIFF
--- a/src/data/encodeQueryString.ts
+++ b/src/data/encodeQueryString.ts
@@ -12,17 +12,18 @@ export const encodeQueryString = ({
   const searchParams = new URLSearchParams()
   // We generally want tag at the start of the query string
   const {tag, ...opts} = options
-  if (tag) searchParams.set('tag', tag)
-  searchParams.set('query', query)
+  // We're using `append` instead of `set` to support React Native: https://github.com/facebook/react-native/blob/1982c4722fcc51aa87e34cf562672ee4aff540f1/packages/react-native/Libraries/Blob/URL.js#L86-L88
+  if (tag) searchParams.append('tag', tag)
+  searchParams.append('query', query)
 
   // Iterate params, the keys are prefixed with `$` and their values JSON stringified
   for (const [key, value] of Object.entries(params)) {
-    searchParams.set(`$${key}`, JSON.stringify(value))
+    searchParams.append(`$${key}`, JSON.stringify(value))
   }
   // Options are passed as-is
   for (const [key, value] of Object.entries(opts)) {
     // Skip falsy values
-    if (value) searchParams.set(key, `${value}`)
+    if (value) searchParams.append(key, `${value}`)
   }
 
   return `?${searchParams}`


### PR DESCRIPTION
React Native doesn't implement `URLSearchParams.set` that we started using recently. However it does implement [`URLSearchParams.append`](https://github.com/facebook/react-native/blob/1982c4722fcc51aa87e34cf562672ee4aff540f1/packages/react-native/Libraries/Blob/URL.js#L66-L68) and that's why this PR refactors `encodeQueryString` to it :)

Fixes #201