### PR TITLE
feat(stega): allow setting `stega` options on `client.fetch`

### DIFF
--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -69,6 +69,11 @@ export function _fetch<R, Q extends QueryParams>(
   params?: Q,
   options: FilteredResponseQueryOptions | UnfilteredResponseQueryOptions = {},
 ): Observable<RawQueryResponse<R> | R> {
+  if ('stega' in options && options['stega'] !== undefined && options['stega'] !== false) {
+    throw new Error(
+      `It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'fetch' to 'false'.`,
+    )
+  }
   const mapResponse =
     options.filterResponse === false ? (res: Any) => res : (res: Any) => res.result
   const {cache, next, ...opts} = {

--- a/src/stega/config.ts
+++ b/src/stega/config.ts
@@ -1,4 +1,8 @@
-import type {ClientConfig} from '../types'
+import type {
+  ClientConfig,
+  FilteredResponseQueryOptions,
+  UnfilteredResponseQueryOptions,
+} from '../types'
 import type {ClientStegaConfig, InitializedStegaConfig, StegaConfig} from './types'
 
 export const defaultStegaConfig: StegaConfig = {
@@ -52,4 +56,21 @@ export const initStegaConfig = (
   }
 
   return newConfig
+}
+
+export function splitStegaConfigFromFetchOptions(
+  options: (FilteredResponseQueryOptions | UnfilteredResponseQueryOptions) & {
+    stega?: boolean | StegaConfig
+  },
+  initializedStegaConfig: InitializedStegaConfig,
+): {
+  fetchOptions: FilteredResponseQueryOptions | UnfilteredResponseQueryOptions
+  stegaConfig: InitializedStegaConfig
+} {
+  const {stega = {}, ...fetchOptions} = options
+  const stegaConfig = initStegaConfig(
+    typeof stega === 'boolean' ? {enabled: stega} : stega,
+    initializedStegaConfig,
+  )
+  return {fetchOptions, stegaConfig}
 }

--- a/test/stega/client.test.ts
+++ b/test/stega/client.test.ts
@@ -8,9 +8,19 @@ import {
 import {vercelStegaDecode, vercelStegaDecodeAll, vercelStegaSplit} from '@vercel/stega'
 import {describe, expect, test} from 'vitest'
 
+const apiHost = 'api.sanity.url'
+const defaultProjectId = 'bf1942'
+const projectHost = (projectId?: string) => `https://${projectId || defaultProjectId}.${apiHost}`
+const clientConfig = {
+  apiHost: `https://${apiHost}`,
+  projectId: 'bf1942',
+  apiVersion: '1',
+  dataset: 'foo',
+  useCdn: false,
+}
+
 describe('@sanity/client/stega', async () => {
   const isEdge = typeof EdgeRuntime === 'string'
-  // const isNode = !isEdge && typeof document === 'undefined'
   let nock: typeof import('nock') = (() => {
     throw new Error('Not supported in EdgeRuntime')
   }) as any
@@ -18,199 +28,328 @@ describe('@sanity/client/stega', async () => {
     const _nock = await import('nock')
     nock = _nock.default
   }
-  const apiHost = 'api.sanity.url'
-  const defaultProjectId = 'bf1942'
-  const projectHost = (projectId?: string) => `https://${projectId || defaultProjectId}.${apiHost}`
-  const clientConfig = {
-    apiHost: `https://${apiHost}`,
-    projectId: 'bf1942',
-    apiVersion: '1',
-    dataset: 'foo',
-    useCdn: false,
-  }
+
   const getClient = (conf?: ClientStegaConfig) => createClient({...clientConfig, ...(conf || {})})
 
-  test('createClient returns a SanityStegaClient instance', () => {
-    const client = createClient({projectId: 'foo', dataset: 'bar'})
-    expect(client).toBeInstanceOf(SanityStegaClient)
-  })
-
-  test('config() returns a stega config property', () => {
-    const client = createClient({projectId: 'foo', dataset: 'bar'})
-    expect(client.config().stega).toMatchInlineSnapshot(`
+  const result = [{_id: 'njgNkngskjg', title: 'IPA', rating: 4, country: 'Norway'}]
+  const resultSourceMap = {
+    documents: [
       {
-        "enabled": false,
-        "filter": [Function],
-      }
-    `)
-  })
-
-  test('withConfig merges stega', () => {
-    const client = createClient({projectId: 'foo', dataset: 'bar', stega: {studioUrl: '/studio'}})
-    expect(client.withConfig({stega: {enabled: true}}).config().stega.studioUrl).toBe('/studio')
-  })
-
-  test('the stega option accepts booleans as a shortcut to toggle `enabled`', () => {
-    const client1 = createClient({
-      projectId: 'foo',
-      dataset: 'bar',
-      stega: {enabled: true, studioUrl: '/studio'},
-    })
-    expect(client1.withConfig({stega: false}).config().stega.enabled).toBe(false)
-    const client2 = createClient({
-      projectId: 'foo',
-      dataset: 'bar',
-      stega: {enabled: false, studioUrl: '/studio'},
-    })
-    expect(client2.withConfig({stega: true}).config().stega.enabled).toBe(true)
-  })
-
-  test('config merges stega', () => {
-    const client = createClient({projectId: 'foo', dataset: 'bar', stega: {studioUrl: '/studio'}})
-    expect(client.config({stega: {enabled: true}}).config().stega.studioUrl).toBe('/studio')
-  })
-
-  test('the stega option accepts booleans as a shortcut to toggle `enabled`', () => {
-    const client = createClient({
-      projectId: 'foo',
-      dataset: 'bar',
-      stega: {enabled: true, studioUrl: '/studio'},
-    })
-    expect(client.config({stega: false}).config().stega.enabled).toBe(false)
-    expect(client.config({stega: true}).config().stega.enabled).toBe(true)
-  })
-
-  test.skipIf(isEdge)('it returns stega strings in the response', async () => {
-    const result = [{_id: 'njgNkngskjg', title: 'IPA', rating: 4, country: 'Norway'}]
-    const resultSourceMap = {
-      documents: [
-        {
-          _id: 'njgNkngskjg',
-          _type: 'beer',
-        },
-      ],
-      paths: ["$['_id']", "$['title']", "$['rating']", "$['country']"],
-      mappings: {
-        "$[0]['_id']": {
-          source: {
-            document: 0,
-            path: 0,
-            type: 'documentValue',
-          },
-          type: 'value',
-        },
-        "$[0]['title']": {
-          source: {
-            document: 0,
-            path: 1,
-            type: 'documentValue',
-          },
-          type: 'value',
-        },
-        "$[0]['rating']": {
-          source: {
-            document: 0,
-            path: 2,
-            type: 'documentValue',
-          },
-          type: 'value',
-        },
-        "$[0]['country']": {
-          source: {
-            document: 0,
-            path: 3,
-            type: 'documentValue',
-          },
-          type: 'value',
-        },
+        _id: 'njgNkngskjg',
+        _type: 'beer',
       },
-    } satisfies ContentSourceMap
-    const query = '*[_id == $id]{_id, title, rating}'
-    const params = {id: 'njgNkngskjg'}
-    const qs = '*%5B_id+%3D%3D+%24id%5D%7B_id%2C+title%2C+rating%7D&%24id=%22njgNkngskjg%22'
+    ],
+    paths: ["$['_id']", "$['title']", "$['rating']", "$['country']"],
+    mappings: {
+      "$[0]['_id']": {
+        source: {
+          document: 0,
+          path: 0,
+          type: 'documentValue',
+        },
+        type: 'value',
+      },
+      "$[0]['title']": {
+        source: {
+          document: 0,
+          path: 1,
+          type: 'documentValue',
+        },
+        type: 'value',
+      },
+      "$[0]['rating']": {
+        source: {
+          document: 0,
+          path: 2,
+          type: 'documentValue',
+        },
+        type: 'value',
+      },
+      "$[0]['country']": {
+        source: {
+          document: 0,
+          path: 3,
+          type: 'documentValue',
+        },
+        type: 'value',
+      },
+    },
+  } satisfies ContentSourceMap
+  const query = '*[_id == $id]{_id, title, rating}'
+  const params = {id: 'njgNkngskjg'}
+  const qs = '*%5B_id+%3D%3D+%24id%5D%7B_id%2C+title%2C+rating%7D&%24id=%22njgNkngskjg%22'
+  const studioUrl = '/studio'
 
-    nock(projectHost())
-      .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
-      .reply(200, {
-        ms: 123,
-        query: query,
-        result,
-        resultSourceMap,
+  describe('createClient', async () => {
+    test('createClient returns a SanityStegaClient instance', () => {
+      const client = createClient({projectId: 'foo', dataset: 'bar'})
+      expect(client).toBeInstanceOf(SanityStegaClient)
+    })
+
+    test('config() returns a stega config property', () => {
+      const client = createClient({projectId: 'foo', dataset: 'bar'})
+      expect(client.config().stega).toMatchInlineSnapshot(`
+        {
+          "enabled": false,
+          "filter": [Function],
+        }
+      `)
+    })
+
+    test('withConfig merges stega', () => {
+      const client = createClient({projectId: 'foo', dataset: 'bar', stega: {studioUrl: '/studio'}})
+      expect(client.withConfig({stega: {enabled: true}}).config().stega.studioUrl).toBe('/studio')
+    })
+
+    test('the stega option accepts booleans as a shortcut to toggle `enabled`', () => {
+      const client1 = createClient({
+        projectId: 'foo',
+        dataset: 'bar',
+        stega: {enabled: true, studioUrl: '/studio'},
       })
+      expect(client1.withConfig({stega: false}).config().stega.enabled).toBe(false)
+      const client2 = createClient({
+        projectId: 'foo',
+        dataset: 'bar',
+        stega: {enabled: false, studioUrl: '/studio'},
+      })
+      expect(client2.withConfig({stega: true}).config().stega.enabled).toBe(true)
+    })
 
-    const res = await getClient({stega: {enabled: true, studioUrl: '/studio'}}).fetch(query, params)
-    expect(res.length, 'length should match').toBe(1)
-    expect(res[0].rating, 'data should match').toBe(4)
-    expect(res[0].title).not.toBe(result[0].title)
-    expect(vercelStegaSplit(res[0].title).cleaned).toBe(result[0].title)
-    expect(vercelStegaDecode(res[0].title)).toMatchInlineSnapshot(`
-      {
-        "href": "/studio/intent/edit/id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title",
-        "origin": "sanity.io",
-      }
-    `)
-    expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot(`
-      [
+    test('config merges stega', () => {
+      const client = createClient({projectId: 'foo', dataset: 'bar', stega: {studioUrl: '/studio'}})
+      expect(client.config({stega: {enabled: true}}).config().stega.studioUrl).toBe('/studio')
+    })
+
+    test('the stega option accepts booleans as a shortcut to toggle `enabled`', () => {
+      const client = createClient({
+        projectId: 'foo',
+        dataset: 'bar',
+        stega: {enabled: true, studioUrl: '/studio'},
+      })
+      expect(client.config({stega: false}).config().stega.enabled).toBe(false)
+      expect(client.config({stega: true}).config().stega.enabled).toBe(true)
+    })
+
+    test.skipIf(isEdge)('it returns stega strings in the response', async () => {
+      nock(projectHost())
+        .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
+        .reply(200, {ms: 123, query, result, resultSourceMap})
+
+      const res = await getClient({stega: {enabled: true, studioUrl: '/studio'}}).fetch(
+        query,
+        params,
+      )
+      expect(res.length, 'length should match').toBe(1)
+      expect(res[0].rating, 'data should match').toBe(4)
+      expect(res[0].title).not.toBe(result[0].title)
+      expect(vercelStegaSplit(res[0].title).cleaned).toBe(result[0].title)
+      expect(vercelStegaDecode(res[0].title)).toMatchInlineSnapshot(`
         {
           "href": "/studio/intent/edit/id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title",
           "origin": "sanity.io",
+        }
+      `)
+      expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot(`
+        [
+          {
+            "href": "/studio/intent/edit/id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title",
+            "origin": "sanity.io",
+          },
+          {
+            "href": "/studio/intent/edit/id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=country",
+            "origin": "sanity.io",
+          },
+        ]
+      `)
+    })
+  })
+
+  describe.skipIf(isEdge)('client.fetch', async () => {
+    test('the stega option accepts booleans as a shortcut to toggle `enabled`', async () => {
+      nock(projectHost())
+        .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
+        .reply(200, {ms: 123, query, result, resultSourceMap})
+
+      const res = await getClient({stega: {studioUrl}}).fetch(query, params, {
+        stega: true,
+      })
+      expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot(`
+        [
+          {
+            "href": "/studio/intent/edit/id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title",
+            "origin": "sanity.io",
+          },
+          {
+            "href": "/studio/intent/edit/id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=country",
+            "origin": "sanity.io",
+          },
+        ]
+      `)
+    })
+
+    test('the stega option accepts booleans as a shortcut to toggle `enabled`', async () => {
+      nock(projectHost())
+        .get(`/v1/data/query/foo?query=${qs}`)
+        .reply(200, {ms: 123, query, result, resultSourceMap})
+
+      const res = await getClient({stega: {studioUrl, enabled: true}}).fetch(query, params, {
+        stega: false,
+      })
+      expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot('undefined')
+    })
+
+    test('the stega option merges in defaults', async () => {
+      nock(projectHost())
+        .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
+        .reply(200, {ms: 123, query, result, resultSourceMap})
+
+      const res = await getClient({stega: {studioUrl, enabled: true}}).fetch(query, params, {
+        stega: {
+          studioUrl: '/admin',
         },
-        {
-          "href": "/studio/intent/edit/id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=country",
-          "origin": "sanity.io",
-        },
-      ]
-    `)
+      })
+      expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot(`
+        [
+          {
+            "href": "/admin/intent/edit/id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fadmin&id=njgNkngskjg&type=beer&path=title",
+            "origin": "sanity.io",
+          },
+          {
+            "href": "/admin/intent/edit/id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fadmin&id=njgNkngskjg&type=beer&path=country",
+            "origin": "sanity.io",
+          },
+        ]
+      `)
+    })
   })
 })
 
 describe('@sanity/client', () => {
-  test('throws an error if trying to use stega options that should use the stega client', () => {
-    expect(() =>
-      createCoreClient({
-        projectId: 'abc123',
+  describe('createClient', () => {
+    test('throws an error if trying to use stega options that should use the stega client', () => {
+      expect(() =>
+        createCoreClient({
+          projectId: 'abc123',
+          // @ts-expect-error - we want to test that it throws an error
+          stega: {
+            enabled: true,
+          },
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'createClient' to 'false'.\"",
+      )
+      expect(() =>
         // @ts-expect-error - we want to test that it throws an error
-        stega: {
-          enabled: true,
-        },
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(
-      "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'createClient' to 'false'.\"",
-    )
-    expect(() =>
-      // @ts-expect-error - we want to test that it throws an error
-      createCoreClient({projectId: 'abc123', stega: null}),
-    ).toThrowErrorMatchingInlineSnapshot(
-      "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'createClient' to 'false'.\"",
-    )
+        createCoreClient({projectId: 'abc123', stega: null}),
+      ).toThrowErrorMatchingInlineSnapshot(
+        "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'createClient' to 'false'.\"",
+      )
+    })
+    test('allows passing stega: undefined', () => {
+      expect(() =>
+        createCoreClient({
+          projectId: 'abc123',
+          // @ts-expect-error - we want to test that it throws an error
+          stega: undefined,
+        }),
+      ).not.toThrow()
+    })
+    test('allows passing stega: false', () => {
+      expect(() =>
+        createCoreClient({
+          projectId: 'abc123',
+          // @ts-expect-error - we want to test that it throws an error
+          stega: false,
+        }),
+      ).not.toThrow()
+    })
+    test('disallows passing stega: true', () => {
+      expect(() =>
+        createCoreClient({
+          projectId: 'abc123',
+          // @ts-expect-error - we want to test that it throws an error
+          stega: true,
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'createClient' to 'false'.\"",
+      )
+    })
   })
-  test('allows passing stega: undefined', () => {
-    expect(() =>
-      createCoreClient({
-        projectId: 'abc123',
+  describe('client.fetch', async () => {
+    const client = createCoreClient(clientConfig)
+    const isEdge = typeof EdgeRuntime === 'string'
+    let nock: typeof import('nock') = (() => {
+      throw new Error('Not supported in EdgeRuntime')
+    }) as any
+    if (!isEdge) {
+      const _nock = await import('nock')
+      nock = _nock.default
+
+      nock(projectHost())
+        .get(`/v1/data/query/foo?query=*`)
+        .reply(200, {ms: 123, query: '*', result: []})
+    }
+
+    test('throws an error if trying to use stega options that should use the stega client', async () => {
+      await expect(() =>
+        client.fetch(
+          '*',
+          {},
+          {
+            // @ts-expect-error - we want to test that it throws an error
+            stega: {
+              enabled: true,
+            },
+          },
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(
+        "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'fetch' to 'false'.\"",
+      )
+      expect(() =>
         // @ts-expect-error - we want to test that it throws an error
-        stega: undefined,
-      }),
-    ).not.toThrow()
-  })
-  test('allows passing stega: false', () => {
-    expect(() =>
-      createCoreClient({
-        projectId: 'abc123',
-        // @ts-expect-error - we want to test that it throws an error
-        stega: false,
-      }),
-    ).not.toThrow()
-  })
-  test('disallows passing stega: true', () => {
-    expect(() =>
-      createCoreClient({
-        projectId: 'abc123',
-        // @ts-expect-error - we want to test that it throws an error
-        stega: true,
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(
-      "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'createClient' to 'false'.\"",
-    )
+        createCoreClient({projectId: 'abc123', stega: null}),
+      ).toThrowErrorMatchingInlineSnapshot(
+        "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'createClient' to 'false'.\"",
+      )
+    })
+    test('allows passing stega: undefined', () => {
+      expect(() =>
+        client.fetch(
+          '*',
+          {},
+          {
+            // @ts-expect-error - we want to test that it throws an error
+            stega: undefined,
+          },
+        ),
+      ).not.toThrow()
+    })
+    test('allows passing stega: false', () => {
+      expect(() =>
+        client.fetch(
+          '*',
+          {},
+          {
+            // @ts-expect-error - we want to test that it throws an error
+            stega: false,
+          },
+        ),
+      ).not.toThrow()
+    })
+    test('disallows passing stega: true', () => {
+      expect(() =>
+        client.fetch(
+          '*',
+          {},
+          {
+            // @ts-expect-error - we want to test that it throws an error
+            stega: true,
+          },
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(
+        "\"It looks like you're using options meant for '@sanity/client/stega'. Make sure you're using the right import. Or set 'stega' in 'fetch' to 'false'.\"",
+      )
+    })
   })
 })


### PR DESCRIPTION
Allows setting `stega` options on `client.fetch`, so it's easy to toggle. For example an Next.js App Router website might wish to setup everything in one place:
```ts
import {createClient} from '@sanity/client/stega'

const createClient({
  // ... other options
  stega: {
    studioUrl: 'https://my-project.sanity.studio',
    filter: props => {
      if(props.sourcePath.some((path) => path === 'metadata' || path === 'openGraph' || path === 'twitter')) {
        return false
      }
      return props.filterDefault(props)
    },
  },
})
```

And later toggle `stega` on or off based on if `draftMode` is true:

```ts
import { draftMode } from 'next/headers'

export default async ReactServerComponent() {
  const data = await client.fetch(query, params, {stega: {enabled: draftMode().isEnabled}})
  // You can pass a boolean as a shortcut for setting stega.enabled
  const data = await client.fetch(query, params, {stega: draftMode().isEnabled})
}
```

It's also useful to be able to enable the logger on specific requests:

```tsx
import { draftMode } from 'next/headers'

export default async ReactServerComponent() {
  const data = await client.fetch(query, params, {
    stega: {
      logger: console,
    }
  })
}
```
