### PR TITLE
feat: add support for `returnQuery` option, default to `false`

### DIFF
--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -28,12 +28,14 @@ import type {
   QueryOptions,
   QueryParams,
   QueryWithoutParams,
+  RawQuerylessQueryResponse,
   RawQueryResponse,
   RawRequestOptions,
   SanityDocument,
   SanityDocumentStub,
   SingleMutationResult,
   UnfilteredResponseQueryOptions,
+  UnfilteredResponseWithoutQuery,
 } from './types'
 import {ObservableUsersClient, UsersClient} from './users/UsersClient'
 
@@ -160,6 +162,18 @@ export class ObservableSanityClient {
     params: Q extends QueryWithoutParams ? QueryWithoutParams : Q,
     options: UnfilteredResponseQueryOptions,
   ): Observable<RawQueryResponse<R>>
+  /**
+   * Perform a GROQ-query against the configured dataset.
+   *
+   * @param query - GROQ-query to perform
+   * @param params - Optional query parameters
+   * @param options - Request options
+   */
+  fetch<R = Any, Q extends QueryWithoutParams | QueryParams = QueryParams>(
+    query: string,
+    params: Q extends QueryWithoutParams ? QueryWithoutParams : Q,
+    options: UnfilteredResponseWithoutQuery,
+  ): Observable<RawQuerylessQueryResponse<R>>
   fetch<R, Q>(
     query: string,
     params?: Q,
@@ -799,6 +813,18 @@ export class SanityClient {
     params: Q extends QueryWithoutParams ? QueryWithoutParams : Q,
     options: UnfilteredResponseQueryOptions,
   ): Promise<RawQueryResponse<R>>
+  /**
+   * Perform a GROQ-query against the configured dataset.
+   *
+   * @param query - GROQ-query to perform
+   * @param params - Optional query parameters
+   * @param options - Request options
+   */
+  fetch<R = Any, Q extends QueryWithoutParams | QueryParams = QueryParams>(
+    query: string,
+    params: Q extends QueryWithoutParams ? QueryWithoutParams : Q,
+    options: UnfilteredResponseWithoutQuery,
+  ): Promise<RawQuerylessQueryResponse<R>>
   fetch<R, Q>(query: string, params?: Q, options?: QueryOptions): Promise<RawQueryResponse<R> | R> {
     return lastValueFrom(
       dataMethods._fetch<R, Q>(

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -80,6 +80,11 @@ export function _fetch<R, Q>(
   const params = stega.enabled ? vercelStegaCleanAll(_params) : _params
   const mapResponse =
     options.filterResponse === false ? (res: Any) => res : (res: Any) => res.result
+
+  // Default to not returning the query, unless `filterResponse` is `false`,
+  // or `returnQuery` is explicitly set. `true` is the default in Content Lake, so skip if truthy
+  const returnQuery = options.filterResponse === false && options.returnQuery !== false
+
   const {cache, next, ...opts} = {
     // Opt out of setting a `signal` on an internal `fetch` if one isn't provided.
     // This is necessary in React Server Components to avoid opting out of Request Memoization.
@@ -93,7 +98,13 @@ export function _fetch<R, Q>(
       ? {...opts, fetch: {cache, next}}
       : opts
 
-  const $request = _dataRequest(client, httpRequest, 'query', {query, params}, reqOpts)
+  const $request = _dataRequest(
+    client,
+    httpRequest,
+    'query',
+    {query, params, options: {returnQuery}},
+    reqOpts,
+  )
   return stega.enabled
     ? $request.pipe(
         combineLatestWith(

--- a/src/data/encodeQueryString.ts
+++ b/src/data/encodeQueryString.ts
@@ -11,7 +11,7 @@ export const encodeQueryString = ({
 }) => {
   const searchParams = new URLSearchParams()
   // We generally want tag at the start of the query string
-  const {tag, ...opts} = options
+  const {tag, returnQuery, ...opts} = options
   // We're using `append` instead of `set` to support React Native: https://github.com/facebook/react-native/blob/1982c4722fcc51aa87e34cf562672ee4aff540f1/packages/react-native/Libraries/Blob/URL.js#L86-L88
   if (tag) searchParams.append('tag', tag)
   searchParams.append('query', query)
@@ -25,6 +25,9 @@ export const encodeQueryString = ({
     // Skip falsy values
     if (value) searchParams.append(key, `${value}`)
   }
+
+  // `returnQuery` is default `true`, so needs an explicit `false` handling
+  if (returnQuery === false) searchParams.append('returnQuery', 'false')
 
   return `?${searchParams}`
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -452,6 +452,8 @@ export interface QueryParams {
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
   resultSourceMap?: never
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
+  returnQuery?: never
+  /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
   signal?: never
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
   stega?: never
@@ -721,6 +723,7 @@ export interface ListenOptions {
 export interface ResponseQueryOptions extends RequestOptions {
   perspective?: ClientPerspective
   resultSourceMap?: boolean | 'withKeyArraySelector'
+  returnQuery?: boolean
   useCdn?: boolean
   stega?: boolean | StegaConfig
   // The `cache` and `next` options are specific to the Next.js App Router integration
@@ -736,10 +739,31 @@ export interface FilteredResponseQueryOptions extends ResponseQueryOptions {
 /** @public */
 export interface UnfilteredResponseQueryOptions extends ResponseQueryOptions {
   filterResponse: false
+
+  /**
+   * When `filterResponse` is `false`, `returnQuery` also defaults to `true` for
+   * backwards compatibility (on the client side, not from the content lake API).
+   * Can also explicitly be set to `true`.
+   */
+  returnQuery?: true
+}
+
+/**
+ * When using `filterResponse: false`, but you do not wish to receive back the query from
+ * the content lake API.
+ *
+ * @public
+ */
+export interface UnfilteredResponseWithoutQuery extends ResponseQueryOptions {
+  filterResponse: false
+  returnQuery: false
 }
 
 /** @public */
-export type QueryOptions = FilteredResponseQueryOptions | UnfilteredResponseQueryOptions
+export type QueryOptions =
+  | FilteredResponseQueryOptions
+  | UnfilteredResponseQueryOptions
+  | UnfilteredResponseWithoutQuery
 
 /** @public */
 export interface RawQueryResponse<R> {
@@ -748,6 +772,9 @@ export interface RawQueryResponse<R> {
   result: R
   resultSourceMap?: ContentSourceMap
 }
+
+/** @public */
+export type RawQuerylessQueryResponse<R> = Omit<RawQueryResponse<R>, 'query'>
 
 /** @internal */
 export type BaseMutationOptions = RequestOptions & {

--- a/test-next/client.test-d.ts
+++ b/test-next/client.test-d.ts
@@ -1,6 +1,12 @@
 /// <reference types="next/types/global" />
 
-import {createClient, QueryOptions, QueryParams, RawQueryResponse} from '@sanity/client'
+import {
+  createClient,
+  type QueryOptions,
+  type QueryParams,
+  type RawQuerylessQueryResponse,
+  type RawQueryResponse,
+} from '@sanity/client'
 import {describe, expectTypeOf, test} from 'vitest'
 
 describe('client.fetch', () => {
@@ -33,6 +39,13 @@ describe('client.fetch', () => {
         {filterResponse: false, cache: 'force-cache', next: {revalidate: 60, tags: ['post']}},
       ),
     ).toMatchTypeOf<RawQueryResponse<any>>()
+    expectTypeOf(
+      await client.fetch(
+        '*[_type == $type]',
+        {type: 'post'},
+        {filterResponse: false, returnQuery: false},
+      ),
+    ).toMatchTypeOf<RawQuerylessQueryResponse<any>>()
   })
   test('generics', async () => {
     expectTypeOf(

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -508,9 +508,8 @@ describe('client', async () => {
       const qs =
         'beerfiesta.beer%5B.title%20%3D%3D%20%24beerName%5D&%24beerName=%22Headroom%20Double%20IPA%22'
 
-      nock(projectHost()).get(`/v1/data/query/foo?query=${qs}`).reply(200, {
+      nock(projectHost()).get(`/v1/data/query/foo?query=${qs}&returnQuery=false`).reply(200, {
         ms: 123,
-        query: query,
         result,
       })
 
@@ -527,7 +526,7 @@ describe('client', async () => {
 
       nock(projectHost()).get(`/v1/data/query/foo?query=${qs}`).reply(200, {
         ms: 123,
-        query: query,
+        query,
         result,
       })
 
@@ -538,12 +537,32 @@ describe('client', async () => {
       expect(res.result[0].rating, 'data should match').toBe(5)
     })
 
-    test.skipIf(isEdge)('can query for documents with request tag', async () => {
-      nock(projectHost()).get(`/v1/data/query/foo?query=*&tag=mycompany.syncjob`).reply(200, {
+    test.skipIf(isEdge)('can explicitly ask to include query in response', async () => {
+      const query = 'beerfiesta.beer[.title == $beerName]'
+      const params = {beerName: 'Headroom Double IPA'}
+      const qs =
+        'beerfiesta.beer%5B.title%20%3D%3D%20%24beerName%5D&%24beerName=%22Headroom%20Double%20IPA%22'
+
+      nock(projectHost()).get(`/v1/data/query/foo?query=${qs}`).reply(200, {
         ms: 123,
-        query: '*',
+        query,
         result,
       })
+
+      const res = await getClient().fetch(query, params, {filterResponse: false, returnQuery: true})
+      expect(res.ms, 'should include timing info').toBe(123)
+      expect(res.query, 'should include query').toBe(query)
+      expect(res.result.length, 'length should match').toBe(1)
+      expect(res.result[0].rating, 'data should match').toBe(5)
+    })
+
+    test.skipIf(isEdge)('can query for documents with request tag', async () => {
+      nock(projectHost())
+        .get(`/v1/data/query/foo?query=*&tag=mycompany.syncjob&returnQuery=false`)
+        .reply(200, {
+          ms: 123,
+          result,
+        })
 
       const res = await getClient().fetch('*', {}, {tag: 'mycompany.syncjob'})
       expect(res.length, 'length should match').toBe(1)
@@ -554,10 +573,11 @@ describe('client', async () => {
       'can query for documents with resultSourceMap and perspective',
       async () => {
         nock(projectHost())
-          .get(`/vX/data/query/foo?query=*&resultSourceMap=true&perspective=previewDrafts`)
+          .get(
+            `/vX/data/query/foo?query=*&returnQuery=false&resultSourceMap=true&perspective=previewDrafts`,
+          )
           .reply(200, {
             ms: 123,
-            query: '*',
             result,
             resultSourceMap,
           })
@@ -578,11 +598,10 @@ describe('client', async () => {
       async () => {
         nock(projectHost())
           .get(
-            `/vX/data/query/foo?query=*&resultSourceMap=withKeyArraySelector&perspective=previewDrafts`,
+            `/vX/data/query/foo?query=*&returnQuery=false&resultSourceMap=withKeyArraySelector&perspective=previewDrafts`,
           )
           .reply(200, {
             ms: 123,
-            query: '*',
             result,
             resultSourceMap,
           })
@@ -600,10 +619,9 @@ describe('client', async () => {
 
     test.skipIf(isEdge)('automatically useCdn false if perspective is previewDrafts', async () => {
       nock('https://abc123.api.sanity.io')
-        .get(`/v1/data/query/foo?query=*&perspective=previewDrafts`)
+        .get(`/v1/data/query/foo?query=*&returnQuery=false&perspective=previewDrafts`)
         .reply(200, {
           ms: 123,
-          query: '*',
           result,
         })
 
@@ -622,10 +640,11 @@ describe('client', async () => {
       'can query for documents with resultSourceMap and perspective using the third client.fetch parameter',
       async () => {
         nock(projectHost())
-          .get(`/vX/data/query/foo?query=*&resultSourceMap=true&perspective=previewDrafts`)
+          .get(
+            `/vX/data/query/foo?query=*&returnQuery=false&resultSourceMap=true&perspective=previewDrafts`,
+          )
           .reply(200, {
             ms: 123,
-            query: '*',
             result,
             resultSourceMap,
           })
@@ -644,12 +663,13 @@ describe('client', async () => {
     test.skipIf(isEdge)(
       'setting resultSourceMap and perspective on client.fetch overrides the config',
       async () => {
-        nock(projectHost()).get(`/vX/data/query/foo?query=*&perspective=published`).reply(200, {
-          ms: 123,
-          query: '*',
-          result,
-          resultSourceMap,
-        })
+        nock(projectHost())
+          .get(`/vX/data/query/foo?query=*&returnQuery=false&perspective=published`)
+          .reply(200, {
+            ms: 123,
+            result,
+            resultSourceMap,
+          })
 
         const client = getClient({
           apiVersion: 'X',
@@ -666,10 +686,9 @@ describe('client', async () => {
       'setting a perspective previewDrafts override on client.fetch sets useCdn to false',
       async () => {
         nock('https://abc123.api.sanity.io')
-          .get(`/v1/data/query/foo?query=*&perspective=previewDrafts`)
+          .get(`/v1/data/query/foo?query=*&returnQuery=false&perspective=previewDrafts`)
           .reply(200, {
             ms: 123,
-            query: '*',
             result,
           })
 
@@ -681,11 +700,12 @@ describe('client', async () => {
     )
 
     test.skipIf(isEdge)('allow overriding useCdn to false on client.fetch', async () => {
-      nock('https://abc123.api.sanity.io').get(`/v1/data/query/foo?query=*`).reply(200, {
-        ms: 123,
-        query: '*',
-        result,
-      })
+      nock('https://abc123.api.sanity.io')
+        .get(`/v1/data/query/foo?query=*&returnQuery=false`)
+        .reply(200, {
+          ms: 123,
+          result,
+        })
 
       const client = createClient({projectId: 'abc123', dataset: 'foo', useCdn: true})
       const res = await client.fetch('*', {}, {useCdn: false})
@@ -694,11 +714,12 @@ describe('client', async () => {
     })
 
     test.skipIf(isEdge)('allow overriding useCdn to true on client.fetch', async () => {
-      nock('https://abc123.apicdn.sanity.io').get(`/v1/data/query/foo?query=*`).reply(200, {
-        ms: 123,
-        query: '*',
-        result,
-      })
+      nock('https://abc123.apicdn.sanity.io')
+        .get(`/v1/data/query/foo?query=*&returnQuery=false`)
+        .reply(200, {
+          ms: 123,
+          result,
+        })
 
       const client = createClient({projectId: 'abc123', dataset: 'foo', useCdn: false})
       const res = await client.fetch('*', {}, {useCdn: true})
@@ -707,23 +728,19 @@ describe('client', async () => {
     })
 
     test.skipIf(isEdge)('throws on invalid request tag on request', () => {
-      nock(projectHost()).get(`/v1/data/query/foo?query=*&tag=mycompany.syncjob`).reply(200, {
-        ms: 123,
-        query: '*',
-        result,
-      })
-
       expect(() => {
         getClient().fetch('*', {}, {tag: 'mycompany syncjob ok'})
       }).toThrow(/tag can only contain alphanumeric/i)
     })
 
     test.skipIf(isEdge)('can use a tag-prefixed client', async () => {
-      nock(projectHost()).get(`/v1/data/query/foo?query=*&tag=mycompany.syncjob`).reply(200, {
-        ms: 123,
-        query: '*',
-        result,
-      })
+      nock(projectHost())
+        .get(`/v1/data/query/foo?query=*&returnQuery=false&tag=mycompany.syncjob`)
+        .reply(200, {
+          ms: 123,
+          query: '*',
+          result,
+        })
 
       const res = await getClient({requestTagPrefix: 'mycompany'}).fetch('*', {}, {tag: 'syncjob'})
       expect(res.length, 'length should match').toBe(1)
@@ -739,7 +756,10 @@ describe('client', async () => {
         message: 'You are not allowed to access this resource',
       }
 
-      nock(projectHost()).get('/v1/data/query/foo?query=area51').times(5).reply(403, response)
+      nock(projectHost())
+        .get('/v1/data/query/foo?query=area51&returnQuery=false')
+        .times(5)
+        .reply(403, response)
 
       try {
         await getClient().fetch('area51')
@@ -766,7 +786,7 @@ describe('client', async () => {
       }
 
       nock(projectHost())
-        .get('/v1/data/query/foo?query=foo.bar.baz%20%2012%23%5B%7B')
+        .get('/v1/data/query/foo?query=foo.bar.baz%20%2012%23%5B%7B&returnQuery=false')
         .reply(400, response)
 
       try {
@@ -1180,7 +1200,7 @@ describe('client', async () => {
     test.skipIf(isEdge)('delete() can use query with params', async () => {
       const query = '*[_type == "beer" && title == $beerName]'
       const params = {beerName: 'Headroom Double IPA'}
-      const expectedBody = {mutations: [{delete: {query: query, params: params}}]}
+      const expectedBody = {mutations: [{delete: {query, params: params}}]}
       nock(projectHost())
         .post(
           '/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync',
@@ -1188,7 +1208,7 @@ describe('client', async () => {
         )
         .reply(200, {transactionId: 'abc123'})
 
-      await expect(getClient().delete({query: query, params: params})).resolves.not.toThrow()
+      await expect(getClient().delete({query, params: params})).resolves.not.toThrow()
     })
 
     test.skipIf(isEdge)('delete() can be told not to return documents', async () => {
@@ -1375,10 +1395,9 @@ describe('client', async () => {
 
       nock(projectHost())
         .get('/v1/data/query/foo')
-        .query({query, ...qParams})
+        .query({query, ...qParams, returnQuery: 'false'})
         .reply(200, {
           ms: 123,
-          query: query,
           result,
         })
 
@@ -1404,7 +1423,7 @@ describe('client', async () => {
         .post('/v1/data/query/foo', '*')
         .reply(200, {
           ms: 123,
-          query: query,
+          query,
           result,
         })
 
@@ -1435,7 +1454,7 @@ describe('client', async () => {
         .post('/v1/data/query/foo', '*')
         .reply(200, {
           ms: 123,
-          query: query,
+          query,
           result,
         })
 
@@ -1462,7 +1481,7 @@ describe('client', async () => {
           .post('/v1/data/query/foo?tag=myapp.silly-query', '*')
           .reply(200, {
             ms: 123,
-            query: query,
+            query,
             result,
           })
 
@@ -1490,7 +1509,7 @@ describe('client', async () => {
           .post('/vX/data/query/foo?resultSourceMap=true&perspective=previewDrafts', '*')
           .reply(200, {
             ms: 123,
-            query: query,
+            query,
             result,
             resultSourceMap,
           })
@@ -1523,7 +1542,7 @@ describe('client', async () => {
         .post('/v1/data/query/foo', '*')
         .reply(200, {
           ms: 123,
-          query: query,
+          query,
           result,
         })
 
@@ -2556,7 +2575,9 @@ describe('client', async () => {
       const client = createClient({projectId: 'abc123', dataset: 'foo'})
 
       const response = {result: []}
-      nock('https://abc123.apicdn.sanity.io').get('/v1/data/query/foo?query=*').reply(200, response)
+      nock('https://abc123.apicdn.sanity.io')
+        .get('/v1/data/query/foo?query=*&returnQuery=false')
+        .reply(200, response)
 
       const docs = await client.fetch('*')
       expect(docs.length).toEqual(0)
@@ -2566,7 +2587,9 @@ describe('client', async () => {
       const client = createClient({projectId: 'abc123', dataset: 'foo', useCdn: false})
 
       const response = {result: []}
-      nock('https://abc123.api.sanity.io').get('/v1/data/query/foo?query=*').reply(200, response)
+      nock('https://abc123.api.sanity.io')
+        .get('/v1/data/query/foo?query=*&returnQuery=false')
+        .reply(200, response)
 
       const docs = await client.fetch('*')
       expect(docs.length).toEqual(0)
@@ -2592,7 +2615,7 @@ describe('client', async () => {
 
       const reqheaders = {Authorization: 'Bearer foo'}
       nock('https://abc123.apicdn.sanity.io', {reqheaders})
-        .get('/v1/data/query/foo?query=*')
+        .get('/v1/data/query/foo?query=*&returnQuery=false')
         .reply(200, {result: []})
 
       await expect(client.fetch('*')).resolves.not.toThrow()
@@ -2608,7 +2631,7 @@ describe('client', async () => {
 
       const reqheaders = {foo: 'bar'}
       nock('https://abc123.api.sanity.io', {reqheaders})
-        .get('/v1/data/query/foo?query=*')
+        .get('/v1/data/query/foo?query=*&returnQuery=false')
         .reply(200, {result: []})
 
       await expect(client.fetch('*', {}, {headers: {foo: 'bar'}})).resolves.not.toThrow()
@@ -2623,7 +2646,7 @@ describe('client', async () => {
       })
 
       nock('https://abc123.api.sanity.io')
-        .get('/v1/data/query/foo?query=*')
+        .get('/v1/data/query/foo?query=*&returnQuery=false')
         .reply(200, {result: []})
 
       await expect(client.fetch('*')).resolves.not.toThrow()
@@ -2632,7 +2655,7 @@ describe('client', async () => {
 
   describe('HTTP REQUESTS', () => {
     test.skipIf(isEdge)('includes token if set', async () => {
-      const qs = '?query=foo.bar'
+      const qs = '?query=foo.bar&returnQuery=false'
       const token = 'abcdefghijklmnopqrstuvwxyz'
       const reqheaders = {Authorization: `Bearer ${token}`}
       nock(projectHost(), {reqheaders}).get(`/v1/data/query/foo${qs}`).reply(200, {result: []})
@@ -2642,7 +2665,7 @@ describe('client', async () => {
     })
 
     test.skipIf(isEdge)('allows overriding token', async () => {
-      const qs = '?query=foo.bar'
+      const qs = '?query=foo.bar&returnQuery=false'
       const token = 'abcdefghijklmnopqrstuvwxyz'
       const override = '123456789'
       const reqheaders = {Authorization: `Bearer ${override}`}
@@ -2653,7 +2676,7 @@ describe('client', async () => {
     })
 
     test.skipIf(isEdge)('allows overriding timeout', async () => {
-      const qs = `?query=${encodeURIComponent('*[][0]')}`
+      const qs = `?query=${encodeURIComponent('*[][0]')}&returnQuery=false`
       nock(projectHost()).get(`/v1/data/query/foo${qs}`).reply(200, {result: []})
 
       const docs = await getClient().fetch('*[][0]', {}, {timeout: 60 * 1000})

--- a/test/stega/client.test.ts
+++ b/test/stega/client.test.ts
@@ -131,8 +131,10 @@ describe('@sanity/client/stega', async () => {
 
     test.skipIf(isEdge)('it returns stega strings in the response', async () => {
       nock(projectHost())
-        .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
-        .reply(200, {ms: 123, query, result, resultSourceMap})
+        .get(
+          `/v1/data/query/foo?query=${qs}&returnQuery=false&resultSourceMap=withKeyArraySelector`,
+        )
+        .reply(200, {ms: 123, result, resultSourceMap})
 
       const res = await getClient({stega: {enabled: true, studioUrl: '/studio'}}).fetch(
         query,
@@ -164,8 +166,10 @@ describe('@sanity/client/stega', async () => {
 
     test.skipIf(isEdge)('it strips stega strings from params', async () => {
       nock(projectHost())
-        .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
-        .reply(200, {ms: 123, query, result, resultSourceMap})
+        .get(
+          `/v1/data/query/foo?query=${qs}&returnQuery=false&resultSourceMap=withKeyArraySelector`,
+        )
+        .reply(200, {ms: 123, result, resultSourceMap})
 
       const res = await getClient({stega: {enabled: true, studioUrl: '/studio'}}).fetch(query, {
         id: vercelStegaCombine(params.id, JSON.stringify({origin: 'sanity.io', href: '/studio'})),
@@ -177,8 +181,10 @@ describe('@sanity/client/stega', async () => {
   describe.skipIf(isEdge)('client.fetch', async () => {
     test('the stega option accepts booleans as a shortcut to toggle `enabled`', async () => {
       nock(projectHost())
-        .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
-        .reply(200, {ms: 123, query, result, resultSourceMap})
+        .get(
+          `/v1/data/query/foo?query=${qs}&returnQuery=false&resultSourceMap=withKeyArraySelector`,
+        )
+        .reply(200, {ms: 123, result, resultSourceMap})
 
       const res = await getClient({stega: {studioUrl}}).fetch(query, params, {
         stega: true,
@@ -199,8 +205,8 @@ describe('@sanity/client/stega', async () => {
 
     test('the stega option accepts booleans as a shortcut to toggle `enabled`', async () => {
       nock(projectHost())
-        .get(`/v1/data/query/foo?query=${qs}`)
-        .reply(200, {ms: 123, query, result, resultSourceMap})
+        .get(`/v1/data/query/foo?query=${qs}&returnQuery=false`)
+        .reply(200, {ms: 123, result, resultSourceMap})
 
       const res = await getClient({stega: {studioUrl, enabled: true}}).fetch(query, params, {
         stega: false,
@@ -210,8 +216,10 @@ describe('@sanity/client/stega', async () => {
 
     test('the stega option merges in defaults', async () => {
       nock(projectHost())
-        .get(`/v1/data/query/foo?query=${qs}&resultSourceMap=withKeyArraySelector`)
-        .reply(200, {ms: 123, query, result, resultSourceMap})
+        .get(
+          `/v1/data/query/foo?query=${qs}&returnQuery=false&resultSourceMap=withKeyArraySelector`,
+        )
+        .reply(200, {ms: 123, result, resultSourceMap})
 
       const res = await getClient({stega: {studioUrl, enabled: true}}).fetch(query, params, {
         stega: {


### PR DESCRIPTION
The `/query` endpoint supports a `returnQuery` option which can be set to `false`. Given that 99% of queries from the client do not use the `filterResponse: false` option, returning this query is unnecessary since it cannot be accessed. Even in the cases where we _do_ use `filterResponse: false` (such as when accessing content source maps), I would argue that it is rare that you actually _need_ the query for anything.

This PR introduces the ability to set the option on a per-query basis, and enables it by default for all queries that do not use the `filterResponse: false` option (for backwards compatibility).

In the next major, I suggest we also disable the query from being returned when using `filterResponse: false`, unless you explicitly also declare `returnQuery: true`.

While this change is fairly trivial, a lot of mocks had to be updated to include the query parameter, so the change appears bigger than it is.

There is a theoretical "breaking" change here _if_ users are relying on mocking specific URLs, but I am not sure it can really thought of as "breaking" per se. Open to opinions here.

Another note: I intentionally did not make it possible to specify `returnQuery: true` if `filterResponse` is not `false`, since there is no way of actually getting at the returned query.