### PR TITLE
fix: remove `module` export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
       "edge-light": "./dist/index.browser.js",
       "worker": "./dist/index.browser.js",
       "source": "./src/index.ts",
-      "module": "./dist/index.js",
       "require": "./dist/index.cjs",
       "node": {
         "import": "./dist/index.cjs.js"
@@ -65,7 +64,6 @@
       "edge-light": "./dist/stega.browser.js",
       "worker": "./dist/stega.browser.js",
       "source": "./src/stega/index.ts",
-      "module": "./dist/stega.js",
       "require": "./dist/stega.cjs",
       "node": {
         "import": "./dist/stega.cjs.js"


### PR DESCRIPTION
Fixes #622. The `module` condition were added to solve an issue in Turbopack #606.

I've tested `next` `v14.1.3` and it seems to be working with `@sanity/client` `v6.15.0`, which indicates it's probably solved on the turbopack side of things.
https://github.com/stipsan/turbopack-repro

