### PR TITLE
fix(types): disambiguate `SanityClient` imports

### DIFF
--- a/src/stega/SanityStegaClient.ts
+++ b/src/stega/SanityStegaClient.ts
@@ -2,7 +2,10 @@ import {Observable} from 'rxjs'
 import {map} from 'rxjs/operators'
 
 import {defaultConfig} from '../config'
-import {ObservableSanityClient, SanityClient} from '../SanityClient'
+import {
+  ObservableSanityClient as INTERNAL_DO_NOT_USE_DIRECTLY_ObservableSanityClient,
+  SanityClient as INTERNAL_DO_NOT_USE_DIRECTLY_SanityClient,
+} from '../SanityClient'
 import type {
   Any,
   ClientConfig,
@@ -17,7 +20,7 @@ import {stegaEncodeSourceMap} from './stegaEncodeSourceMap'
 import {ClientStegaConfig, InitializedClientStegaConfig, InitializedStegaConfig} from './types'
 
 /** @public */
-export class ObservableSanityStegaClient extends ObservableSanityClient {
+export class ObservableSanityStegaClient extends INTERNAL_DO_NOT_USE_DIRECTLY_ObservableSanityClient {
   /**
    * Private properties
    */
@@ -143,7 +146,7 @@ export class ObservableSanityStegaClient extends ObservableSanityClient {
 }
 
 /** @public */
-export class SanityStegaClient extends SanityClient {
+export class SanityStegaClient extends INTERNAL_DO_NOT_USE_DIRECTLY_SanityClient {
   /**
    * Observable version of the Sanity client, with the same configuration as the promise-based one
    */
@@ -271,4 +274,9 @@ export class SanityStegaClient extends SanityClient {
         return originalFilterResponse ? result : {...res, result}
       })
   }
+}
+
+export type {
+  INTERNAL_DO_NOT_USE_DIRECTLY_ObservableSanityClient,
+  INTERNAL_DO_NOT_USE_DIRECTLY_SanityClient,
 }

--- a/src/stega/index.browser.ts
+++ b/src/stega/index.browser.ts
@@ -10,6 +10,7 @@ const exp = defineCreateClientExports<SanityStegaClient, ClientStegaConfig>(
   SanityStegaClient,
 )
 
+export type {ObservableSanityClient, SanityClient} from './shared'
 export * from './shared'
 
 /** @public */

--- a/src/stega/index.ts
+++ b/src/stega/index.ts
@@ -10,6 +10,7 @@ const exp = defineCreateClientExports<SanityStegaClient, ClientStegaConfig>(
   SanityStegaClient,
 )
 
+export type {ObservableSanityClient, SanityClient} from './shared'
 export * from './shared'
 
 /** @public */

--- a/src/stega/shared.ts
+++ b/src/stega/shared.ts
@@ -3,3 +3,15 @@ export * from './SanityStegaClient'
 export {stegaEncodeSourceMap} from './stegaEncodeSourceMap'
 export * from './types'
 export {vercelStegaCleanAll} from './vercelStegaCleanAll'
+
+/**
+ * @deprecated -- Use `import type {SanityClient} from '@sanity/client'` instead
+ * @public
+ */
+export type SanityClient = never
+
+/**
+ * @deprecated -- Use `import type {ObservableSanityClient} from '@sanity/client'` instead
+ * @public
+ */
+export type ObservableSanityClient = never


### PR DESCRIPTION
In the JS world these two are the same instance: 
```js
import {SanityClient} from '@sanity/client'
import {SanityClient as SanityCoreClient} from '@sanity/client/stega'

assert(SanityClient === SanityCoreClient) // all good
```

But due to how we generate typings, TypeScript thinks they're not compatible as they're classes with private properties:
```ts
import type {SanityClient, SanityStegaClient} from '@sanity/client/stega'

interface Props {
  client: SanityClient | SanityStegaClient
}
function Component(props: Props) {}

// Later on
import {createClient} from '@sanity/client'
<Component client={createClient()} />
```

But now it'll throw an error like:
```
Argument of type 'import("@sanity/client/dist/index").SanityClient' is not assignable to parameter of type 'import("@sanity/client/dist/stega").SanityClient'.
  Property '#private' in type 'SanityClient' refers to a different member that cannot be accessed from within type 'SanityClient'.ts(2345)
```
Errors are usually not as clear as the above btw, it took me a while to figure out what was wrong when I first encountered this. The fix is not obvious:

```diff
-import type {SanityClient, SanityStegaClient} from '@sanity/client/stega'
+import type {SanityClient} from '@sanity/client'
+import type {SanityStegaClient} from '@sanity/client/stega'
```

So the point of this PR is that if you now do this:
```ts
import type {SanityClient} from '@sanity/client'
```
You'll get a clear error:
```
Argument of type 'SanityStegaClient' is not assignable to parameter of type 'never'.ts(2345)
```
And the import uses a `@deprecated` symbol to make sure VS Code don't autocomplete it, and clearly highlights it:
![image](https://github.com/sanity-io/client/assets/81981/794519b1-23be-415b-b38f-ec7be6f686a1)
