### PR TITLE
fix: support `signal` on `getDocument(s)` to cancel requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.21.2",
+  "version": "6.21.3-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.21.2",
+      "version": "6.21.3-canary.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.21.2",
+  "version": "6.21.3-canary.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -900,7 +900,7 @@ export class SanityClient {
    */
   getDocument<R extends Record<string, Any> = Record<string, Any>>(
     id: string,
-    options?: {tag?: string},
+    options?: {signal?: AbortSignal; tag?: string},
   ): Promise<SanityDocument<R> | undefined> {
     return lastValueFrom(dataMethods._getDocument<R>(this, this.#httpRequest, id, options))
   }
@@ -916,7 +916,7 @@ export class SanityClient {
    */
   getDocuments<R extends Record<string, Any> = Record<string, Any>>(
     ids: string[],
-    options?: {tag?: string},
+    options?: {signal?: AbortSignal; tag?: string},
   ): Promise<(SanityDocument<R> | null)[]> {
     return lastValueFrom(dataMethods._getDocuments<R>(this, this.#httpRequest, ids, options))
   }

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -129,9 +129,14 @@ export function _getDocument<R extends Record<string, Any>>(
   client: ObservableSanityClient | SanityClient,
   httpRequest: HttpRequest,
   id: string,
-  opts: {tag?: string} = {},
+  opts: {signal?: AbortSignal; tag?: string} = {},
 ): Observable<SanityDocument<R> | undefined> {
-  const options = {uri: _getDataUrl(client, 'doc', id), json: true, tag: opts.tag}
+  const options = {
+    uri: _getDataUrl(client, 'doc', id),
+    json: true,
+    tag: opts.tag,
+    signal: opts.signal,
+  }
   return _requestObservable<SanityDocument<R> | undefined>(client, httpRequest, options).pipe(
     filter(isResponse),
     map((event) => event.body.documents && event.body.documents[0]),
@@ -143,9 +148,14 @@ export function _getDocuments<R extends Record<string, Any>>(
   client: ObservableSanityClient | SanityClient,
   httpRequest: HttpRequest,
   ids: string[],
-  opts: {tag?: string} = {},
+  opts: {signal?: AbortSignal; tag?: string} = {},
 ): Observable<(SanityDocument<R> | null)[]> {
-  const options = {uri: _getDataUrl(client, 'doc', ids.join(',')), json: true, tag: opts.tag}
+  const options = {
+    uri: _getDataUrl(client, 'doc', ids.join(',')),
+    json: true,
+    tag: opts.tag,
+    signal: opts.signal,
+  }
   return _requestObservable<(SanityDocument<R> | null)[]>(client, httpRequest, options).pipe(
     filter(isResponse),
     map((event: Any) => {


### PR DESCRIPTION
Allows cancelling `getDocument` and `getDocuments` with an `AbortController` when using the promise API:

```ts
import {createClient} from '@sanity/client'
import {useEffect} from 'react'

const client = createClient({ /* ... */ })

const [document, setDocument] = useState(null)
useEffect(() => {
  const controller = new AbortController()
  client.getDocument('abc123', {signal: controller.signal}).then(setDocument)
  return () => controller.abort()
}, [])
```

The `ObservableSanityClient` doesn't need this, as it automatically cancels inflight requests when the observer no longer has any subscribers.