### PR TITLE
feat: optionally encode cross dataset reference specific data

### DIFF
--- a/src/csm/createEditUrl.ts
+++ b/src/csm/createEditUrl.ts
@@ -12,6 +12,8 @@ export function createEditUrl(options: CreateEditUrlOptions): `${StudioBaseUrl}$
     id: _id,
     type,
     path,
+    projectId,
+    dataset,
   } = options
 
   if (!baseUrl) {
@@ -49,6 +51,12 @@ export function createEditUrl(options: CreateEditUrlOptions): `${StudioBaseUrl}$
   }
   if (tool) {
     searchParams.set('tool', tool)
+  }
+  if (projectId) {
+    searchParams.set('projectId', projectId)
+  }
+  if (dataset) {
+    searchParams.set('dataset', dataset)
   }
 
   const segments = [baseUrl === '/' ? '' : baseUrl]

--- a/src/csm/resolveEditInfo.ts
+++ b/src/csm/resolveEditInfo.ts
@@ -34,7 +34,7 @@ export function resolveEditInfo(options: ResolveEditInfoOptions): CreateEditUrlO
       typeof options.studioUrl === 'function' ? options.studioUrl(sourceDoc) : options.studioUrl,
     )
     if (!baseUrl) return undefined
-    const {_id, _type} = sourceDoc
+    const {_id, _type, _projectId, _dataset} = sourceDoc
     return {
       baseUrl,
       workspace,
@@ -42,6 +42,8 @@ export function resolveEditInfo(options: ResolveEditInfoOptions): CreateEditUrlO
       id: _id,
       type: _type,
       path: parseJsonPath(sourcePath + pathSuffix),
+      projectId: _projectId,
+      dataset: _dataset,
     } satisfies CreateEditUrlOptions
   }
 

--- a/src/csm/types.ts
+++ b/src/csm/types.ts
@@ -70,6 +70,8 @@ export interface CreateEditUrlOptions {
   id: string
   type: string
   path: ContentSourceMapParsedPath | string
+  projectId?: string
+  dataset?: string
 }
 
 /** @alpha */

--- a/src/stega/stegaEncodeSourceMap.ts
+++ b/src/stega/stegaEncodeSourceMap.ts
@@ -84,7 +84,7 @@ export function stegaEncodeSourceMap<Result = unknown>(
           : config.studioUrl!,
       )
       if (!baseUrl) return value
-      const {_id: id, _type: type} = sourceDocument
+      const {_id: id, _type: type, _projectId: projectId, _dataset: dataset} = sourceDocument
 
       return vercelStegaCombine(
         value,
@@ -97,6 +97,7 @@ export function stegaEncodeSourceMap<Result = unknown>(
             id,
             type,
             path: sourcePath,
+            ...(!config.omitCrossDatasetReferenceData && {dataset, projectId}),
           }),
         },
         // We use custom logic to determine if we should skip encoding

--- a/src/stega/types.ts
+++ b/src/stega/types.ts
@@ -50,6 +50,10 @@ export interface StegaConfig {
    * Specify a `console.log` compatible logger to see debug logs, which keys are encoded and which are not.
    */
   logger?: Logger
+  /**
+   * Set to `true` to omit cross dataset reference specific data from encoded strings
+   */
+  omitCrossDatasetReferenceData?: boolean
 }
 
 /** @public */

--- a/test/csm/createEditUrl.test.ts
+++ b/test/csm/createEditUrl.test.ts
@@ -8,6 +8,8 @@ const workspace = 'staging'
 const tool = 'content'
 const id = 'drafts.homepage'
 const type = 'page'
+const projectId = 'a1b2c3d4'
+const dataset = 'production'
 
 const cases = [
   {
@@ -27,6 +29,12 @@ const cases = [
     path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
     expected:
       '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content',
+  },
+  {
+    context: {baseUrl: '/', workspace, tool, id, type, projectId, dataset},
+    path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
+    expected:
+      '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content&projectId=a1b2c3d4&dataset=production',
   },
 ]
 


### PR DESCRIPTION
Adds `projectId` and `dataset` to the stega encoded href string via `createEditUrl` if encoding a cross dataset reference. Opt out of this behaviour by setting `omitCrossDatasetReferenceData` to true (is this necessary?).

This is primarily so we can more accurately report documents in use from the visual editing package without the need for augmenting data on the client side.

Also adds a change to return `projectId` and `dataset` from `resolveEditInfo` if present, in case we also want to add these params via `encodeDataAttribute`.