### PR TITLE
fix: strip `#private` annotation from `.d.ts` files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.11.4-canary.0",
+  "version": "6.11.4-canary.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.11.4-canary.0",
+      "version": "6.11.4-canary.4",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.11.4-canary.0",
+  "version": "6.11.4-canary.4",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",
@@ -102,6 +102,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "pkg build --strict && pkg --strict && npm run rollup && npm run minify",
+    "postbuild": "node ./scripts/fix-dts.mjs",
     "clean": "npx rimraf dist coverage umd/*.js",
     "coverage": "vitest run --coverage",
     "lint": "eslint . --ext .cjs,.js,.ts --max-warnings 0",

--- a/scripts/fix-dts.mjs
+++ b/scripts/fix-dts.mjs
@@ -1,0 +1,66 @@
+/**
+ * 
+ * Using private properties with a # prefix in classes pose problems that 
+ * tend to can be painful to resolve in userland. If there are more than one `@sanity/client`
+ * package in `node_modules` then TS is unable to resolve checks like:
+ * ```
+ * import {SanityClient} from 'sanity' // resolves to ./node_modules/sanity/node_modules/@sanity/client
+ 
+ * function isSanityClient(client: unknown): client is SanityClient {
+ *   return client instanceof SanityClient
+ * }
+ * ```
+ * The above check will fail in a scenario like this:
+ * ```
+ * import {createClient} from '@sanity/client' // resolves to ./node_modules/@sanity/client
+ * 
+ * console.log(isSanityClient(createClient({})))
+ * ```
+ * The above will throw a confusing error like:
+ * ```
+ * Argument of type 'import("/node_modules/@sanity/client/dist/index").SanityClient' is not assignable to parameter of type 'import("/node_modules/sanity/node_modules/@sanity/client/dist/index").SanityClient'.
+ * The types of 'observable.listen' are incompatible between these types.
+ * ```
+ * It's possible to resolve these by deduping the dependency using `pnpm`, `npm` or `yarn`.
+ * But not always, and more importantly, it's seldom obvious that's what the problem is.
+ * Thus we strip the `#private` annotations from the generated `.d.ts` files.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const readPackageJsonTypesExports = () => {
+  const packageJsonPath = path.join(__dirname, '../package.json') // Adjust if your package.json is not in the same directory
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  const exportsEntries = Object.values(packageJson.exports)
+
+  // Extract 'types' entries
+  const dtsPaths = exportsEntries
+    .map((entry) => {
+      if (typeof entry === 'object' && entry.types) {
+        return entry.types
+      }
+      return null
+    })
+    .filter((dir) => dir !== null)
+
+  return dtsPaths
+}
+
+const removePrivateFields = (filePath) => {
+  const data = fs.readFileSync(filePath, 'utf8')
+  const result = data
+    .split('\n')
+    .filter((line) => !line.includes('#private'))
+    .join('\n')
+  fs.writeFileSync(filePath, result, 'utf8')
+}
+
+const dtsFiles = readPackageJsonTypesExports()
+dtsFiles.forEach((file) => {
+  const filePath = path.join(__dirname, '..', file)
+  removePrivateFields(filePath)
+})


### PR DESCRIPTION
Using private properties with a # prefix in classes pose problems that 
 tend to can be painful to resolve in userland. If there are more than one `@sanity/client`
 package in `node_modules` then TS is unable to resolve checks like:
 ```
 import {SanityClient} from 'sanity' // resolves to ./node_modules/sanity/node_modules/@sanity/client
 
 function isSanityClient(client: unknown): client is SanityClient {
   return client instanceof SanityClient
 }
 ```
 The above check will fail in a scenario like this:
 ```
 import {createClient} from '@sanity/client' // resolves to ./node_modules/@sanity/client
 
 console.log(isSanityClient(createClient({})))
 ```
 The above will throw a confusing error like:
 ```
 Argument of type 'import("/node_modules/@sanity/client/dist/index").SanityClient' is not assignable to parameter of type 'import("/node_modules/sanity/node_modules/@sanity/client/dist/index").SanityClient'.
  The types of 'observable.listen' are incompatible between these types.
 ```
  It's possible to resolve these by deduping the dependency using `pnpm`, `npm` or `yarn`.
  But not always, and more importantly, it's seldom obvious that's what the problem is.
  Thus we strip the `#private` annotations from the generated `.d.ts` files.
 
# Issue reproduction

A reliable way to reproduce the scenario is to force `npm` to install two instances of the client on two different versions to break the built in deduping:
```sh
npm i --save-exact sanity-client-a@npm:@sanity/client@6.11.0 sanity-client-b@npm:@sanity/client@6.11.1
```
Then create a new file `repro.ts`:
```ts
import {SanityClient} from 'sanity-client-a'
import {createClient} from 'sanity-client-b'

function allPosts(client: SanityClient) {
  return client.fetch('*[_type == "post"]')
}

allPosts(createClient({}))
```
You'll see an error like this:
```sh
Argument of type 'import("/node_modules/sanity-client-b/dist/index").SanityClient' is not assignable to parameter of type 'import("/node_modules/sanity-client-a/dist/index").SanityClient'.
  Property '#private' in type 'SanityClient' refers to a different member that cannot be accessed from within type 'SanityClient'.ts(2345)
```

# Fix reproduction

I published two canaries so you just have to run this command in the repro:
```sh
npm i --save-exact sanity-client-a@npm:@sanity/client@6.11.4-canary.3 sanity-client-b@npm:@sanity/client@6.11.4-canary.4
```