### PR TITLE
fix: race condition in `client.listen` memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.18.0",
+  "version": "6.18.1-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.18.0",
+      "version": "6.18.1-canary.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.18.0",
+  "version": "6.18.1-canary.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -171,6 +171,10 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
         .then((eventSource) => {
           if (eventSource) {
             es = eventSource
+            // Handle race condition where the observer is unsubscribed before the EventSource is set up
+            if (unsubscribed) {
+              unsubscribe()
+            }
           }
         })
         .catch((reason) => {


### PR DESCRIPTION
While implementing `client.live.events()` the code underlying `client.listen` was used and a new race condition were discovered that leads to instances of `new EventSource` that should've been closed, but are instead left open.
In `client.live.events()` the race condition were pretty easy to reproduce, all you need is a React application in StrictMode and a `useEffect` implementation:
```tsx
import {createClient} from '@sanity/client'

const client = createClient({
  projectId: 'pv8y60vp',
  dataset: 'production',
  useCdn: true,
  apiVersion: 'X',
})

export default function Example() {
  useEffect(() => {
    const subscription = client.live.events().subscribe({
      next: (event) => {
        console.log({event})
      },
      error: (err) => console.error(err),
    })
    return () => {
      subscription.unsubscribe()
    }
  }, [])

  return null
}
```
Inspecting the browser devtools networks tab would reveal two instances of an EventSource, where it should've been 1.

Since `client.live.events()` is built upon `client.listen()` I assumed the same reproduction would work there as well, but it doesn't:

```tsx
import {createClient} from '@sanity/client'

const client = createClient({
  projectId: 'pv8y60vp',
  dataset: 'production',
  useCdn: true,
  apiVersion: 'X',
})

export default function Example() {
  useEffect(() => {
    const query = '*[_type == "$type"]'
    const params = {type: 'post'}
    const subscription = client.listen({query, params}).subscribe({
      next: (event) => {
        console.log({event})
      },
      error: (err) => console.error(err),
    })
    return () => {
      subscription.unsubscribe()
    }
  }, [])

  return null
}
```

It turns out the reason it was so easily, and consistently, reproduced in `client.live.events()`, but not for `client.listen()`, turned out to be that `client.listen` always lazy imports `@sanity/eventsource`, while `client.live.events()` only does so if there's no native `globalThis.EventSource` available. Since dynamic ESM imports are resolved at the same time, no matter what call site or call order, it's possible to consistently reproduce the race condition by waiting with calling `.unsubscribe()` until after the dynamic import is resolved:
```diff
     return () => {
-      subscription.unsubscribe()
+      import('@sanity/eventsource').then(() => subscription.unsubscribe())
     }
```

I tried to capture this in a unit test but it was too flaky and I eventually gave up.
Instead [I have a Codesandbox instance that demonstrates it](https://codesandbox.io/p/devbox/client-listen-leak-reproduction-6n92l4?file=%2Fapp%2Fpage.tsx%3A10%2C28&workspaceId=a62c30b1-dee0-4fe7-b019-3c78f066e62d&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clw50yk2t00063b6jjm6v7z1a%2522%252C%2522sizes%2522%253A%255B73.62844702467343%252C26.371552975326566%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clw50yk2t00023b6jlb46k9lf%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clw50yk2t00043b6jk7na1rfb%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clw50yk2t00053b6jcxb9035y%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clw50yk2t00023b6jlb46k9lf%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clw50yk2t00013b6j2uiiljjp%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clw51au9o00023b6p422tty5j%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A10%252C%2522startColumn%2522%253A28%252C%2522endLineNumber%2522%253A10%252C%2522endColumn%2522%253A28%257D%255D%252C%2522filepath%2522%253A%2522%252Fapp%252Fpage.tsx%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clw50yk2t00023b6jlb46k9lf%2522%252C%2522activeTabId%2522%253A%2522clw51au9o00023b6p422tty5j%2522%257D%252C%2522clw50yk2t00053b6jcxb9035y%2522%253A%257B%2522id%2522%253A%2522clw50yk2t00053b6jcxb9035y%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A3000%252C%2522id%2522%253A%2522clw50zx9k001f3b6j67nh35xo%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clw50zx9k001f3b6j67nh35xo%2522%257D%252C%2522clw50yk2t00043b6jk7na1rfb%2522%253A%257B%2522id%2522%253A%2522clw50yk2t00043b6jk7na1rfb%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clw517nv501yf3b6jigyctwo4%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clw517nyt002tdjglbn9gcz5t%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clw517nv501yf3b6jigyctwo4%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A26.839080459770116%257D):
![image](https://github.com/sanity-io/client/assets/81981/717f524e-5f16-4613-a9b6-9a5eaead2673)

[And here's the same sandbox but demonstrating that the fix works.](https://codesandbox.io/p/devbox/client-listen-leak-reproduction-forked-lxpnsh?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clw50yk2t00063b6jjm6v7z1a%2522%252C%2522sizes%2522%253A%255B73.62844702467343%252C26.371552975326566%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clw50yk2t00023b6jlb46k9lf%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clw50yk2t00043b6jk7na1rfb%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clw50yk2t00053b6jcxb9035y%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clw50yk2t00023b6jlb46k9lf%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clw50yk2t00013b6j2uiiljjp%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clw51au9o00023b6p422tty5j%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A10%252C%2522startColumn%2522%253A28%252C%2522endLineNumber%2522%253A10%252C%2522endColumn%2522%253A28%257D%255D%252C%2522filepath%2522%253A%2522%252Fapp%252Fpage.tsx%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clw50yk2t00023b6jlb46k9lf%2522%252C%2522activeTabId%2522%253A%2522clw51au9o00023b6p422tty5j%2522%257D%252C%2522clw50yk2t00053b6jcxb9035y%2522%253A%257B%2522id%2522%253A%2522clw50yk2t00053b6jcxb9035y%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A3000%252C%2522id%2522%253A%2522clw50zx9k001f3b6j67nh35xo%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clw50zx9k001f3b6j67nh35xo%2522%257D%252C%2522clw50yk2t00043b6jk7na1rfb%2522%253A%257B%2522id%2522%253A%2522clw50yk2t00043b6jk7na1rfb%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clw517nv501yf3b6jigyctwo4%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clw517nyt002tdjglbn9gcz5t%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clw517nv501yf3b6jigyctwo4%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A26.839080459770116%257D)