### PR TITLE
fix: passing array of document ids to patch()/delete()

### DIFF
--- a/src/util/getSelection.ts
+++ b/src/util/getSelection.ts
@@ -1,8 +1,12 @@
 import type {MutationSelection} from '../types'
 
 export function getSelection(sel: unknown): MutationSelection {
-  if (typeof sel === 'string' || Array.isArray(sel)) {
+  if (typeof sel === 'string') {
     return {id: sel}
+  }
+
+  if (Array.isArray(sel)) {
+    return {query: '*[_id in $ids]', params: {ids: sel}}
   }
 
   if (typeof sel === 'object' && sel !== null && 'query' in sel && typeof sel.query === 'string') {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1561,7 +1561,11 @@ describe('client', async () => {
 
     test('patch() can take an array of IDs', () => {
       const patch = getClient().patch(['abc123', 'foo.456']).inc({count: 1}).serialize()
-      expect(patch).toEqual({id: ['abc123', 'foo.456'], inc: {count: 1}})
+      expect(patch).toEqual({
+        query: '*[_id in $ids]',
+        params: {ids: ['abc123', 'foo.456']},
+        inc: {count: 1},
+      })
     })
 
     test('patch() can take a query', () => {


### PR DESCRIPTION
Deleting and patching documents by their IDs is not actually supported by the content lake API in the current form - they need to be converted into a query.
