### PR TITLE
fix: allow setting middleware on `requester`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -293,7 +293,6 @@ export interface ErrorProps {
 
 /** @public */
 export type HttpRequest = {
-  defaultRequester: Requester
   (options: RequestOptions, requester: Requester): ReturnType<Requester>
 }
 


### PR DESCRIPTION
Alternative solution for #741. Opening PR to get the tests to run.