### PR TITLE
fix: allow setting middleware on `requester`

### DIFF
--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -24,17 +24,10 @@ export default function defineCreateClientExports<
   ClassConstructor: new (httpRequest: HttpRequest, config: ClientConfigType) => SanityClientType,
 ) {
   // Set the http client to use for requests, and its environment specific middleware
-  const httpRequest = defineHttpRequest(envMiddleware, {})
+  const httpRequest = defineHttpRequest(envMiddleware)
   const requester = httpRequest.defaultRequester
 
-  const createClient = (config: ClientConfigType) =>
-    new ClassConstructor(
-      defineHttpRequest(envMiddleware, {
-        maxRetries: config.maxRetries,
-        retryDelay: config.retryDelay,
-      }),
-      config,
-    )
+  const createClient = (config: ClientConfigType) => new ClassConstructor(httpRequest, config)
 
   return {requester, createClient}
 }


### PR DESCRIPTION
This refactor allows setting global middleware, useful for use cases such as logging, or test mocking:

```ts
import {requester} from '@sanity/client'

requester.use({
  onResponse: (response) => {
    console.log('onResponse', response);
    return response;
  },
});

// Later in the app:
import {createClient} from '@sanity/client'

const client = createClient({
  projectId: '...',
  apiVersion: '2023-06-21',
  dataset: 'production',
  useCdn: false,
});
await client.fetch(`count(*)`) // logs `onResponse response`
```

Can be tested using:
```bash
npm install @sanity/client@6.15.17-canary.1
```