### PR TITLE
fix(stega): remove try/catch block from `stegaClean`

### DIFF
--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -25,6 +25,7 @@ jobs:
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6
         with:
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           body: I ran `npx update-browserslist-db@latest` 🧑‍💻
           branch: actions/update-browserslist-database-if-needed
           commit-message: 'chore: update browserslist db'

--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6
         with:
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           body: I ran `bun install` 🧑‍💻
           branch: actions/maintain-bun-lock
           commit-message: 'chore(bun): update bun lockfile'

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -31,6 +31,7 @@ jobs:
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6
         with:
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           body: I ran `npm run test:deno:update_import_map` 🧑‍💻
           branch: actions/maintain-import-map
           commit-message: 'chore(deno): update import_map.json'

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -37,6 +37,7 @@ jobs:
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6
         with:
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           body: I ran `npx prettier --ignore-path .gitignore --cache --write .` 🧑‍💻
           branch: actions/prettier
           commit-message: 'chore(prettier): 🤖 ✨'

--- a/src/stega/stegaClean.ts
+++ b/src/stega/stegaClean.ts
@@ -6,11 +6,7 @@ import {vercelStegaClean} from '@vercel/stega'
  * @public
  */
 export function stegaClean<Result = unknown>(result: Result): Result {
-  try {
-    return vercelStegaClean<Result>(result)
-  } catch {
-    return result
-  }
+  return vercelStegaClean<Result>(result)
 }
 
 /**

--- a/test/stega/stegaClean.test.ts
+++ b/test/stega/stegaClean.test.ts
@@ -31,7 +31,6 @@ test('it handles strings', () => {
 test('it handles values that are not supported by JSON', () => {
   expect(stegaClean(undefined)).toMatchInlineSnapshot(`undefined`)
   expect(stegaClean(null)).toMatchInlineSnapshot(`null`)
-  expect(stegaClean(Symbol('foo'))).toMatchInlineSnapshot(`Symbol(foo)`)
   expect(stegaClean(new Set([1, 2, 3]))).toMatchInlineSnapshot(`{}`)
   expect(
     stegaClean(


### PR DESCRIPTION
`@vercel/stega` v1.0.2 (updated in #784) changed the `vercelStegaClean` function to no longer need us to wrap it in a try/catch block.

The test suite removes the `Symbol()` test, this shouldn't cause any issues as it was only there to begin with out of an abundance of caution. The values our users were seeing, that caused problems, were `null` and `undefined`.

While at it I also updated `create-pull-request` actions to set the author as `github-actions`, for the same reason as explained here: https://github.com/sanity-io/pkg-utils/pull/845