### PR TITLE
[WIP] feat(client.fetch): add support for bundlePerspective

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.22.2",
+  "version": "6.22.2-bundle-perspective",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,16 @@ export const validateApiPerspective = function validateApiPerspective(perspectiv
   }
 }
 
+export const validateApiBundlePerspective = function validateApiBundlePerspective(
+  perspective?: string,
+  bundlePerspective?: string[],
+) {
+  if (perspective !== 'raw' && bundlePerspective) {
+    throw new TypeError(
+      'Invalid, perspective and bundlePerspective parameters are mutually exclusive',
+    )
+  }
+}
 export const initConfig = (
   config: Partial<ClientConfig>,
   prevConfig: Partial<ClientConfig>,

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -419,7 +419,11 @@ export function _requestObservable<R>(
     const bundlePerspective = options.bundlePerspective || config.bundlePerspective
     if (Array.isArray(bundlePerspective) && bundlePerspective.length > 0) {
       validateApiBundlePerspective(perspective, bundlePerspective)
-      options.query = {perspective: undefined, bundlePerspective, ...options.query}
+      options.query = {
+        perspective: undefined,
+        bundlePerspective: bundlePerspective.join(','),
+        ...options.query,
+      }
     }
 
     if (options.lastLiveEventId) {

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -1,7 +1,7 @@
 import {from, type MonoTypeOperatorFunction, Observable} from 'rxjs'
 import {combineLatestWith, filter, map} from 'rxjs/operators'
 
-import {validateApiPerspective} from '../config'
+import {validateApiBundlePerspective, validateApiPerspective} from '../config'
 import {requestOptions} from '../http/requestOptions'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import {stegaClean} from '../stega/stegaClean'
@@ -312,6 +312,7 @@ export function _dataRequest(
     tag,
     returnQuery,
     perspective: options.perspective,
+    bundlePerspective: options.bundlePerspective,
     resultSourceMap: options.resultSourceMap,
     lastLiveEventId: Array.isArray(lastLiveEventId) ? lastLiveEventId[0] : lastLiveEventId,
     canUseCdn: isQuery,
@@ -413,6 +414,12 @@ export function _requestObservable<R>(
         useCdn = false
         printCdnPreviewDraftsWarning()
       }
+    }
+
+    const bundlePerspective = options.bundlePerspective || config.bundlePerspective
+    if (Array.isArray(bundlePerspective) && bundlePerspective.length > 0) {
+      validateApiBundlePerspective(perspective, bundlePerspective)
+      options.query = {perspective: undefined, bundlePerspective, ...options.query}
     }
 
     if (options.lastLiveEventId) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,8 @@ export interface ClientConfig {
   token?: string
   /** @defaultValue 'raw' */
   perspective?: ClientPerspective
+  /** @defaultValue 'raw' */
+  bundlePerspective?: string[]
   apiHost?: string
   apiVersion?: string
   proxy?: string
@@ -306,6 +308,7 @@ export interface RequestObservableOptions extends Omit<RequestOptions, 'url'> {
   returnQuery?: boolean
   resultSourceMap?: boolean | 'withKeyArraySelector'
   perspective?: ClientPerspective
+  bundlePerspective?: string[]
   lastLiveEventId?: string
 }
 
@@ -470,6 +473,8 @@ export interface QueryParams {
   next?: 'next' extends keyof RequestInit ? never : any
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
   perspective?: never
+  /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
+  bundlePerspective?: never
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
   query?: never
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
@@ -937,6 +942,7 @@ export interface ListenOptions {
 /** @public */
 export interface ResponseQueryOptions extends RequestOptions {
   perspective?: ClientPerspective
+  bundlePerspective?: string[]
   resultSourceMap?: boolean | 'withKeyArraySelector'
   returnQuery?: boolean
   useCdn?: boolean


### PR DESCRIPTION
Adds support for `bundlePerspective` in `client.fetch`

Bundle perspective allows users to define a list of bundle ids which they want to query data from. 
Content Lake will infer how the documents should be returned when using this new perspective.