### PR TITLE
fix: add warning about setting both useCdn and withCredentials to true

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -130,6 +130,11 @@ export const initConfig = (
 
   newConfig.apiVersion = `${newConfig.apiVersion}`.replace(/^v/, '')
   newConfig.isDefaultApi = newConfig.apiHost === defaultConfig.apiHost
+
+  if (newConfig.useCdn === true && newConfig.withCredentials) {
+    warnings.printCdnAndWithCredentialsWarning();
+  }
+
   // If `useCdn` is undefined, we treat it as `true`
   newConfig.useCdn = newConfig.useCdn !== false && !newConfig.withCredentials
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,7 +132,7 @@ export const initConfig = (
   newConfig.isDefaultApi = newConfig.apiHost === defaultConfig.apiHost
 
   if (newConfig.useCdn === true && newConfig.withCredentials) {
-    warnings.printCdnAndWithCredentialsWarning();
+    warnings.printCdnAndWithCredentialsWarning()
   }
 
   // If `useCdn` is undefined, we treat it as `true`

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -8,7 +8,7 @@ const createWarningPrinter = (message: string[]) =>
 
 export const printCdnAndWithCredentialsWarning = createWarningPrinter([
   `Because you set \`withCredentials\` to true, we will override your \`useCdn\``,
-  `setting to be false since (cookie-based) credentials are never set on the CDN`
+  `setting to be false since (cookie-based) credentials are never set on the CDN`,
 ])
 
 export const printCdnWarning = createWarningPrinter([

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -6,6 +6,11 @@ const createWarningPrinter = (message: string[]) =>
   // eslint-disable-next-line no-console
   once((...args: Any[]) => console.warn(message.join(' '), ...args))
 
+export const printCdnAndWithCredentialsWarning = createWarningPrinter([
+  `Since you have set \`withCredentials\` to true, we will default`,
+  `\`useCdn\` to false.`,
+])
+
 export const printCdnWarning = createWarningPrinter([
   `Since you haven't set a value for \`useCdn\`, we will deliver content using our`,
   `global, edge-cached API-CDN. If you wish to have content delivered faster, set`,

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -7,8 +7,8 @@ const createWarningPrinter = (message: string[]) =>
   once((...args: Any[]) => console.warn(message.join(' '), ...args))
 
 export const printCdnAndWithCredentialsWarning = createWarningPrinter([
-  `Since you have set \`withCredentials\` to true, we will default`,
-  `\`useCdn\` to false.`,
+  `Because you set \`withCredentials\` to true, we will override your \`useCdn\``,
+   `setting to be false since (cookie-based) credentials are never set on the CDN`
 ])
 
 export const printCdnWarning = createWarningPrinter([

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -8,7 +8,7 @@ const createWarningPrinter = (message: string[]) =>
 
 export const printCdnAndWithCredentialsWarning = createWarningPrinter([
   `Because you set \`withCredentials\` to true, we will override your \`useCdn\``,
-   `setting to be false since (cookie-based) credentials are never set on the CDN`
+  `setting to be false since (cookie-based) credentials are never set on the CDN`
 ])
 
 export const printCdnWarning = createWarningPrinter([


### PR DESCRIPTION
This is a proposed fix to address the minimum solution suggested for https://github.com/sanity-io/client/issues/833

