### PR TITLE
fix(types): adjust action types to reflect Actions API

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -557,11 +557,6 @@ export type ReplaceDraftAction = {
   actionType: 'sanity.action.document.replaceDraft'
 
   /**
-   * Draft document ID to replace, if it exists.
-   */
-  draftId: string
-
-  /**
    * Published document ID to create draft from, if draft does not exist
    */
   publishedId: string
@@ -621,7 +616,7 @@ export type DeleteAction = {
   /**
    * Delete document history
    */
-  purge: boolean
+  purge?: boolean
 }
 
 /**
@@ -641,7 +636,7 @@ export type DiscardAction = {
   /**
    * Delete document history
    */
-  purge: boolean
+  purge?: boolean
 }
 
 /**
@@ -664,7 +659,7 @@ export type PublishAction = {
   /**
    * Draft revision ID to match
    */
-  ifDraftRevisionId: string
+  ifDraftRevisionId?: string
 
   /**
    * Published document ID to replace
@@ -674,7 +669,7 @@ export type PublishAction = {
   /**
    * Published revision ID to match
    */
-  ifPublishedRevisionId: string
+  ifPublishedRevisionId?: string
 }
 
 /**

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1500,7 +1500,6 @@ describe('client', async () => {
 
       const action2: ReplaceDraftAction = {
         actionType: 'sanity.action.document.replaceDraft',
-        draftId: 'drafts.post2',
         publishedId: 'post2',
         attributes: {_id: 'post2', _type: 'post'},
       }


### PR DESCRIPTION
This branch adjusts the action types to align them with the Actions API.

- In `sanity.action.document.delete`, `purge` should be optional.
- In `sanity.action.document.discard`, `purge` should be optional.
- In `sanity.action.document.publish`, `ifDraftRevisionId` should be optional.
- In `sanity.action.document.publish`, `ifPublishedRevisionId` should be optional.
- In `sanity.action.document.replaceDraft`, `draftId` should not exist.