### PR TITLE
fix: don't set `signal` on `fetch` unless provided to `client.fetch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",
-        "get-it": "^8.4.2",
+        "get-it": "^8.4.3",
         "rxjs": "^7.0.0"
       },
       "devDependencies": {
@@ -9143,9 +9143,9 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.2.tgz",
-      "integrity": "sha512-xseDj1loKLcPYKhdlP2k7ZYDE03jTrHgRNt0AURtALOu+8pREmBn+UxZ4JbsxpQ8AvupgmpYuuTa3cS1mtuy2w==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.3.tgz",
+      "integrity": "sha512-H9YbPCN3QCbxtojv42fvmrkIYe434qKg1nKpMMtBqwL8U3XprnHMgDbQwMJIxSIFOPpajQPf0BxhjsHoFI0cEQ==",
       "dependencies": {
         "debug": "^4.3.4",
         "decompress-response": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@sanity/eventsource": "^5.0.0",
-    "get-it": "^8.4.2",
+    "get-it": "^8.4.3",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -70,7 +70,12 @@ export function _fetch<R, Q extends QueryParams>(
 ): Observable<RawQueryResponse<R> | R> {
   const mapResponse =
     options.filterResponse === false ? (res: Any) => res : (res: Any) => res.result
-  const {cache, next, ...opts} = options
+  const {cache, next, ...opts} = {
+    // Opt out of setting a `signal` on an internal `fetch` if one isn't provided.
+    // This is necessary in React Server Components to avoid opting out of Request Memoization.
+    useAbortSignal: typeof options.signal !== 'undefined',
+    ...options,
+  }
   const reqOpts =
     typeof cache !== 'undefined' || typeof next !== 'undefined'
       ? {...opts, fetch: {cache, next}}
@@ -235,6 +240,7 @@ export function _dataRequest(
     canUseCdn: isQuery,
     signal: options.signal,
     fetch: options.fetch,
+    useAbortSignal: options.useAbortSignal,
   }
 
   return _requestObservable(client, httpRequest, reqOptions).pipe(


### PR DESCRIPTION
This is blocked by https://github.com/sanity-io/get-it/pull/180

Next.js doesn't currently have a way to debug and show if requests are memoized or not, and so it's difficult to setup tests for it. For now I've tested it manually on https://github.com/sanity-io/sanity-template-nextjs-app-router-personal-website using canary releases of the whole chain:
```bash
npm i @sanity/client@canary next-sanity@canary
```

The impact of this PR is limited to:
- React Server Components.
- When `client.fetch` is called, other client operations are unaffected and will pass `signal` like before.