### PR TITLE
fix: add missing `listenerName` property on welcome event

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -850,6 +850,7 @@ export type ReconnectEvent = {
  */
 export type WelcomeEvent = {
   type: 'welcome'
+  listenerName: string
 }
 
 /** @public */


### PR DESCRIPTION
The `listenerName` property is handy to debug certain listener related issues, but was not part of the typings.
