### PR TITLE
feat(csm): add conditional `isDraft` search parameter to edit urls

### DIFF
--- a/src/csm/applySourceDocuments.ts
+++ b/src/csm/applySourceDocuments.ts
@@ -68,7 +68,7 @@ export function applySourceDocuments<Result = unknown>(
         cachedDocument = getCachedDocument(
           sourceDocument._id.startsWith(DRAFTS_PREFIX)
             ? sourceDocument
-            : {...sourceDocument, _id: `${DRAFTS_PREFIX}.${sourceDocument._id}}`},
+            : {...sourceDocument, _id: `${DRAFTS_PREFIX}${sourceDocument._id}}`},
         )
         if (!cachedDocument) {
           cachedDocument = getCachedDocument(

--- a/src/csm/createEditUrl.ts
+++ b/src/csm/createEditUrl.ts
@@ -31,8 +31,6 @@ export function createEditUrl(options: CreateEditUrlOptions): `${StudioBaseUrl}$
 
   const workspace = _workspace === 'default' ? undefined : _workspace
   const tool = _tool === 'default' ? undefined : _tool
-  // eslint-disable-next-line no-warning-comments
-  // @TODO allow passing draft prefixed IDs, to better open the right perspective mode
   const id = getPublishedId(_id)
   const stringifiedPath = Array.isArray(path)
     ? studioPath.toString(jsonPathToStudioPath(path))

--- a/src/csm/createEditUrl.ts
+++ b/src/csm/createEditUrl.ts
@@ -1,4 +1,4 @@
-import {getPublishedId} from './getPublishedId'
+import {DRAFTS_PREFIX, getPublishedId} from './getPublishedId'
 import {jsonPathToStudioPath} from './jsonPath'
 import * as studioPath from './studioPath'
 import type {CreateEditUrlOptions, EditIntentUrl, StudioBaseUrl} from './types'
@@ -57,6 +57,9 @@ export function createEditUrl(options: CreateEditUrlOptions): `${StudioBaseUrl}$
   }
   if (dataset) {
     searchParams.set('dataset', dataset)
+  }
+  if (_id.startsWith(DRAFTS_PREFIX)) {
+    searchParams.set('isDraft', '')
   }
 
   const segments = [baseUrl === '/' ? '' : baseUrl]

--- a/test/csm/createEditUrl.test.ts
+++ b/test/csm/createEditUrl.test.ts
@@ -16,25 +16,25 @@ const cases = [
     context: {baseUrl, workspace, tool, id, type},
     path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]['baz'][?(@._key=='section-2')]"),
     expected:
-      'https://test.sanity.studio/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0].baz[_key=="section-2"];tool=content?baseUrl=https://test.sanity.studio&id=homepage&type=page&path=foo[_key=="section-1"][0].baz[_key=="section-2"]&workspace=staging&tool=content',
+      'https://test.sanity.studio/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0].baz[_key=="section-2"];tool=content?baseUrl=https://test.sanity.studio&id=homepage&type=page&path=foo[_key=="section-1"][0].baz[_key=="section-2"]&workspace=staging&tool=content&isDraft=',
   },
   {
     context: {baseUrl: '/', id, type},
     path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
     expected:
-      '/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0]?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]',
+      '/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0]?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&isDraft=',
   },
   {
     context: {baseUrl: '/', workspace, tool, id, type},
     path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
     expected:
-      '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content',
+      '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content&isDraft=',
   },
   {
     context: {baseUrl: '/', workspace, tool, id, type, projectId, dataset},
     path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
     expected:
-      '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content&projectId=a1b2c3d4&dataset=production',
+      '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content&projectId=a1b2c3d4&dataset=production&isDraft=',
   },
 ]
 

--- a/test/csm/resolveEditUrl.test.ts
+++ b/test/csm/resolveEditUrl.test.ts
@@ -501,19 +501,19 @@ const cases = [
     path: 'products[0].title',
     studioUrl: 'https://test.sanity.studio',
     expected:
-      'https://test.sanity.studio/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=title?baseUrl=https://test.sanity.studio&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=title',
+      'https://test.sanity.studio/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=title?baseUrl=https://test.sanity.studio&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=title&isDraft=',
   },
   {
     path: 'products[0].media.alt',
     studioUrl: '/',
     expected:
-      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=media[_key=="cee5fbb69da2"].alt?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=media[_key=="cee5fbb69da2"].alt',
+      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=media[_key=="cee5fbb69da2"].alt?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=media[_key=="cee5fbb69da2"].alt&isDraft=',
   },
   {
     path: 'products[0].description[0].children[0].text',
     studioUrl: '/',
     expected:
-      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=description[0].children[0].text?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=description[0].children[0].text',
+      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=description[0].children[0].text?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=description[0].children[0].text&isDraft=',
   },
 ]
 


### PR DESCRIPTION
Adds an additional search parameter `isDraft` when constructing edit URLs if the given document is a draft.

Primarily used to more accurately report documents to Presentation tool, as we currently pass the document `id` as its published variant.