### PR TITLE
fix: remove deprecation warnings for the request method

### DIFF
--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -605,9 +605,8 @@ export class ObservableSanityClient {
   }
 
   /**
-   * DEPRECATED: Perform an HTTP request against the Sanity API
+   * Perform an HTTP request against the Sanity API
    *
-   * @deprecated Use your own request library!
    * @param options - Request options
    */
   request<R = Any>(options: RawRequestOptions): Observable<R> {


### PR DESCRIPTION
It seems that enough cases have come up where it's convenient to use `client.request` to interact with Sanity endpoints that haven't been abstracted into the client (yet). For example, like `client.config({ withCredentials: true}).request('/users/me')` or the more recent code that we're shipping: 
```ts
client.request<QueryResult[]>({
    method: 'POST',
    url: `/embeddings-index/query/${dataset}/${indexName}?projectId=${projectId}`,
    body: {
      query: queryString,
      maxResults,
      filter,
    },
  })
```

So I propose that we un-deprecate, and document this method unless there is an apparent reason not to. 