### PR TITLE
fix(esm): support `nuxt-module-build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.4.9",
+  "version": "6.4.10-canary.3",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",
@@ -40,10 +40,8 @@
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
       "node": {
-        "module": "./dist/index.js",
         "import": "./dist/index.cjs.js"
       },
-      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Fixes #308. Fixes #309.

Tested by [checking out `@nuxtjs/sanity`](https://github.com/nuxt-modules/sanity) and running these commands on `main`:
```bash
pnpm install @sanity/client@canary --save-dev -w && pnpm build && pnpm test -- --coverage
```
Output:
```bash
      Coverage enabled with v8

     ⠋ [ beforeAll ]
 ✓ test/unit/client.test.ts (10)
 ✓ test/unit/client.test.ts (10)
 ✓ test/unit/helpers.test.ts (3)
 ✓ test/e2e/ssr.test.ts (5) 7487ms
 ✓ test/unit/sanity-image.test.ts (31)
 ✓ test/unit/sanity-file.test.ts (2)
 ✓ test/e2e/ssr-minimal.test.ts (5) 6366ms
 ✓ test/unit/sanity-content.test.ts (14)

 Test Files  7 passed (7)
      Tests  70 passed (70)
   Start at  19:59:44
   Duration  8.19s (transform 287ms, setup 0ms, collect 1.10s, tests 13.96s, environment 736ms, prepare 549ms)

 % Coverage report from v8
------------------------|---------|----------|---------|---------|-------------------------------------
File                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                   
------------------------|---------|----------|---------|---------|-------------------------------------
All files               |   93.41 |    86.75 |   86.04 |   93.41 |                                     
 playground             |     100 |      100 |     100 |     100 |                                     
  nuxt.config.js        |     100 |      100 |     100 |     100 |                                     
 src/runtime            |   79.25 |       80 |   58.33 |   79.25 |                                     
  client.ts             |     100 |      100 |     100 |     100 |                                     
  composables.ts        |   64.63 |    33.33 |   33.33 |   64.63 | 27-29,36-37,45-46,52-55,63-71,74-82 
  groq.ts               |   41.17 |        0 |       0 |   41.17 | 8-17                                
 src/runtime/components |   98.43 |     87.9 |   96.77 |   98.43 |                                     
  sanity-content.ts     |   97.39 |     87.5 |   94.44 |   97.39 | 180-181,212-214,258,263             
  sanity-file.ts        |     100 |    66.66 |     100 |     100 | 36-41                               
  sanity-image.ts       |   99.49 |    93.33 |     100 |   99.49 | 195                                 
------------------------|---------|----------|---------|---------|-------------------------------------
```

@danielroe @pi0 if you can confirm the fix is working on the canary release on your end we'll merge and release promptly 🙌 