### PR TITLE
fix: resolve turbopack regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.15.2",
+  "version": "6.15.3-canary.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.15.2",
+      "version": "6.15.3-canary.2",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.15.2",
+  "version": "6.15.3-canary.2",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",
@@ -39,9 +39,7 @@
       "worker": "./dist/index.browser.js",
       "source": "./src/index.ts",
       "require": "./dist/index.cjs",
-      "node": {
-        "import": "./dist/index.cjs.js"
-      },
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./csm": {
@@ -65,9 +63,6 @@
       "worker": "./dist/stega.browser.js",
       "source": "./src/stega/index.ts",
       "require": "./dist/stega.cjs",
-      "node": {
-        "import": "./dist/stega.cjs.js"
-      },
       "import": "./dist/stega.js",
       "default": "./dist/stega.js"
     },


### PR DESCRIPTION
The fix for Nuxt (#625) broke Next with Turbopack again (#606).

[The last reproduction was a false positive.](https://github.com/stipsan/turbopack-repro/tree/53c8bb00e75d4c2ea37bfbb69f7eb64a6e5e36ac).
[The Turbopack issue happens whenever a client component imports an `@sanity/client` instance.](https://github.com/stipsan/turbopack-repro/commit/fb48059803b8116c8315b137f6c292d2fa751834)

```bash
next dev --turbo
   ▲ Next.js 14.1.3 (turbo)
   - Local:        http://localhost:3000

 ✓ Ready in 886ms
 ○ Compiling / ...
 ✓ Compiled / in 5.1s

 ⨯ app/sanity.ts (3:13) @ <unknown>
 ⨯ TypeError: __TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f$next$2d$sanity$2f$node_modules$2f40$sanity$2f$client$2f$dist$2f$index$2e$cjs$2e$js__$5b$app$2d$ssr$5d$__$28$ecmascript$29$__.createClient is not a function
    at /workspace/.next/server/chunks/app_7485fc._.js:12:220
    at [project]/app/sanity.ts [app-ssr] (ecmascript) (/workspace/.next/server/chunks/app_7485fc._.js:19:3)
    at instantiateModule (/workspace/.next/server/chunks/[turbopack]_runtime.js:488:23)
    at getOrInstantiateModuleFromParent (/workspace/.next/server/chunks/[turbopack]_runtime.js:539:12)
    at esmImport (/workspace/.next/server/chunks/[turbopack]_runtime.js:113:20)
    at /workspace/.next/server/chunks/app_7485fc._.js:29:117
    at [project]/app/page.client.tsx [app-ssr] (ecmascript) (/workspace/.next/server/chunks/app_7485fc._.js:56:3)
    at instantiateModule (/workspace/.next/server/chunks/[turbopack]_runtime.js:488:23)
    at getOrInstantiateModuleFromParent (/workspace/.next/server/chunks/[turbopack]_runtime.js:539:12)
    at commonJsRequire (/workspace/.next/server/chunks/[turbopack]_runtime.js:127:20)
  1 | import { createClient } from "next-sanity";
  2 |
> 3 | export const client = createClient({
    |             ^
  4 |   projectId: "hiomol4a",
  5 |   dataset: "development",
  6 |   apiVersion: "2024-03-07",
```

The fix is to remove the `node.import` re-export wrapper pattern completely. [Testing a canary of this PR solves the repro.](https://github.com/stipsan/turbopack-repro/tree/test-canary-fix).
[It doesn't cause regressions in Node runtimes.](https://github.com/sanity-io/client-runtimes-compatibility/actions/runs/8192314464) Moving forward it seems we need to end the Dual Package Hazard patterns for compatibility with the npm ecosystem of frameworks and runtimes.