### PR TITLE
fix: reverse node export conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
-        "module": "./dist/index.js",
-        "import": "./dist/index.cjs.js"
+        "import": "./dist/index.cjs.js",
+        "module": "./dist/index.js"
       },
       "import": "./dist/index.js",
       "default": "./dist/index.js"


### PR DESCRIPTION
resolves https://github.com/sanity-io/client/issues/308

this tries to fix [an issue we're experiencing](https://github.com/nuxt-modules/sanity/pull/892) triggered by the `module` export condition being added. Because the first matching condition is picked, it would likely be safer to add the `import` before `module` bundler.

(I would also suggest removing the `module` condition as it's not supported by node, and this is within the node condition. But I'm not sure why it was added in the first place so I'm reluctant to make changes.)