### PR TITLE
feat: allow passing null as tag to explicitly disable it

### DIFF
--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -314,7 +314,7 @@ export function _requestObservable<R>(
       ? [config.requestTagPrefix, options.tag].join('.')
       : options.tag || config.requestTagPrefix
 
-  if (tag) {
+  if (tag && options.tag !== null) {
     options.query = {tag: validate.requestTag(tag), ...options.query}
   }
 

--- a/src/datasets/DatasetsClient.ts
+++ b/src/datasets/DatasetsClient.ts
@@ -47,7 +47,10 @@ export class ObservableDatasetsClient {
    * Fetch a list of datasets for the configured project
    */
   list(): Observable<DatasetsResponse> {
-    return _request<DatasetsResponse>(this.#client, this.#httpRequest, {uri: '/datasets'})
+    return _request<DatasetsResponse>(this.#client, this.#httpRequest, {
+      uri: '/datasets',
+      tag: null,
+    })
   }
 }
 
@@ -98,7 +101,7 @@ export class DatasetsClient {
    */
   list(): Promise<DatasetsResponse> {
     return lastValueFrom(
-      _request<DatasetsResponse>(this.#client, this.#httpRequest, {uri: '/datasets'}),
+      _request<DatasetsResponse>(this.#client, this.#httpRequest, {uri: '/datasets', tag: null}),
     )
   }
 }
@@ -111,5 +114,10 @@ function _modify<R = unknown>(
   options?: {aclMode?: DatasetAclMode},
 ) {
   validate.dataset(name)
-  return _request<R>(client, httpRequest, {method, uri: `/datasets/${name}`, body: options})
+  return _request<R>(client, httpRequest, {
+    method,
+    uri: `/datasets/${name}`,
+    body: options,
+    tag: null,
+  })
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -450,29 +450,31 @@ describe('client', async () => {
   })
 
   describe('DATASETS', () => {
+    const dsClient = getClient({requestTagPrefix: 'test'})
+
     test('throws when trying to create dataset with invalid name', () => {
-      expect(() => getClient().datasets.create('*foo*')).toThrow(/Datasets can only contain/i)
+      expect(() => dsClient.datasets.create('*foo*')).toThrow(/Datasets can only contain/i)
     })
 
     test('throws when trying to delete dataset with invalid name', () => {
-      expect(() => getClient().datasets.delete('*foo*')).toThrow(/Datasets can only contain/i)
+      expect(() => dsClient.datasets.delete('*foo*')).toThrow(/Datasets can only contain/i)
     })
 
     test.skipIf(isEdge)('can create dataset', async () => {
       nock(projectHost()).put('/v1/datasets/bar').reply(200)
-      await expect(getClient().datasets.create('bar')).resolves.not.toThrow()
+      await expect(dsClient.datasets.create('bar')).resolves.not.toThrow()
     })
 
     test.skipIf(isEdge)('can delete dataset', async () => {
       nock(projectHost()).delete('/v1/datasets/bar').reply(200)
-      await expect(getClient().datasets.delete('bar')).resolves.not.toThrow()
+      await expect(dsClient.datasets.delete('bar')).resolves.not.toThrow()
     })
 
     test.skipIf(isEdge)('can list datasets', async () => {
       nock(projectHost())
         .get('/v1/datasets')
         .reply(200, [{name: 'foo'}, {name: 'bar'}] as DatasetsResponse)
-      await expect(getClient().datasets.list()).resolves.toEqual([{name: 'foo'}, {name: 'bar'}])
+      await expect(dsClient.datasets.list()).resolves.toEqual([{name: 'foo'}, {name: 'bar'}])
     })
   })
 


### PR DESCRIPTION
Currently the dataset APIs do not support request tags on their endpoints, which leads to requests failing when client is configured to use a tag.

This PR allows passing `null` as the `tag` on a per-request basis, which opts out of including the tag altogether. This fixes certain cases where for instance the studio is configured with a global tag prefix and tries to call dataset methods like `client.datasets.list()` 