### PR TITLE
fix(stega): 2x faster encoding of portable text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: echo "::add-matcher::.github/eslint-compact.json"
       - run: npm run lint -- --report-unused-disable-directives -f compact
       - run: npm run coverage
+      - run: npm run benchmark
       - uses: actions/upload-artifact@v4
         name: Cache build output
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.22.4",
+  "version": "6.22.5-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.22.4",
+      "version": "6.22.5-canary.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
@@ -18,6 +18,7 @@
         "@edge-runtime/vm": "^4.0.4",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
+        "@sanity/client-latest": "npm:@sanity/client@latest",
         "@sanity/pkg-utils": "^6.11.11",
         "@types/json-diff": "^1.0.3",
         "@types/node": "^22.9.0",
@@ -3481,6 +3482,21 @@
       "resolved": "https://registry.npmjs.org/@sanity/browserslist-config/-/browserslist-config-1.0.3.tgz",
       "integrity": "sha512-UkJuiTyROgPcxbvpHYyXwr+T88Np4eLzu3h05gMgeZ2hv3EM7g/4VMyng5HuA1JdPQPEdq8bmmfQDR+u4KC+TA==",
       "dev": true
+    },
+    "node_modules/@sanity/client-latest": {
+      "name": "@sanity/client",
+      "version": "6.22.4",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.22.4.tgz",
+      "integrity": "sha512-l807VLFs/CVrbWoqQ6C9SNqpvSvNkNnJ5RgxUSfCB2t8elkJ7fr3ahi1bbGrIMrfr/uL044WfWIQ4E3DoqpiuQ==",
+      "dev": true,
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.6.5",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
     },
     "node_modules/@sanity/eventsource": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.22.4",
+  "version": "6.22.5-canary.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",
@@ -89,6 +89,7 @@
     "umd"
   ],
   "scripts": {
+    "benchmark": "npm test -- bench",
     "prebuild": "npm run clean",
     "build": "pkg build --strict && pkg --strict && npm run rollup && npm run minify",
     "clean": "npx rimraf dist coverage umd/*.js",
@@ -126,6 +127,7 @@
     "@edge-runtime/vm": "^4.0.4",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
+    "@sanity/client-latest": "npm:@sanity/client@latest",
     "@sanity/pkg-utils": "^6.11.11",
     "@types/json-diff": "^1.0.3",
     "@types/node": "^22.9.0",

--- a/src/csm/walkMap.ts
+++ b/src/csm/walkMap.ts
@@ -25,6 +25,17 @@ export function walkMap(
   }
 
   if (isRecord(value)) {
+    // Handle Portable Text in a faster way
+    if (value._type === 'block' || value._type === 'span') {
+      const result = {...value}
+      if (value._type === 'block') {
+        result.children = walkMap(value.children, mappingFn, path.concat('children'))
+      } else if (value._type === 'span') {
+        result.text = walkMap(value.text, mappingFn, path.concat('text'))
+      }
+      return result
+    }
+
     return Object.fromEntries(
       Object.entries(value).map(([k, v]) => [k, walkMap(v, mappingFn, path.concat(k))]),
     )

--- a/src/stega/filterDefault.ts
+++ b/src/stega/filterDefault.ts
@@ -17,30 +17,6 @@ export const filterDefault: FilterDefault = ({sourcePath, resultPath, value}) =>
     return false
   }
 
-  /**
-   * Best effort infer Portable Text paths that should not be encoded.
-   * Nothing is for certain, and the below implementation may cause paths that aren't Portable Text and otherwise be safe to encode to be skipped.
-   * However, that's ok as userland can always opt-in with the `encodeSourceMapAtPath` option and mark known safe paths as such, which will override this heuristic.
-   */
-  // If the path ends in marks[number] it's likely a PortableTextSpan: https://github.com/portabletext/types/blob/e54eb24f136d8efd51a46c6a190e7c46e79b5380/src/portableText.ts#LL154C16-L154C16
-  if (typeof endPath === 'number' && sourcePath.at(-2) === 'marks') {
-    return false
-  }
-  // Or if it's [number].markDefs[number].href it's likely a PortableTextLink: https://github.com/portabletext/types/blob/e54eb24f136d8efd51a46c6a190e7c46e79b5380/src/portableText.ts#L163
-  if (
-    endPath === 'href' &&
-    typeof sourcePath.at(-2) === 'number' &&
-    sourcePath.at(-3) === 'markDefs'
-  ) {
-    return false
-  }
-  // Otherwise we have to deal with special properties of PortableTextBlock, and we can't confidently know if it's actually a `_type: 'block'` array item or not.
-  // All we know is that if it is indeed a block, and we encode the strings on these keys it'll for sure break the PortableText rendering and thus we skip encoding.
-  // https://github.com/portabletext/types/blob/e54eb24f136d8efd51a46c6a190e7c46e79b5380/src/portableText.ts#L48-L58
-  if (endPath === 'style' || endPath === 'listItem') {
-    return false
-  }
-
   // Don't encode into anything that is suggested it'll render for SEO in meta tags
   if (
     sourcePath.some(

--- a/test/stega/__snapshots__/stegaEncodeSourceMap.test.ts.snap
+++ b/test/stega/__snapshots__/stegaEncodeSourceMap.test.ts.snap
@@ -73,7 +73,7 @@ exports[`resolveEditUrl '/' > logger.log 1`] = `
     "[@sanity/client]: Encoding source map into result",
   ],
   [
-    "[@sanity/client]: Paths encoded: 18, skipped: 81",
+    "[@sanity/client]: Paths encoded: 18, skipped: 36",
   ],
   [
     "[@sanity/client]: Table of encoded paths",
@@ -81,9 +81,6 @@ exports[`resolveEditUrl '/' > logger.log 1`] = `
   [
     "[@sanity/client]: List of skipped paths",
     [
-      "description[]._key",
-      "description[]._type",
-      "description[].style",
       "slug.current",
       "slug._type",
       "media[]._type",
@@ -227,7 +224,7 @@ exports[`resolveEditUrl 'https://test.sanity.studio' > logger.log 1`] = `
     "[@sanity/client]: Encoding source map into result",
   ],
   [
-    "[@sanity/client]: Paths encoded: 18, skipped: 81",
+    "[@sanity/client]: Paths encoded: 18, skipped: 36",
   ],
   [
     "[@sanity/client]: Table of encoded paths",
@@ -235,9 +232,6 @@ exports[`resolveEditUrl 'https://test.sanity.studio' > logger.log 1`] = `
   [
     "[@sanity/client]: List of skipped paths",
     [
-      "description[]._key",
-      "description[]._type",
-      "description[].style",
       "slug.current",
       "slug._type",
       "media[]._type",

--- a/test/stega/stegaEncodeSourceMap.bench.ts
+++ b/test/stega/stegaEncodeSourceMap.bench.ts
@@ -1,0 +1,20 @@
+import {stegaEncodeSourceMap as stegaEncodeSourceMapLatest} from '@sanity/client-latest/stega'
+import {bench, describe} from 'vitest'
+
+import {stegaEncodeSourceMap} from '../../src/stega/stegaEncodeSourceMap'
+import type {InitializedStegaConfig} from '../../src/stega/types'
+import data from './stegaSnapshotHuge.json' with {type: 'json'}
+
+const config = {
+  enabled: true,
+  studioUrl: 'https://test.sanity.studio',
+} satisfies InitializedStegaConfig
+
+describe('stegaEncodeSourceMap can handle Portable Text in a performant way', () => {
+  bench('@sanity/client@latest', () => {
+    stegaEncodeSourceMapLatest(data.result, data.resultSourceMap as any, config)
+  })
+  bench('src', () => {
+    stegaEncodeSourceMap(data.result, data.resultSourceMap as any, config)
+  })
+})

--- a/test/stega/stegaSnapshotHuge.json
+++ b/test/stega/stegaSnapshotHuge.json
@@ -1,0 +1,10252 @@
+{
+  "query": "{\n    \"entries\": *[_type == \"post\"] | order(publishedAt desc)[0..10] {\n    ...,\n    title,\n    excerpt,\n    date,\n    author-\u003e {\n        ...,\n    },\n},\n}",
+  "result": {
+    "entries": [
+      {
+        "author": {
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "alt": "Just a silly robot",
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image"
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person"
+        },
+        "_id": "011eba9a-1777-476b-8529-55a533fb83d3",
+        "slug": {"_type": "slug", "current": "94"},
+        "date": "2024-10-17T21:25:00.000Z",
+        "_rev": "1U42a9jxrELBwJpoIWNx3d",
+        "_type": "post",
+        "title": "Why Next.js Developers Love Sanity",
+        "_updatedAt": "2024-11-15T15:30:23Z",
+        "content": [
+          {
+            "_type": "block",
+            "style": "h2",
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0"
+              }
+            ]
+          },
+          {
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/structured-content-platform",
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true
+              },
+              {
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio"
+              },
+              {
+                "_key": "805a8b2f2238",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0"
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_key": "54f5e904446b3",
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7",
+                "_type": "span",
+                "marks": ["805a8b2f2238"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8"
+              },
+              {
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"],
+                "text": "libraries and tools",
+                "_key": "54f5e904446b9"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "a0ee536bccf5"
+          },
+          {
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ]
+          },
+          {
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export",
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true
+              },
+              {
+                "_key": "496bed921a88",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1"
+              },
+              {
+                "text": "one API request",
+                "_key": "3ce9d583712f2",
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"]
+              },
+              {"text": " or ", "_key": "3ce9d583712f3", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command",
+                "_key": "3ce9d583712f4"
+              },
+              {
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "957c930c6a11",
+            "listItem": "bullet"
+          },
+          {
+            "_key": "84194559957b",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets",
+                "_key": "8171baf14b8d",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true
+              },
+              {
+                "_key": "4480f82451f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "a6b14269fd59"
+              }
+            ],
+            "children": [
+              {
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": ["code"], "text": "name", "_key": "ebb58ede26df2"},
+              {"_key": "ebb58ede26df3", "_type": "span", "marks": [], "text": " and a "},
+              {"marks": ["code"], "text": "type", "_key": "ebb58ede26df4", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5"
+              },
+              {
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_key": "ebb58ede26df8",
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components"
+              },
+              {"_type": "span", "marks": [], "text": " and ", "_key": "ebb58ede26df9"},
+              {
+                "text": "previews",
+                "_key": "ebb58ede26df10",
+                "_type": "span",
+                "marks": ["072aed996572"]
+              },
+              {"_key": "ebb58ede26df11", "_type": "span", "marks": [], "text": " with React, "},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "marks": [],
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13",
+                "_type": "span"
+              },
+              {
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools",
+                "_key": "ebb58ede26df14",
+                "_type": "span"
+              },
+              {
+                "_key": "ebb58ede26df15",
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses."
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241"
+              },
+              {
+                "_type": "span",
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field",
+                "_key": "c82f983069242"
+              },
+              {
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243",
+                "_type": "span"
+              },
+              {
+                "_key": "c82f983069244",
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840",
+            "listItem": "bullet"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_type": "span", "marks": [], "text": ". Sanity.io offer ", "_key": "4e252fbb1cee1"},
+              {
+                "_type": "span",
+                "marks": ["b296479901e6"],
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3"
+              },
+              {
+                "_key": "4e252fbb1cee4",
+                "_type": "span",
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source"
+              },
+              {
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5",
+                "_type": "span"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql",
+                "_key": "96eb022755a1",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations",
+                "_key": "7318f97464f3",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/docs/realtime-updates",
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_key": "f8000bc6c2cc0",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Great APIs."
+              },
+              {
+                "_key": "f8000bc6c2cc1",
+                "_type": "span",
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with "
+              },
+              {
+                "_key": "f8000bc6c2cc2",
+                "_type": "span",
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "marks": ["7318f97464f3"],
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": [], "text": ". The ", "_key": "f8000bc6c2cc5"},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "_key": "f8000bc6c2cc8",
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9"
+              },
+              {
+                "_key": "f8000bc6c2cc10",
+                "_type": "span",
+                "marks": ["b108371134f2"],
+                "text": "History API"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "style": "normal",
+            "_key": "1c02b32c603f",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61"
+              },
+              {
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62"
+              },
+              {
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing",
+                "_key": "71794103a7f7"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing",
+                "_key": "0b6e3394738b0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1"
+              },
+              {
+                "text": "All tiers are pay-as-you-go with modestly priced overages",
+                "_key": "0b6e3394738b2",
+                "_type": "span",
+                "marks": ["71794103a7f7"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "have to", "_key": "0b6e3394738b4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199",
+            "listItem": "bullet"
+          },
+          {
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business",
+                "_key": "1cfae7e0e4bb"
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"],
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "style": "normal",
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be",
+                "openInNewTab": true
+              },
+              {
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b"
+              },
+              {
+                "_key": "193b3762fbae",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1"
+              },
+              {"_type": "span", "marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2"},
+              {
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "9cf7212a8f89"},
+              {
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas",
+                "_key": "40e8def3484d"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "e7b7bb453ddb"},
+              {
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude",
+                "_key": "7e0dfa3067ee"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "3fa730ff6ef0"},
+              {
+                "_type": "span",
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa"
+              },
+              {"_key": "a6efaf5a6352", "_type": "span", "marks": [], "text": ", and lots more."}
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "style": "normal",
+            "_key": "fbc03667027e",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find ",
+                "_key": "348e76282adc1",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content",
+                "_key": "348e76282adc2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3"
+              },
+              {"marks": ["em"], "text": "content-first", "_key": "348e76282adc4", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          }
+        ],
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!",
+        "_createdAt": "2024-11-15T15:30:18Z",
+        "coverImage": {
+          "_type": "image",
+          "alt": "Pitching Sanity to your team",
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          }
+        }
+      },
+      {
+        "_type": "post",
+        "_updatedAt": "2024-11-15T15:04:17Z",
+        "_rev": "7gdSa6uKISxL9MxpDxkHpA",
+        "date": "2024-10-17T21:25:00.000Z",
+        "_createdAt": "2024-11-15T15:04:13Z",
+        "coverImage": {
+          "_type": "image",
+          "alt": "Pitching Sanity to your team",
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          }
+        },
+        "content": [
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "238557b72f01",
+            "markDefs": []
+          },
+          {
+            "children": [
+              {
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "_type": "span",
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7"
+              },
+              {
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "text": "libraries and tools",
+                "_key": "54f5e904446b9",
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "a0ee536bccf5",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/structured-content-platform",
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true
+              },
+              {
+                "_key": "805a8b2f2238",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience"
+              },
+              {
+                "_key": "fefeec7b4d3a",
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins"
+              },
+              {
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ]
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "957c930c6a11",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export",
+                "_key": "e5c0fe55bd0e"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "_key": "3ce9d583712f1",
+                "_type": "span",
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with "
+              },
+              {
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request",
+                "_key": "3ce9d583712f2"
+              },
+              {"text": " or ", "_key": "3ce9d583712f3", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command",
+                "_key": "3ce9d583712f4"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "style": "normal",
+            "_key": "84194559957b",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/docs/custom-input-widgets",
+                "_key": "8171baf14b8d",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "a6b14269fd59",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1"
+              },
+              {"_type": "span", "marks": ["code"], "text": "name", "_key": "ebb58ede26df2"},
+              {"_type": "span", "marks": [], "text": " and a ", "_key": "ebb58ede26df3"},
+              {"_type": "span", "marks": ["code"], "text": "type", "_key": "ebb58ede26df4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5"
+              },
+              {
+                "_type": "span",
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8"
+              },
+              {"_key": "ebb58ede26df9", "_type": "span", "marks": [], "text": " and "},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"_key": "ebb58ede26df11", "_type": "span", "marks": [], "text": " with React, "},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "marks": [],
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13",
+                "_type": "span"
+              },
+              {
+                "_key": "ebb58ede26df14",
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools"
+              },
+              {
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241"
+              },
+              {
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field",
+                "_key": "c82f983069242",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_type": "span", "marks": [], "text": ". Sanity.io offer ", "_key": "4e252fbb1cee1"},
+              {
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2",
+                "_type": "span",
+                "marks": ["b296479901e6"]
+              },
+              {
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4"
+              },
+              {
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5",
+                "_type": "span"
+              }
+            ]
+          },
+          {
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql",
+                "_key": "96eb022755a1",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations",
+                "_key": "7318f97464f3",
+                "openInNewTab": true
+              },
+              {
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/realtime-updates"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0"
+              },
+              {
+                "text": " In addition to GROQ, you can query your content with ",
+                "_key": "f8000bc6c2cc1",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "text": "GraphQL",
+                "_key": "f8000bc6c2cc2",
+                "_type": "span",
+                "marks": ["96eb022755a1"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4"
+              },
+              {"marks": [], "text": ". The ", "_key": "f8000bc6c2cc5", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9"
+              },
+              {
+                "text": "History API",
+                "_key": "f8000bc6c2cc10",
+                "_type": "span",
+                "marks": ["b108371134f2"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "_key": "f8000bc6c2cc12",
+                "_type": "span",
+                "marks": ["699302d30793"],
+                "text": "Webhooks"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2"
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61"
+              },
+              {
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "1c02b32c603f"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing",
+                "_key": "71794103a7f7"
+              }
+            ],
+            "children": [
+              {
+                "_key": "0b6e3394738b0",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing"
+              },
+              {
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages",
+                "_key": "0b6e3394738b2"
+              },
+              {
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": ["em"], "text": "have to", "_key": "0b6e3394738b4"},
+              {
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199"
+          },
+          {
+            "style": "normal",
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business",
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"],
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att",
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew",
+                "_key": "193b3762fbae",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1"
+              },
+              {"text": "OMA", "_key": "12245601a16d2", "_type": "span", "marks": ["2751faf930be"]},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "9cf7212a8f89"},
+              {
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas",
+                "_key": "40e8def3484d"
+              },
+              {"marks": [], "text": ", ", "_key": "e7b7bb453ddb", "_type": "span"},
+              {
+                "_key": "7e0dfa3067ee",
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "3fa730ff6ef0"},
+              {
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa",
+                "_type": "span"
+              },
+              {"text": ", and lots more.", "_key": "a6efaf5a6352", "_type": "span", "marks": []}
+            ]
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "fbc03667027e",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find ",
+                "_key": "348e76282adc1",
+                "_type": "span"
+              },
+              {
+                "text": "structured content",
+                "_key": "348e76282adc2",
+                "_type": "span",
+                "marks": ["em"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "content-first", "_key": "348e76282adc4"},
+              {
+                "_key": "348e76282adc5",
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!"
+              }
+            ],
+            "level": 1
+          }
+        ],
+        "slug": {"current": "48", "_type": "slug"},
+        "author": {
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2"
+        },
+        "_id": "0297d6e3-f1e0-4223-80a4-8623aa67bfc0",
+        "title": "Why Next.js Developers Love Sanity",
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!"
+      },
+      {
+        "_type": "post",
+        "_updatedAt": "2024-11-15T14:50:14Z",
+        "slug": {"current": "pitching-sanity-to-your-teamsss", "_type": "slug"},
+        "title": "Why Next.js Developers Love Sanity",
+        "date": "2024-10-17T21:25:00.000Z",
+        "_createdAt": "2024-11-15T14:50:05Z",
+        "content": [
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0",
+                "_type": "span"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "238557b72f01"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "a0ee536bccf5",
+            "markDefs": [
+              {
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/structured-content-platform"
+              },
+              {
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_key": "805a8b2f2238",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "_type": "span",
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8"
+              },
+              {
+                "_key": "54f5e904446b9",
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"],
+                "text": "libraries and tools"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14"
+              }
+            ]
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5"
+          },
+          {
+            "_key": "957c930c6a11",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/export",
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request",
+                "_key": "3ce9d583712f2"
+              },
+              {"_key": "3ce9d583712f3", "_type": "span", "marks": [], "text": " or "},
+              {
+                "text": "CLI command",
+                "_key": "3ce9d583712f4",
+                "_type": "span",
+                "marks": ["496bed921a88"]
+              },
+              {
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1"
+              },
+              {"marks": ["code"], "text": "name", "_key": "ebb58ede26df2", "_type": "span"},
+              {"_type": "span", "marks": [], "text": " and a ", "_key": "ebb58ede26df3"},
+              {"text": "type", "_key": "ebb58ede26df4", "_type": "span", "marks": ["code"]},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5"
+              },
+              {
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6",
+                "_type": "span"
+              },
+              {"text": ", ", "_key": "ebb58ede26df7", "_type": "span", "marks": []},
+              {
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": [], "text": " and ", "_key": "ebb58ede26df9"},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"_type": "span", "marks": [], "text": " with React, ", "_key": "ebb58ede26df11"},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "marks": [],
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools",
+                "_key": "ebb58ede26df14"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets",
+                "_key": "8171baf14b8d",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "a6b14269fd59"
+              }
+            ]
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241"
+              },
+              {
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field",
+                "_key": "c82f983069242",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840"
+          },
+          {
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_type": "span", "marks": [], "text": ". Sanity.io offer ", "_key": "4e252fbb1cee1"},
+              {
+                "marks": ["b296479901e6"],
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3"
+              },
+              {
+                "_type": "span",
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with ",
+                "_key": "f8000bc6c2cc1"
+              },
+              {
+                "_type": "span",
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL",
+                "_key": "f8000bc6c2cc2"
+              },
+              {
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4"
+              },
+              {"_type": "span", "marks": [], "text": ". The ", "_key": "f8000bc6c2cc5"},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8",
+                "_type": "span",
+                "marks": ["2015bb11a8e1"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9"
+              },
+              {
+                "marks": ["b108371134f2"],
+                "text": "History API",
+                "_key": "f8000bc6c2cc10",
+                "_type": "span"
+              },
+              {
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12"
+              },
+              {
+                "marks": [],
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "96eb022755a1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql"
+              },
+              {
+                "_key": "7318f97464f3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations"
+              },
+              {
+                "href": "https://www.sanity.io/docs/realtime-updates",
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ]
+          },
+          {
+            "style": "normal",
+            "_key": "1c02b32c603f",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "5effc21937f2",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60"
+              },
+              {
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_key": "60f152de9ae62",
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery"
+              },
+              {
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "style": "normal",
+            "_key": "8e80c9eb6199",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing",
+                "_key": "71794103a7f7",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing",
+                "_key": "0b6e3394738b0"
+              },
+              {
+                "_key": "0b6e3394738b1",
+                "_type": "span",
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. "
+              },
+              {
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages",
+                "_key": "0b6e3394738b2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"marks": ["em"], "text": "have to", "_key": "0b6e3394738b4", "_type": "span"},
+              {
+                "_key": "0b6e3394738b5",
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want)."
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "children": [
+              {
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172",
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"]
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business"
+              }
+            ]
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att",
+                "_key": "e4b70a04a7fc"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true
+              },
+              {
+                "_key": "193b3762fbae",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew"
+              }
+            ],
+            "children": [
+              {
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1",
+                "_type": "span",
+                "marks": []
+              },
+              {"_type": "span", "marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"text": ", ", "_key": "9cf7212a8f89", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas",
+                "_key": "40e8def3484d"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "e7b7bb453ddb"},
+              {
+                "text": "Amplitude",
+                "_key": "7e0dfa3067ee",
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"]
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "3fa730ff6ef0"},
+              {
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa",
+                "_type": "span",
+                "marks": ["193b3762fbae"]
+              },
+              {"_type": "span", "marks": [], "text": ", and lots more.", "_key": "a6efaf5a6352"}
+            ]
+          },
+          {
+            "_key": "fbc03667027e",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_key": "348e76282adc1",
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find "
+              },
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content",
+                "_key": "348e76282adc2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3"
+              },
+              {"_key": "348e76282adc4", "_type": "span", "marks": ["em"], "text": "content-first"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          }
+        ],
+        "author": {
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "_type": "image",
+            "alt": "Just a silly robot",
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            }
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z"
+        },
+        "coverImage": {
+          "_type": "image",
+          "alt": "Pitching Sanity to your team",
+          "asset": {
+            "_type": "reference",
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg"
+          }
+        },
+        "_rev": "N06nnxz6bPVwWf6YHjiGyG",
+        "_id": "0627c001-bb4a-4bc7-8d23-b8b263af9c3d",
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!"
+      },
+      {
+        "_type": "post",
+        "excerpt": "Tips on how to convince your clients to choose Sanity over a more traditional CMS",
+        "coverImage": {
+          "_type": "image",
+          "alt": "Why Sanity Wins Over Traditional CMS",
+          "asset": {
+            "_ref": "image-6a11229b5953e13ce02bedcb19fed0474481555e-2560x1440-jpg",
+            "_type": "reference"
+          }
+        },
+        "_updatedAt": "2024-11-15T12:33:38Z",
+        "date": "2024-10-16T15:12:00.000Z",
+        "_rev": "1U42a9jxrELBwJpoIUqBII",
+        "title": "Why Sanity Wins Over Traditional CMS",
+        "_id": "0a78332d-8860-415e-87c6-61f543e9cbf9",
+        "content": [
+          {
+            "_key": "c2346b2c894e",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Most of your clients are likely used to more traditional ways of working with content. Here are some tips on how to convince them to go with structured content.",
+                "_key": "d6b0f9ceeb8e0"
+              }
+            ],
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "_key": "149147e66cf4",
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Let’s say you’re convinced that you want to use Sanity.io for your client’s project because you enjoy the developer experience. That’s not always easy to communicate to clients, and great developer experience isn’t always their primary, or only, concern (and rightly so). Most of your clients are likely used to more traditional ways of working with content for their website and digital services. It’s not always easy to convince them of a different approach, especially if they aren’t familiar with it, or if they have had past bad experiences with similar services.",
+                "_key": "e75c59e11a7e0",
+                "_type": "span"
+              }
+            ],
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Your client’s needs first",
+                "_key": "2027c0fc11a30"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "b0d53edf13f7",
+            "markDefs": []
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Your priority should be to understand what your clients are trying to achieve.",
+                "_key": "cfe75fa691140"
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "68c79215fc8e",
+            "markDefs": []
+          },
+          {
+            "_key": "6f9e0d521a07",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Your goal shouldn’t be to use Sanity.io. It should be solving your client’s challenges in the best and most efficient way. Of course, we would argue that using Sanity will, in most cases, let you do that, but as a means to an end. So before suggesting using Sanity.io for managing content, get a good understanding of what strategic goals your client has for the project. And then think about how using Sanity.io fits into that.",
+                "_key": "3abb73d251810"
+              }
+            ],
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_key": "d2745514970b0",
+                "_type": "span",
+                "marks": [],
+                "text": "When you present your proposal, it’s often useful to set up a demo with some basic content models and your client’s content that makes it more tangible."
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "e88d3227f088"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://sanity.io/create",
+                "_key": "c40d60a420c9",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "You can often use one of the templates on ",
+                "_key": "b83112c7a39a0"
+              },
+              {
+                "_key": "b83112c7a39a1",
+                "_type": "span",
+                "marks": ["c40d60a420c9"],
+                "text": "https://sanity.io/create"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and modify them quickly to make a feature-rich demo.",
+                "_key": "b83112c7a39a2"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "46fc2c267093"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_key": "bf837bff50e10",
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io is different"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "d8916e796b28"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_key": "446d26c2b8f30",
+                "_type": "span",
+                "marks": [],
+                "text": "Be upfront about that Sanity.io comes with a different way of approaching content compared to traditional CMSes."
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "a9abd5457991"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity Studio comes with almost no assumption about how your content is structured, created, validated, and presented. This leaves you with a lot of freedom and flexibility. From what we have seen, the best projects entail some work on structuring content in a way that makes sense for the project’s team and organization. That prescribes a different approach than just filling out whatever templates the CMS has given you - or just thinking about a website as a collection of pages on which to put some text, images, and media.",
+                "_key": "64635eab74240"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "5dc72301fdbf"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "That said, working with structured content is often more fun and fulfilling because you end up with something that is much more intuitive and familiar. It might also be useful to look at conversations within ",
+                "_key": "6972d8c1d8720"
+              },
+              {
+                "text": "Content Strategy",
+                "_key": "6972d8c1d8721",
+                "_type": "span",
+                "marks": ["em"]
+              },
+              {"_type": "span", "marks": [], "text": ", and books like ", "_key": "6972d8c1d8722"},
+              {
+                "_key": "6972d8c1d8723",
+                "_type": "span",
+                "marks": ["em"],
+                "text": "Designing Connected Content"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " (Atherton \u0026 Hane, 2018).",
+                "_key": "6972d8c1d8724"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "29ffbbde8539"
+          },
+          {
+            "children": [
+              {"_key": "107cc080d72d0", "_type": "span", "marks": [], "text": "Look into "},
+              {
+                "_type": "span",
+                "marks": ["415cf6bcb1c0", "em"],
+                "text": "Content-first",
+                "_key": "107cc080d72d1"
+              },
+              {"text": " strategies, ", "_key": "107cc080d72d2", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["b9b885fc7872"],
+                "text": "The Core Model",
+                "_key": "107cc080d72d3"
+              },
+              {"_key": "107cc080d72d4", "_type": "span", "marks": [], "text": ", and "},
+              {
+                "_type": "span",
+                "marks": ["f5db0073710d"],
+                "text": "Designing Connected Content",
+                "_key": "107cc080d72d5"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " for tips and clues for how to think and talk about this way of working.",
+                "_key": "107cc080d72d6"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ee2c690ccfc4",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://uxdesign.cc/why-you-should-design-the-content-first-for-better-experiences-374f4ba1fe3c",
+                "_key": "415cf6bcb1c0",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://alistapart.com/article/the-core-model-designing-inside-out-for-better-results/",
+                "_key": "b9b885fc7872",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.amazon.com/Designing-Connected-Content-Products-Tomorrow/dp/0134763386",
+                "_key": "f5db0073710d",
+                "openInNewTab": true
+              }
+            ]
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Rapid content modeling",
+                "_key": "ff62defdd8d00"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "5376cba166a3"
+          },
+          {
+            "children": [
+              {
+                "marks": [],
+                "text": "Content modeling in code is as fast, if not faster, than web-based drag and drop.",
+                "_key": "3ee06821ffd30",
+                "_type": "span"
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "0ce0b5e4d99a",
+            "markDefs": []
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Understandably, the code based schemas for Sanity Studio might seem complicated for people not familiar with coding, especially compared to drag and drop solutions. Be empathetic of this stance. The reason, however, we still decided to ship Sanity Studio like that, is because we think the developer should have a say in how fields are named and work because apps and services rely on them. We also wanted to empower developers by making it possible to check these schemas into git, to let them use npm modules and programmatically generate them, and to make it really easy to customize and extend studio functionality.",
+                "_key": "26533ec380650"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "792124a36a81",
+            "markDefs": []
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "An effective way to convince your client’s that this is a great way to work is to sit and write a schema with them. Not only do they get a better understanding of how little work it takes to add new fields or to change something, in our experience, but they might also get inspired to learn how to do it for themselves.",
+                "_key": "39a14a792d710"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "d54fd567cb4f"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Have the code and the Studio running locally side by side. Make a change and save, and demonstrate how it’s instantly reflected in the browser.",
+                "_key": "f09ca5543bdd0"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "43d722b05ab6",
+            "listItem": "bullet",
+            "markDefs": []
+          },
+          {
+            "style": "normal",
+            "_key": "fe341841e1a6",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {"marks": [], "text": "Use ", "_key": "bd2d45a42c0d0", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "sanity deploy",
+                "_key": "bd2d45a42c0d1"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and invite your client to show how fast you get changes to production.",
+                "_key": "bd2d45a42c0d2"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "_key": "7c894f20009f",
+            "markDefs": [],
+            "children": [
+              {
+                "text": "The content is your client’s",
+                "_key": "1c27270e1f9a0",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "_type": "block",
+            "style": "h2"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Even though Sanity.io is a SaaS, that doesn’t mean that your client’s content is “locked-in”.",
+                "_key": "bf159e42a8fd0"
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "015522325c7b"
+          },
+          {
+            "style": "normal",
+            "_key": "96ade61bcfe7",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Contrary to other traditional and headless CMSes, Sanity.io doesn’t lock in your content: The point with Sanity is to make it as easy and effortless as to take your content and use it wherever you need it. What you lose if you move away from Sanity is the unique capabilities in the real-time data store, as well as the no-ops experience and the great CDN-networks. Your content, however, is yours, and you can export, at any point, with only one command, all your documents, and assets",
+                "_key": "cbd81447fa050"
+              }
+            ],
+            "_type": "block"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Show your clients how easy it is to export a dataset along with uploaded images and files.",
+                "_key": "5a9a0c8e42340"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "08ed0825d6bd",
+            "listItem": "bullet",
+            "markDefs": []
+          },
+          {
+            "_key": "226b8a677c6f",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Work better with Structured Content",
+                "_key": "aa434323709c0"
+              }
+            ],
+            "_type": "block",
+            "style": "h2"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Working with a structured content approach is more efficient, creates for more possibility, and reduce bloat, and headache.",
+                "_key": "f000b49a09790",
+                "_type": "span"
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "7dbe6cd38aaa"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io lets you work with content and create single sources of truth. For example, if you have a collection of products, you should be able to refer to these products in your marketing copy and be assured that if you changed a product name or some of its properties, this would propagate to wherever this product was referred to. You should never have to copy-paste the same piece of the product’s description to have it appear in different places (and hence make it difficult to keep consistent).",
+                "_key": "d6f86b566bd80"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "9dca2c99db6d"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Structured content often means organizing it by what it ",
+                "_key": "f5f255fb291b0",
+                "_type": "span"
+              },
+              {"_key": "f5f255fb291b1", "_type": "span", "marks": ["em"], "text": "means"},
+              {"_type": "span", "marks": [], "text": " and not ", "_key": "f5f255fb291b2"},
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "how it might be presented",
+                "_key": "f5f255fb291b3"
+              },
+              {
+                "marks": [],
+                "text": ". If your clients are used to managing content by editing it inline on webpages, this might be unfamiliar to them at first, but in our experience, most people get intrigued when they understand the implications, like saving them work and creating new possibilities for how to work and present content.",
+                "_key": "f5f255fb291b4",
+                "_type": "span"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "332e1dd3a93b"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Set up a demo using inline references in the rich text editor, have the Studio open in two browsers, change a referenced document to show how the changes are immediately reflected.\n",
+                "_key": "300d0307c15b0",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8342eb38e970"
+          },
+          {
+            "children": [
+              {"_type": "span", "marks": [], "text": "Less “hidden costs”", "_key": "af0aeabed5e80"}
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "d1727b5d5b20",
+            "markDefs": []
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io takes away a lot of the “hidden costs” that come with traditional CMSes.",
+                "_key": "ca044f805c770"
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "3d2220c3e131"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "text": "Even though you might find that some of the traditional CMSes are free or have cheaper licenses, you should account for the “hidden costs” that come with setting them up, extending them, and keeping them up to date and monitored. There is virtually no setup with Sanity; you’re ready to work on a new project within minutes. There’s no database or backend that you have to install or configure (however, your client can host the Studio on their custom backend if they want to). As long as you keep your authentication credentials safe, you don’t have to worry about your CMS getting hacked or taken down.",
+                "_key": "bf65aa5cc1050",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "efa2f8da713f"
+          },
+          {
+            "style": "normal",
+            "_key": "5ee876dc50ce",
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Where the advantage with Sanity.io and structured content shows, is whenever you need to redesign or re-use your content in another presentation. Contrary to traditional CMSes where you’re often constrained by a tight connection between content and a particular web presentation or limits in the APIs, you can pretty much get going without any refactoring with Sanity.io. If you do need to make some minor changes in your content, you can export and import your dataset and make a new branch of your Studio and work with it separately. When you’re ready to go to production, you can do so by importing and replacing the new documents, without any downtime.",
+                "_key": "ceee9cc977e80",
+                "_type": "span"
+              }
+            ],
+            "_type": "block"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "4eaf8e3dbea8",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://sanity.io/create"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Demonstrate how quickly you’re up and running with a new project using the CLI or ",
+                "_key": "a2d2e65d15310"
+              },
+              {
+                "_type": "span",
+                "marks": ["4eaf8e3dbea8"],
+                "text": "sanity.io/create",
+                "_key": "a2d2e65d15311"
+              },
+              {"_type": "span", "marks": [], "text": ".", "_key": "a2d2e65d15312"}
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "35cafeaa01e3"
+          },
+          {
+            "_key": "1b1e28442e0a",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Bring your own framework",
+                "_key": "f062d2772f960"
+              }
+            ],
+            "_type": "block",
+            "style": "h2"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "With Sanity.io, you give your clients more freedom to choose who they want to work with.",
+                "_key": "5de6360cc9e00"
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "4904235fa31c",
+            "markDefs": []
+          },
+          {
+            "style": "normal",
+            "_key": "8715070ebead",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sometimes, clients can be initially worried about being “locked-in” with you, especially when choosing something that seems unfamiliar. While we hope that you'll have a long and happy collaboration with those you choose to work with, it might be useful to assure them that using Sanity.io doesn't require any particular skill or certification (like a lot of other traditional CMSes do).",
+                "_key": "a94ebe29bed90"
+              }
+            ],
+            "_type": "block"
+          },
+          {
+            "_key": "58898bbce9bd",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "If you’re building services for the web, there’s a high probability that you’re already using HTML, CSS, and JavaScript. With Sanity.io you don’t have to add another programming language to the mix, like PHP or .NET, to build the editor experience or use the data store. JavaScript is one of the most popular programming languages in the world, which in turn means that there is a big pool of talent that can work with Sanity.io.",
+                "_key": "3c779cfd20220"
+              }
+            ],
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Multiple editing environments",
+                "_key": "7f817899fa010",
+                "_type": "span"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "c316ac27262c"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "text": "Sanity.io lets your client have multiple editing environments in the same project.",
+                "_key": "09c89166dba80",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "_type": "block",
+            "style": "blockquote",
+            "_key": "0103aeef7829"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "2f7e0f3669f9",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://reactjs.org/",
+                "_key": "4caba3e07509"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://expressjs.com/",
+                "_key": "058772be3962",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://nodejs.org/",
+                "_key": "43150c633a12",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://httpd.apache.org/",
+                "_key": "dceefadea72d",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.nginx.com/",
+                "_key": "6756dea7e963",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.netlify.com/",
+                "_key": "914e8f4edb86"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://vercel.com/",
+                "_key": "72023b3713ca",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.digitalocean.com/",
+                "_key": "e3ff0cd367d3",
+                "openInNewTab": true
+              },
+              {
+                "_key": "bf4b51e6f2a6",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://azure.microsoft.com/"
+              }
+            ],
+            "children": [
+              {
+                "text": "Sanity Studio is an open-source Single Page Application built with ",
+                "_key": "dc5abaca22830",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["4caba3e07509"],
+                "text": "React",
+                "_key": "dc5abaca22831"
+              },
+              {
+                "_key": "dc5abaca22832",
+                "_type": "span",
+                "marks": [],
+                "text": " and you can deploy as many of them you want, either on your own server (using, for example, "
+              },
+              {
+                "_type": "span",
+                "marks": ["058772be3962"],
+                "text": "Express",
+                "_key": "dc5abaca22833"
+              },
+              {"marks": [], "text": " in ", "_key": "dc5abaca22834", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["43150c633a12"],
+                "text": "Node.js",
+                "_key": "dc5abaca22835"
+              },
+              {"marks": [], "text": ", ", "_key": "dc5abaca22836", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["dceefadea72d"],
+                "text": "Apache",
+                "_key": "dc5abaca22837"
+              },
+              {"_key": "dc5abaca22838", "_type": "span", "marks": [], "text": ", or "},
+              {
+                "_type": "span",
+                "marks": ["6756dea7e963"],
+                "text": "Nginx",
+                "_key": "dc5abaca22839"
+              },
+              {
+                "marks": [],
+                "text": "), or on a hosted services like ",
+                "_key": "dc5abaca228310",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["914e8f4edb86"],
+                "text": "Netlify",
+                "_key": "dc5abaca228311"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "dc5abaca228312"},
+              {
+                "_type": "span",
+                "marks": ["72023b3713ca"],
+                "text": "Vercel",
+                "_key": "dc5abaca228313"
+              },
+              {"text": ", ", "_key": "dc5abaca228314", "_type": "span", "marks": []},
+              {
+                "_key": "dc5abaca228315",
+                "_type": "span",
+                "marks": ["e3ff0cd367d3"],
+                "text": "Digital Ocean"
+              },
+              {"text": ", or ", "_key": "dc5abaca228316", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["bf4b51e6f2a6"],
+                "text": "Azure",
+                "_key": "dc5abaca228317"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "). This means you can create customized editorial experiences for different parts of your organization, and have it all work in real-time, without your client having to worry about document-locking or race conditions (where someone is overwriting someone else’s content without knowing it).",
+                "_key": "dc5abaca228318"
+              }
+            ]
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Transparent pricing with reasonable quotas",
+                "_key": "8e81b1271a5a0"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "16184b07c8ea",
+            "markDefs": []
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "While other headless CMSes might try to push you to change tiers based on the number of content models or locales you may have, Sanity.io lets you add a credit card to pay-as-you-go for any usage over the quotas you may have of bandwidth, API requests, users on the project, or storage. You only have to change tiers based on your need for SLAs, support, or advanced features that are usually required in larger organizations. Furthermore, you are free to change between tiers at any point if your requirements change.",
+                "_key": "be4755edbbf10"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "4e4e125ea211",
+            "markDefs": []
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "With Sanity.io you can say “yes” to more things",
+                "_key": "e06bc8de39e80"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "307988a72d2a",
+            "markDefs": []
+          },
+          {
+            "style": "normal",
+            "_key": "255f3ae94a10",
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Saying \"no\" is essential for most projects to keep the focus on building the right things. However, 'saying “no” to a perfectly reasonable request because the technology doesn’t let you build what you need' is something we work to avoid. There’s no better experience than being able to say “yes” to your client’s request, knowing that you have a stack that is flexible enough to let you build it.",
+                "_key": "5ceadef95e7b0",
+                "_type": "span"
+              }
+            ],
+            "_type": "block"
+          }
+        ],
+        "slug": {
+          "current": "convincing-your-clients-why-sanity-wins-over-traditional-cmsss",
+          "_type": "slug"
+        },
+        "author": {
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          }
+        },
+        "_createdAt": "2024-11-15T12:33:35Z"
+      },
+      {
+        "_id": "0c10a30b-7faf-43bb-aa19-aa917880bc26",
+        "_updatedAt": "2024-11-15T15:04:27Z",
+        "date": "2024-10-17T21:25:00.000Z",
+        "_createdAt": "2024-11-15T15:04:22Z",
+        "_rev": "1U42a9jxrELBwJpoIWGYWW",
+        "coverImage": {
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          },
+          "_type": "image",
+          "alt": "Pitching Sanity to your team"
+        },
+        "_type": "post",
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!",
+        "title": "Why Next.js Developers Love Sanity",
+        "author": {
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ"
+        },
+        "content": [
+          {
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0"
+              }
+            ],
+            "_type": "block",
+            "style": "h2"
+          },
+          {
+            "markDefs": [
+              {
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/structured-content-platform"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience",
+                "_key": "805a8b2f2238"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0"
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "_type": "span",
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7"
+              },
+              {
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8",
+                "_type": "span"
+              },
+              {
+                "text": "libraries and tools",
+                "_key": "54f5e904446b9",
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "a0ee536bccf5"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5"
+          },
+          {
+            "_key": "957c930c6a11",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1",
+                "_type": "span"
+              },
+              {
+                "text": "one API request",
+                "_key": "3ce9d583712f2",
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"]
+              },
+              {"text": " or ", "_key": "3ce9d583712f3", "_type": "span", "marks": []},
+              {
+                "_key": "3ce9d583712f4",
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets",
+                "_key": "8171baf14b8d"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "a6b14269fd59"
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1"
+              },
+              {"text": "name", "_key": "ebb58ede26df2", "_type": "span", "marks": ["code"]},
+              {"text": " and a ", "_key": "ebb58ede26df3", "_type": "span", "marks": []},
+              {"_type": "span", "marks": ["code"], "text": "type", "_key": "ebb58ede26df4"},
+              {
+                "_key": "ebb58ede26df5",
+                "_type": "span",
+                "marks": [],
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom "
+              },
+              {
+                "_key": "ebb58ede26df6",
+                "_type": "span",
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8"
+              },
+              {"marks": [], "text": " and ", "_key": "ebb58ede26df9", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"_type": "span", "marks": [], "text": " with React, ", "_key": "ebb58ede26df11"},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "_key": "ebb58ede26df13",
+                "_type": "span",
+                "marks": [],
+                "text": ", and you can install "
+              },
+              {
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools",
+                "_key": "ebb58ede26df14"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b",
+            "listItem": "bullet"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241"
+              },
+              {
+                "text": "Creating a field",
+                "_key": "c82f983069242",
+                "_type": "span",
+                "marks": ["0a56d6069b1f"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245",
+                "_type": "span"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6"
+              },
+              {
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_key": "4e252fbb1cee1", "_type": "span", "marks": [], "text": ". Sanity.io offer "},
+              {
+                "_type": "span",
+                "marks": ["b296479901e6"],
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3"
+              },
+              {
+                "_type": "span",
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5"
+              }
+            ]
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/graphql",
+                "_key": "96eb022755a1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations",
+                "_key": "7318f97464f3"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/realtime-updates",
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with ",
+                "_key": "f8000bc6c2cc1"
+              },
+              {
+                "_key": "f8000bc6c2cc2",
+                "_type": "span",
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4"
+              },
+              {"_key": "f8000bc6c2cc5", "_type": "span", "marks": [], "text": ". The "},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9"
+              },
+              {
+                "text": "History API",
+                "_key": "f8000bc6c2cc10",
+                "_type": "span",
+                "marks": ["b108371134f2"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "_type": "span",
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12"
+              },
+              {
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13",
+                "_type": "span",
+                "marks": []
+              }
+            ]
+          },
+          {
+            "children": [
+              {
+                "_key": "60f152de9ae60",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61"
+              },
+              {
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "1c02b32c603f",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ]
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "71794103a7f7",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing",
+                "_key": "0b6e3394738b0"
+              },
+              {
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages",
+                "_key": "0b6e3394738b2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"_key": "0b6e3394738b4", "_type": "span", "marks": ["em"], "text": "have to"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5"
+              }
+            ]
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business",
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172",
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"]
+              }
+            ]
+          },
+          {
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att",
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew",
+                "_key": "193b3762fbae",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_key": "12245601a16d0",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015."
+              },
+              {
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1",
+                "_type": "span",
+                "marks": []
+              },
+              {"_type": "span", "marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"marks": [], "text": ", ", "_key": "9cf7212a8f89", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas",
+                "_key": "40e8def3484d"
+              },
+              {"text": ", ", "_key": "e7b7bb453ddb", "_type": "span", "marks": []},
+              {
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude",
+                "_key": "7e0dfa3067ee",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "3fa730ff6ef0"},
+              {
+                "_type": "span",
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa"
+              },
+              {"text": ", and lots more.", "_key": "a6efaf5a6352", "_type": "span", "marks": []}
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "style": "normal",
+            "_key": "fbc03667027e",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_key": "348e76282adc1",
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find "
+              },
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content",
+                "_key": "348e76282adc2"
+              },
+              {
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": ["em"], "text": "content-first", "_key": "348e76282adc4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          }
+        ],
+        "slug": {"current": "50", "_type": "slug"}
+      },
+      {
+        "slug": {"_type": "slug", "current": "65"},
+        "author": {
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ"
+        },
+        "date": "2024-10-17T21:25:00.000Z",
+        "_createdAt": "2024-11-15T15:26:06Z",
+        "coverImage": {
+          "_type": "image",
+          "alt": "Pitching Sanity to your team",
+          "asset": {
+            "_type": "reference",
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg"
+          }
+        },
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!",
+        "_updatedAt": "2024-11-15T15:26:13Z",
+        "content": [
+          {
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0"
+              }
+            ],
+            "_type": "block",
+            "style": "h2"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "a0ee536bccf5",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/structured-content-platform",
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/developer-experience",
+                "_key": "805a8b2f2238",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a"
+              },
+              {
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0"
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2"
+              },
+              {
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3",
+                "_type": "span"
+              },
+              {
+                "_key": "54f5e904446b4",
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a "
+              },
+              {
+                "_type": "span",
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8"
+              },
+              {
+                "text": "libraries and tools",
+                "_key": "54f5e904446b9",
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_key": "54f5e904446b14",
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you."
+              }
+            ]
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "957c930c6a11",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export",
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1"
+              },
+              {
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request",
+                "_key": "3ce9d583712f2"
+              },
+              {"_type": "span", "marks": [], "text": " or ", "_key": "3ce9d583712f3"},
+              {
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command",
+                "_key": "3ce9d583712f4"
+              },
+              {
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5",
+                "_type": "span"
+              }
+            ]
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets",
+                "_key": "8171baf14b8d",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "a6b14269fd59"
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1"
+              },
+              {"_type": "span", "marks": ["code"], "text": "name", "_key": "ebb58ede26df2"},
+              {"text": " and a ", "_key": "ebb58ede26df3", "_type": "span", "marks": []},
+              {"_type": "span", "marks": ["code"], "text": "type", "_key": "ebb58ede26df4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5"
+              },
+              {
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6",
+                "_type": "span",
+                "marks": ["9fff35c62de3"]
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8"
+              },
+              {"_type": "span", "marks": [], "text": " and ", "_key": "ebb58ede26df9"},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"text": " with React, ", "_key": "ebb58ede26df11", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools",
+                "_key": "ebb58ede26df14"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b"
+          },
+          {
+            "children": [
+              {
+                "_key": "c82f983069240",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241"
+              },
+              {
+                "text": "Creating a field",
+                "_key": "c82f983069242",
+                "_type": "span",
+                "marks": ["0a56d6069b1f"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f"
+              }
+            ]
+          },
+          {
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_type": "span", "marks": [], "text": ". Sanity.io offer ", "_key": "4e252fbb1cee1"},
+              {
+                "marks": ["b296479901e6"],
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2",
+                "_type": "span"
+              },
+              {
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4"
+              },
+              {
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "96eb022755a1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql"
+              },
+              {
+                "_key": "7318f97464f3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations"
+              },
+              {
+                "href": "https://www.sanity.io/docs/realtime-updates",
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/asset-pipeline"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2"
+              },
+              {
+                "_key": "699302d30793",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0"
+              },
+              {
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with ",
+                "_key": "f8000bc6c2cc1",
+                "_type": "span"
+              },
+              {
+                "text": "GraphQL",
+                "_key": "f8000bc6c2cc2",
+                "_type": "span",
+                "marks": ["96eb022755a1"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "_key": "f8000bc6c2cc4",
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API"
+              },
+              {"marks": [], "text": ". The ", "_key": "f8000bc6c2cc5", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8",
+                "_type": "span",
+                "marks": ["2015bb11a8e1"]
+              },
+              {
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["b108371134f2"],
+                "text": "History API",
+                "_key": "f8000bc6c2cc10"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13"
+              }
+            ]
+          },
+          {
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60"
+              },
+              {
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_key": "60f152de9ae62",
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery"
+              },
+              {
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "1c02b32c603f",
+            "listItem": "bullet"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "71794103a7f7",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing"
+              }
+            ],
+            "children": [
+              {
+                "_key": "0b6e3394738b0",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1"
+              },
+              {
+                "_key": "0b6e3394738b2",
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"text": "have to", "_key": "0b6e3394738b4", "_type": "span", "marks": ["em"]},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199"
+          },
+          {
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business"
+              }
+            ],
+            "children": [
+              {
+                "_key": "12cf600307170",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Privacy and GDPR."
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"],
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att",
+                "_key": "e4b70a04a7fc"
+              },
+              {
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew",
+                "_key": "193b3762fbae",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1"
+              },
+              {"_type": "span", "marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"marks": [], "text": ", ", "_key": "9cf7212a8f89", "_type": "span"},
+              {
+                "_key": "40e8def3484d",
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas"
+              },
+              {"marks": [], "text": ", ", "_key": "e7b7bb453ddb", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude",
+                "_key": "7e0dfa3067ee"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "3fa730ff6ef0"},
+              {
+                "_type": "span",
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa"
+              },
+              {"_type": "span", "marks": [], "text": ", and lots more.", "_key": "a6efaf5a6352"}
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "9a9acc4dee4d"
+          },
+          {
+            "_key": "fbc03667027e",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find ",
+                "_key": "348e76282adc1"
+              },
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content",
+                "_key": "348e76282adc2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "content-first", "_key": "348e76282adc4"},
+              {
+                "_key": "348e76282adc5",
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          }
+        ],
+        "_id": "0da613bc-e237-45b3-a3e1-8afb8e61e85b",
+        "title": "Why Next.js Developers Love Sanity",
+        "_rev": "7gdSa6uKISxL9MxpDxqhpx",
+        "_type": "post"
+      },
+      {
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!",
+        "_createdAt": "2024-11-15T15:26:54Z",
+        "_type": "post",
+        "slug": {"current": "72", "_type": "slug"},
+        "_id": "0dd7bbc2-eb2f-4432-bbab-c023ad375e76",
+        "title": "Why Next.js Developers Love Sanity",
+        "content": [
+          {
+            "style": "h2",
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0"
+              }
+            ],
+            "_type": "block"
+          },
+          {
+            "style": "normal",
+            "_key": "a0ee536bccf5",
+            "markDefs": [
+              {
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/structured-content-platform"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience",
+                "_key": "805a8b2f2238",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a",
+                "_type": "link"
+              },
+              {
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://slack.sanity.io/"
+              }
+            ],
+            "children": [
+              {
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "text": "structured content",
+                "_key": "54f5e904446b1",
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2"
+              },
+              {
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "_type": "span",
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8"
+              },
+              {
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"],
+                "text": "libraries and tools",
+                "_key": "54f5e904446b9"
+              },
+              {
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14"
+              }
+            ],
+            "_type": "block"
+          },
+          {
+            "style": "h2",
+            "_key": "911f59ed9bd5",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ],
+            "_type": "block"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88"
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0",
+                "_type": "span"
+              },
+              {
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request",
+                "_key": "3ce9d583712f2"
+              },
+              {"_type": "span", "marks": [], "text": " or ", "_key": "3ce9d583712f3"},
+              {
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command",
+                "_key": "3ce9d583712f4"
+              },
+              {
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "957c930c6a11"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets",
+                "_key": "8171baf14b8d"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true
+              },
+              {
+                "_key": "a6b14269fd59",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1"
+              },
+              {"_type": "span", "marks": ["code"], "text": "name", "_key": "ebb58ede26df2"},
+              {"_type": "span", "marks": [], "text": " and a ", "_key": "ebb58ede26df3"},
+              {"_type": "span", "marks": ["code"], "text": "type", "_key": "ebb58ede26df4"},
+              {
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6"
+              },
+              {"text": ", ", "_key": "ebb58ede26df7", "_type": "span", "marks": []},
+              {
+                "_key": "ebb58ede26df8",
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components"
+              },
+              {"_type": "span", "marks": [], "text": " and ", "_key": "ebb58ede26df9"},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"_type": "span", "marks": [], "text": " with React, ", "_key": "ebb58ede26df11"},
+              {
+                "_key": "ebb58ede26df12",
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides"
+              },
+              {
+                "marks": [],
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools",
+                "_key": "ebb58ede26df14"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15"
+              }
+            ]
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241"
+              },
+              {
+                "_type": "span",
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field",
+                "_key": "c82f983069242"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_type": "span", "marks": [], "text": ". Sanity.io offer ", "_key": "4e252fbb1cee1"},
+              {
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2",
+                "_type": "span",
+                "marks": ["b296479901e6"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3"
+              },
+              {
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5"
+              }
+            ]
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "96eb022755a1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations",
+                "_key": "7318f97464f3",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/realtime-updates",
+                "_key": "ef62068d84b3"
+              },
+              {
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/asset-pipeline"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with ",
+                "_key": "f8000bc6c2cc1"
+              },
+              {
+                "_type": "span",
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL",
+                "_key": "f8000bc6c2cc2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4"
+              },
+              {"_type": "span", "marks": [], "text": ". The ", "_key": "f8000bc6c2cc5"},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8"
+              },
+              {
+                "_key": "f8000bc6c2cc9",
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the "
+              },
+              {
+                "_type": "span",
+                "marks": ["b108371134f2"],
+                "text": "History API",
+                "_key": "f8000bc6c2cc10"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12",
+                "_type": "span"
+              },
+              {
+                "marks": [],
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13",
+                "_type": "span"
+              }
+            ]
+          },
+          {
+            "_key": "1c02b32c603f",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60"
+              },
+              {
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/pricing",
+                "_key": "71794103a7f7",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing",
+                "_key": "0b6e3394738b0"
+              },
+              {
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_key": "0b6e3394738b2",
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "have to", "_key": "0b6e3394738b4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "markDefs": [
+              {
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172",
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"]
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "efc861cba2eb",
+            "listItem": "bullet"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be"
+              },
+              {
+                "href": "https://www.sanity.io/customers/att",
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew",
+                "_key": "193b3762fbae"
+              }
+            ],
+            "children": [
+              {
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1"
+              },
+              {"_type": "span", "marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_key": "0fda6f062eba",
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "9cf7212a8f89"},
+              {
+                "_key": "40e8def3484d",
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "e7b7bb453ddb"},
+              {
+                "_key": "7e0dfa3067ee",
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude"
+              },
+              {"text": ", ", "_key": "3fa730ff6ef0", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa"
+              },
+              {"_type": "span", "marks": [], "text": ", and lots more.", "_key": "a6efaf5a6352"}
+            ],
+            "level": 1
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find ",
+                "_key": "348e76282adc1"
+              },
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content",
+                "_key": "348e76282adc2"
+              },
+              {
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3",
+                "_type": "span",
+                "marks": []
+              },
+              {"_type": "span", "marks": ["em"], "text": "content-first", "_key": "348e76282adc4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "fbc03667027e",
+            "listItem": "bullet"
+          }
+        ],
+        "date": "2024-10-17T21:25:00.000Z",
+        "author": {
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          },
+          "firstName": "Sanity"
+        },
+        "_rev": "1U42a9jxrELBwJpoIWNE1M",
+        "coverImage": {
+          "_type": "image",
+          "alt": "Pitching Sanity to your team",
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          }
+        },
+        "_updatedAt": "2024-11-15T15:27:07Z"
+      },
+      {
+        "content": [
+          {
+            "_type": "block",
+            "style": "h2",
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0",
+                "_type": "span",
+                "marks": []
+              }
+            ]
+          },
+          {
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/structured-content-platform",
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience",
+                "_key": "805a8b2f2238",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a"
+              },
+              {
+                "linkType": "href",
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0"
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2"
+              },
+              {
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7",
+                "_type": "span"
+              },
+              {
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8",
+                "_type": "span"
+              },
+              {
+                "_key": "54f5e904446b9",
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"],
+                "text": "libraries and tools"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14"
+              }
+            ],
+            "_type": "block",
+            "style": "normal",
+            "_key": "a0ee536bccf5"
+          },
+          {
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ]
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/export",
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request",
+                "_key": "3ce9d583712f2"
+              },
+              {"_type": "span", "marks": [], "text": " or ", "_key": "3ce9d583712f3"},
+              {
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command",
+                "_key": "3ce9d583712f4"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "957c930c6a11"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true
+              },
+              {
+                "_key": "8171baf14b8d",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_key": "a6b14269fd59",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0"
+              },
+              {
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1",
+                "_type": "span"
+              },
+              {"_key": "ebb58ede26df2", "_type": "span", "marks": ["code"], "text": "name"},
+              {"_type": "span", "marks": [], "text": " and a ", "_key": "ebb58ede26df3"},
+              {"text": "type", "_key": "ebb58ede26df4", "_type": "span", "marks": ["code"]},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5"
+              },
+              {
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8"
+              },
+              {"_type": "span", "marks": [], "text": " and ", "_key": "ebb58ede26df9"},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"_type": "span", "marks": [], "text": " with React, ", "_key": "ebb58ede26df11"},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_key": "ebb58ede26df14",
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools"
+              },
+              {
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15",
+                "_type": "span"
+              }
+            ]
+          },
+          {
+            "_key": "8df79202a840",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field",
+                "_key": "c82f983069242"
+              },
+              {
+                "_key": "c82f983069243",
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing "
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_key": "4e252fbb1cee1", "_type": "span", "marks": [], "text": ". Sanity.io offer "},
+              {
+                "_type": "span",
+                "marks": ["b296479901e6"],
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3"
+              },
+              {
+                "_key": "4e252fbb1cee4",
+                "_type": "span",
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with ",
+                "_key": "f8000bc6c2cc1"
+              },
+              {
+                "_type": "span",
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL",
+                "_key": "f8000bc6c2cc2"
+              },
+              {
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3",
+                "_type": "span"
+              },
+              {
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4",
+                "_type": "span",
+                "marks": ["7318f97464f3"]
+              },
+              {"_key": "f8000bc6c2cc5", "_type": "span", "marks": [], "text": ". The "},
+              {
+                "_key": "f8000bc6c2cc6",
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8"
+              },
+              {
+                "_key": "f8000bc6c2cc9",
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the "
+              },
+              {
+                "text": "History API",
+                "_key": "f8000bc6c2cc10",
+                "_type": "span",
+                "marks": ["b108371134f2"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12",
+                "_type": "span",
+                "marks": ["699302d30793"]
+              },
+              {
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql",
+                "_key": "96eb022755a1"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations",
+                "_key": "7318f97464f3",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/realtime-updates",
+                "_key": "ef62068d84b3",
+                "openInNewTab": true
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_key": "b108371134f2",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793"
+              }
+            ]
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "1c02b32c603f",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61"
+              },
+              {
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62"
+              },
+              {
+                "_key": "60f152de9ae63",
+                "_type": "span",
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences."
+              }
+            ],
+            "level": 1
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "71794103a7f7",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing",
+                "_key": "0b6e3394738b0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1"
+              },
+              {
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages",
+                "_key": "0b6e3394738b2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "have to", "_key": "0b6e3394738b4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199"
+          },
+          {
+            "style": "normal",
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business",
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172",
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"]
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att",
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true
+              },
+              {
+                "_key": "193b3762fbae",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew"
+              }
+            ],
+            "children": [
+              {
+                "_key": "12245601a16d0",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015."
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1"
+              },
+              {"text": "OMA", "_key": "12245601a16d2", "_type": "span", "marks": ["2751faf930be"]},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "9cf7212a8f89"},
+              {
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas",
+                "_key": "40e8def3484d"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "e7b7bb453ddb"},
+              {
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude",
+                "_key": "7e0dfa3067ee"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "3fa730ff6ef0"},
+              {
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa",
+                "_type": "span"
+              },
+              {"text": ", and lots more.", "_key": "a6efaf5a6352", "_type": "span", "marks": []}
+            ],
+            "level": 1
+          },
+          {
+            "_key": "fbc03667027e",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find ",
+                "_key": "348e76282adc1"
+              },
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content",
+                "_key": "348e76282adc2"
+              },
+              {
+                "_key": "348e76282adc3",
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes "
+              },
+              {"marks": ["em"], "text": "content-first", "_key": "348e76282adc4", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          }
+        ],
+        "_updatedAt": "2024-11-15T15:29:12Z",
+        "slug": {"current": "84", "_type": "slug"},
+        "author": {
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z"
+        },
+        "_type": "post",
+        "coverImage": {
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          },
+          "_type": "image",
+          "alt": "Pitching Sanity to your team"
+        },
+        "_rev": "N06nnxz6bPVwWf6YHjt3Ap",
+        "title": "Why Next.js Developers Love Sanity",
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!",
+        "date": "2024-10-17T21:25:00.000Z",
+        "_createdAt": "2024-11-15T15:29:08Z",
+        "_id": "11a1e8e4-46e9-4cfc-8988-206de09c0b99"
+      },
+      {
+        "_type": "post",
+        "date": "2024-10-17T21:25:00.000Z",
+        "_rev": "7gdSa6uKISxL9MxpDxr5zN",
+        "_updatedAt": "2024-11-15T15:29:24Z",
+        "title": "Why Next.js Developers Love Sanity",
+        "content": [
+          {
+            "_type": "block",
+            "style": "h2",
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0",
+                "_type": "span"
+              }
+            ]
+          },
+          {
+            "_key": "a0ee536bccf5",
+            "markDefs": [
+              {
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/structured-content-platform"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience",
+                "_key": "805a8b2f2238",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a",
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0"
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2"
+              },
+              {
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3",
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "_type": "span",
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8"
+              },
+              {
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"],
+                "text": "libraries and tools",
+                "_key": "54f5e904446b9"
+              },
+              {
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14"
+              }
+            ],
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "_key": "911f59ed9bd5",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ],
+            "_type": "block",
+            "style": "h2"
+          },
+          {
+            "_key": "957c930c6a11",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export"
+              },
+              {
+                "_key": "496bed921a88",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1"
+              },
+              {
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request",
+                "_key": "3ce9d583712f2"
+              },
+              {"_type": "span", "marks": [], "text": " or ", "_key": "3ce9d583712f3"},
+              {
+                "text": "CLI command",
+                "_key": "3ce9d583712f4",
+                "_type": "span",
+                "marks": ["496bed921a88"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "children": [
+              {
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1"
+              },
+              {"text": "name", "_key": "ebb58ede26df2", "_type": "span", "marks": ["code"]},
+              {"_type": "span", "marks": [], "text": " and a ", "_key": "ebb58ede26df3"},
+              {"_type": "span", "marks": ["code"], "text": "type", "_key": "ebb58ede26df4"},
+              {
+                "_key": "ebb58ede26df5",
+                "_type": "span",
+                "marks": [],
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom "
+              },
+              {
+                "_type": "span",
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8"
+              },
+              {"_type": "span", "marks": [], "text": " and ", "_key": "ebb58ede26df9"},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"_key": "ebb58ede26df11", "_type": "span", "marks": [], "text": " with React, "},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13"
+              },
+              {
+                "text": "plugins and tools",
+                "_key": "ebb58ede26df14",
+                "_type": "span",
+                "marks": ["a6b14269fd59"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_key": "8171baf14b8d",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets"
+              },
+              {
+                "_key": "072aed996572",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_key": "a6b14269fd59",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins"
+              }
+            ]
+          },
+          {
+            "style": "normal",
+            "_key": "8df79202a840",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field",
+                "_key": "c82f983069242",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757"
+              }
+            ],
+            "children": [
+              {
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0",
+                "_type": "span",
+                "marks": ["strong"]
+              },
+              {"text": ". Sanity.io offer ", "_key": "4e252fbb1cee1", "_type": "span", "marks": []},
+              {
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2",
+                "_type": "span",
+                "marks": ["b296479901e6"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3"
+              },
+              {
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/graphql",
+                "_key": "96eb022755a1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "href": "https://www.sanity.io/docs/http-mutations",
+                "_key": "7318f97464f3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/realtime-updates",
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0",
+                "_type": "span"
+              },
+              {
+                "_key": "f8000bc6c2cc1",
+                "_type": "span",
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with "
+              },
+              {
+                "_key": "f8000bc6c2cc2",
+                "_type": "span",
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "_key": "f8000bc6c2cc4",
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API"
+              },
+              {"text": ". The ", "_key": "f8000bc6c2cc5", "_type": "span", "marks": []},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_key": "f8000bc6c2cc7",
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the "
+              },
+              {
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9"
+              },
+              {
+                "_type": "span",
+                "marks": ["b108371134f2"],
+                "text": "History API",
+                "_key": "f8000bc6c2cc10"
+              },
+              {
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44"
+          },
+          {
+            "_key": "1c02b32c603f",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "5effc21937f2",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn"
+              }
+            ],
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61"
+              },
+              {
+                "_type": "span",
+                "marks": ["5effc21937f2"],
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62"
+              },
+              {
+                "_key": "60f152de9ae63",
+                "_type": "span",
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences."
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing",
+                "_key": "71794103a7f7"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing",
+                "_key": "0b6e3394738b0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1"
+              },
+              {
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages",
+                "_key": "0b6e3394738b2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"text": "have to", "_key": "0b6e3394738b4", "_type": "span", "marks": ["em"]},
+              {
+                "_key": "0b6e3394738b5",
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want)."
+              }
+            ],
+            "level": 1
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business",
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"],
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "efc861cba2eb"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew",
+                "_key": "193b3762fbae",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm ",
+                "_key": "12245601a16d1"
+              },
+              {"marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2", "_type": "span"},
+              {
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba",
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"]
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "9cf7212a8f89"},
+              {
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas",
+                "_key": "40e8def3484d",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "e7b7bb453ddb"},
+              {
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude",
+                "_key": "7e0dfa3067ee",
+                "_type": "span"
+              },
+              {"_key": "3fa730ff6ef0", "_type": "span", "marks": [], "text": ", "},
+              {
+                "_type": "span",
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa"
+              },
+              {"marks": [], "text": ", and lots more.", "_key": "a6efaf5a6352", "_type": "span"}
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "9a9acc4dee4d"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "fbc03667027e",
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find ",
+                "_key": "348e76282adc1"
+              },
+              {
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content",
+                "_key": "348e76282adc2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3"
+              },
+              {"_key": "348e76282adc4", "_type": "span", "marks": ["em"], "text": "content-first"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ]
+          }
+        ],
+        "author": {
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2"
+        },
+        "_createdAt": "2024-11-15T15:29:19Z",
+        "slug": {"current": "86", "_type": "slug"},
+        "coverImage": {
+          "_type": "image",
+          "alt": "Pitching Sanity to your team",
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          }
+        },
+        "_id": "17a9a1df-54e6-4d3d-a588-43a043bf5fe8",
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!"
+      },
+      {
+        "coverImage": {
+          "alt": "Pitching Sanity to your team",
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          },
+          "_type": "image"
+        },
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!",
+        "_createdAt": "2024-11-15T14:50:16Z",
+        "_type": "post",
+        "content": [
+          {
+            "_type": "block",
+            "style": "h2",
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0"
+              }
+            ]
+          },
+          {
+            "_key": "a0ee536bccf5",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/structured-content-platform",
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "href": "https://www.sanity.io/developer-experience",
+                "_key": "805a8b2f2238",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06"
+              }
+            ],
+            "children": [
+              {
+                "marks": [],
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0",
+                "_type": "span"
+              },
+              {
+                "text": "structured content",
+                "_key": "54f5e904446b1",
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"]
+              },
+              {
+                "_key": "54f5e904446b2",
+                "_type": "span",
+                "marks": [],
+                "text": ". It comes with an "
+              },
+              {
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a ",
+                "_key": "54f5e904446b4"
+              },
+              {
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7",
+                "_type": "span",
+                "marks": ["805a8b2f2238"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8"
+              },
+              {
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"],
+                "text": "libraries and tools",
+                "_key": "54f5e904446b9"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you.",
+                "_key": "54f5e904446b14"
+              }
+            ],
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "children": [
+              {
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5",
+            "markDefs": []
+          },
+          {
+            "_key": "957c930c6a11",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export",
+                "_key": "e5c0fe55bd0e",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1"
+              },
+              {
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request",
+                "_key": "3ce9d583712f2",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": [], "text": " or ", "_key": "3ce9d583712f3"},
+              {
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command",
+                "_key": "3ce9d583712f4"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets",
+                "_key": "8171baf14b8d",
+                "openInNewTab": true
+              },
+              {
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "a6b14269fd59"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A customizable editor environment",
+                "_key": "ebb58ede26df0"
+              },
+              {
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1",
+                "_type": "span"
+              },
+              {"_type": "span", "marks": ["code"], "text": "name", "_key": "ebb58ede26df2"},
+              {"_type": "span", "marks": [], "text": " and a ", "_key": "ebb58ede26df3"},
+              {"_key": "ebb58ede26df4", "_type": "span", "marks": ["code"], "text": "type"},
+              {
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_key": "ebb58ede26df6",
+                "_type": "span",
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8"
+              },
+              {"_key": "ebb58ede26df9", "_type": "span", "marks": [], "text": " and "},
+              {
+                "text": "previews",
+                "_key": "ebb58ede26df10",
+                "_type": "span",
+                "marks": ["072aed996572"]
+              },
+              {"_type": "span", "marks": [], "text": " with React, ", "_key": "ebb58ede26df11"},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_key": "ebb58ede26df14",
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b"
+          },
+          {
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "_key": "c82f983069241",
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. "
+              },
+              {
+                "_type": "span",
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field",
+                "_key": "c82f983069242"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245",
+                "_type": "span",
+                "marks": []
+              }
+            ]
+          },
+          {
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0",
+                "_type": "span"
+              },
+              {"marks": [], "text": ". Sanity.io offer ", "_key": "4e252fbb1cee1", "_type": "span"},
+              {
+                "_type": "span",
+                "marks": ["b296479901e6"],
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2"
+              },
+              {
+                "_key": "4e252fbb1cee3",
+                "_type": "span",
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. "
+              },
+              {
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4",
+                "_type": "span"
+              },
+              {
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents",
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ]
+          },
+          {
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql",
+                "_key": "96eb022755a1",
+                "openInNewTab": true
+              },
+              {
+                "_key": "7318f97464f3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations"
+              },
+              {
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/realtime-updates"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2",
+                "openInNewTab": true
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0"
+              },
+              {
+                "text": " In addition to GROQ, you can query your content with ",
+                "_key": "f8000bc6c2cc1",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL",
+                "_key": "f8000bc6c2cc2",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4"
+              },
+              {"_type": "span", "marks": [], "text": ". The ", "_key": "f8000bc6c2cc5"},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9"
+              },
+              {
+                "_type": "span",
+                "marks": ["b108371134f2"],
+                "text": "History API",
+                "_key": "f8000bc6c2cc10"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "_type": "span",
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61"
+              },
+              {
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62",
+                "_type": "span",
+                "marks": ["5effc21937f2"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "1c02b32c603f",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              }
+            ]
+          },
+          {
+            "style": "normal",
+            "_key": "8e80c9eb6199",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing",
+                "_key": "71794103a7f7",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_key": "0b6e3394738b0",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing"
+              },
+              {
+                "_key": "0b6e3394738b1",
+                "_type": "span",
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. "
+              },
+              {
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages",
+                "_key": "0b6e3394738b2"
+              },
+              {
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3",
+                "_type": "span",
+                "marks": []
+              },
+              {"_key": "0b6e3394738b4", "_type": "span", "marks": ["em"], "text": "have to"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business"
+              }
+            ],
+            "children": [
+              {
+                "_key": "12cf600307170",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Privacy and GDPR."
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also ",
+                "_key": "12cf600307171"
+              },
+              {
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"],
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att",
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/tecovas",
+                "_key": "59cbe6b65a1c",
+                "openInNewTab": true
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude",
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew",
+                "_key": "193b3762fbae",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0"
+              },
+              {
+                "_key": "12245601a16d1",
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm "
+              },
+              {"_type": "span", "marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "9cf7212a8f89"},
+              {
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas",
+                "_key": "40e8def3484d"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "e7b7bb453ddb"},
+              {
+                "_key": "7e0dfa3067ee",
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "3fa730ff6ef0"},
+              {
+                "_type": "span",
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa"
+              },
+              {"_type": "span", "marks": [], "text": ", and lots more.", "_key": "a6efaf5a6352"}
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find ",
+                "_key": "348e76282adc1"
+              },
+              {
+                "_key": "348e76282adc2",
+                "_type": "span",
+                "marks": ["em"],
+                "text": "structured content"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "content-first", "_key": "348e76282adc4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "fbc03667027e",
+            "listItem": "bullet"
+          }
+        ],
+        "slug": {"current": "pitching-sanity-to-your-teamssss", "_type": "slug"},
+        "date": "2024-10-17T21:25:00.000Z",
+        "_rev": "N06nnxz6bPVwWf6YHjiLXR",
+        "_id": "18671bfe-7428-4141-b6ff-d95c2df5438a",
+        "title": "Why Next.js Developers Love Sanity",
+        "author": {
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2",
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            },
+            "_type": "image",
+            "alt": "Just a silly robot"
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS"
+        },
+        "_updatedAt": "2024-11-15T14:50:21Z"
+      },
+      {
+        "_updatedAt": "2024-11-15T15:02:43Z",
+        "_rev": "N06nnxz6bPVwWf6YHjm4jT",
+        "_id": "1961848e-64ef-4e80-a305-12002869d9d2",
+        "title": "Why Next.js Developers Love Sanity",
+        "content": [
+          {
+            "_type": "block",
+            "style": "h2",
+            "_key": "238557b72f01",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Need help convincing your developer team to build with Sanity? Here are some points that may be useful!",
+                "_key": "99dfd3722b0b0"
+              }
+            ]
+          },
+          {
+            "_key": "a0ee536bccf5",
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/structured-content-platform",
+                "_key": "dc5a6fbdd4f0",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/studio",
+                "_key": "d6d78d9a4c00",
+                "openInNewTab": true
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/developer-experience",
+                "_key": "805a8b2f2238",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins",
+                "_key": "fefeec7b4d3a"
+              },
+              {
+                "linkType": "href",
+                "href": "https://slack.sanity.io/",
+                "_key": "0df9bd61dd06",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io is the platform for ",
+                "_key": "54f5e904446b0"
+              },
+              {
+                "_type": "span",
+                "marks": ["dc5a6fbdd4f0"],
+                "text": "structured content",
+                "_key": "54f5e904446b1"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". It comes with an ",
+                "_key": "54f5e904446b2"
+              },
+              {
+                "_type": "span",
+                "marks": ["d6d78d9a4c00"],
+                "text": "open-source headless CMS called Sanity Studio",
+                "_key": "54f5e904446b3"
+              },
+              {
+                "_key": "54f5e904446b4",
+                "_type": "span",
+                "marks": [],
+                "text": " that’s built with React, and that you can customize. You also get a "
+              },
+              {
+                "_type": "span",
+                "marks": ["805a8b2f2238"],
+                "text": "hosted real-time datastore",
+                "_key": "54f5e904446b7"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " with powerful APIs. There are also ",
+                "_key": "54f5e904446b8"
+              },
+              {
+                "_key": "54f5e904446b9",
+                "_type": "span",
+                "marks": ["fefeec7b4d3a"],
+                "text": "libraries and tools"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " that make it easier to use structured content in the products and services that you’re building. And not the least, there’s a growing ",
+                "_key": "54f5e904446b10"
+              },
+              {
+                "_type": "span",
+                "marks": ["0df9bd61dd06"],
+                "text": "friendly community of developers",
+                "_key": "54f5e904446b13"
+              },
+              {
+                "_key": "54f5e904446b14",
+                "_type": "span",
+                "marks": [],
+                "text": " that will gladly help and learn with you."
+              }
+            ],
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "Sanity.io gives your team:",
+                "_key": "d7f2b466be110"
+              }
+            ],
+            "_type": "block",
+            "style": "h2",
+            "_key": "911f59ed9bd5",
+            "markDefs": []
+          },
+          {
+            "_type": "block",
+            "style": "normal",
+            "_key": "957c930c6a11",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/export",
+                "_key": "e5c0fe55bd0e"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/getting-started-with-sanity-cli",
+                "_key": "496bed921a88",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Ultra-portable structured content.",
+                "_key": "3ce9d583712f0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " Your content is stored as plain JSON documents. That’s it. You can export all your documents from the backend with ",
+                "_key": "3ce9d583712f1"
+              },
+              {
+                "_key": "3ce9d583712f2",
+                "_type": "span",
+                "marks": ["e5c0fe55bd0e"],
+                "text": "one API request"
+              },
+              {"_type": "span", "marks": [], "text": " or ", "_key": "3ce9d583712f3"},
+              {
+                "_type": "span",
+                "marks": ["496bed921a88"],
+                "text": "CLI command",
+                "_key": "3ce9d583712f4"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". And if you need to move them out of Sanity, it’s much easier to import these documents into another system, compared with some specific XML-export from a CMS littered with plugin-specific junk (looking at you WordPress). After all, portability is the hallmark of structured content.",
+                "_key": "3ce9d583712f5"
+              }
+            ],
+            "level": 1
+          },
+          {
+            "markDefs": [
+              {
+                "href": "https://www.sanity.io/docs/validation",
+                "_key": "9fff35c62de3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href"
+              },
+              {
+                "_key": "8171baf14b8d",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/custom-input-widgets"
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/previewing-block-content",
+                "_key": "072aed996572",
+                "openInNewTab": true,
+                "_type": "link"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/guides/how-to-brand-your-studio",
+                "_key": "4480f82451f0"
+              },
+              {
+                "_key": "a6b14269fd59",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/plugins"
+              }
+            ],
+            "children": [
+              {
+                "_key": "ebb58ede26df0",
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A customizable editor environment"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". With Sanity.io, you get a CMS that’s open-source and customizable with JavaScript and React. You only need a ",
+                "_key": "ebb58ede26df1"
+              },
+              {"_type": "span", "marks": ["code"], "text": "name", "_key": "ebb58ede26df2"},
+              {"_type": "span", "marks": [], "text": " and a ", "_key": "ebb58ede26df3"},
+              {"text": "type", "_key": "ebb58ede26df4", "_type": "span", "marks": ["code"]},
+              {
+                "text": " to make a new field, and when you’re ready for it, you can extend with custom ",
+                "_key": "ebb58ede26df5",
+                "_type": "span",
+                "marks": []
+              },
+              {
+                "_type": "span",
+                "marks": ["9fff35c62de3"],
+                "text": "JavaScript validations",
+                "_key": "ebb58ede26df6"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "ebb58ede26df7"},
+              {
+                "_type": "span",
+                "marks": ["8171baf14b8d"],
+                "text": "custom input components",
+                "_key": "ebb58ede26df8"
+              },
+              {"_type": "span", "marks": [], "text": " and ", "_key": "ebb58ede26df9"},
+              {
+                "_type": "span",
+                "marks": ["072aed996572"],
+                "text": "previews",
+                "_key": "ebb58ede26df10"
+              },
+              {"_type": "span", "marks": [], "text": " with React, ", "_key": "ebb58ede26df11"},
+              {
+                "_type": "span",
+                "marks": ["4480f82451f0"],
+                "text": "CSS-variable overrides",
+                "_key": "ebb58ede26df12"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and you can install ",
+                "_key": "ebb58ede26df13"
+              },
+              {
+                "_type": "span",
+                "marks": ["a6b14269fd59"],
+                "text": "plugins and tools",
+                "_key": "ebb58ede26df14"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " or make your own. You have access to all the APIs that the Studio uses.",
+                "_key": "ebb58ede26df15"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "84194559957b",
+            "listItem": "bullet"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/content-modelling",
+                "_key": "0a56d6069b1f",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Something that’s easy to set up",
+                "_key": "c82f983069240"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You are probably way faster on a keyboard compared to dragging and dropping fields with your mouse. ",
+                "_key": "c82f983069241"
+              },
+              {
+                "_key": "c82f983069242",
+                "_type": "span",
+                "marks": ["0a56d6069b1f"],
+                "text": "Creating a field"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " in Sanity Studio is as easy as writing ",
+                "_key": "c82f983069243"
+              },
+              {
+                "_type": "span",
+                "marks": ["code"],
+                "text": "{ name: ‘title’, type: ‘string’ }",
+                "_key": "c82f983069244"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " and hitting “save”. With content models in code, you can create your own snippets, you can bootstrap config, commit them to git, or even publish on npm.",
+                "_key": "c82f983069245"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8df79202a840"
+          },
+          {
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/groq-reference",
+                "_key": "b296479901e6",
+                "openInNewTab": true
+              },
+              {
+                "_key": "0fed2e2f2757",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/we-re-open-sourcing-groq-a-query-language-for-json-documents"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The joy of rapid iteration with GROQ",
+                "_key": "4e252fbb1cee0"
+              },
+              {"_type": "span", "marks": [], "text": ". Sanity.io offer ", "_key": "4e252fbb1cee1"},
+              {
+                "text": "GROQ (Graph-Relation Object Queries)",
+                "_key": "4e252fbb1cee2",
+                "_type": "span",
+                "marks": ["b296479901e6"]
+              },
+              {
+                "marks": [],
+                "text": " as a way to filter your dataset’s documents, join them, and project the data structures that you need for your project. Like GraphQL it gives you one endpoint for all your content, but it’s way more versatile in the way you can shape and wrangle your data. After a couple of minutes, you can learn enough GROQ to be productive. With GROQ there is no need to loop over your data on the client-side after querying, you can shape it how you want it right in the query. This saves both bandwidth and processing time. ",
+                "_key": "4e252fbb1cee3",
+                "_type": "span"
+              },
+              {
+                "_type": "span",
+                "marks": ["0fed2e2f2757"],
+                "text": "GROQ is open source",
+                "_key": "4e252fbb1cee4"
+              },
+              {
+                "marks": [],
+                "text": " and can be used elsewhere as well.",
+                "_key": "4e252fbb1cee5",
+                "_type": "span"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "967720ce9152",
+            "listItem": "bullet"
+          },
+          {
+            "children": [
+              {
+                "marks": ["strong"],
+                "text": "Great APIs.",
+                "_key": "f8000bc6c2cc0",
+                "_type": "span"
+              },
+              {
+                "_key": "f8000bc6c2cc1",
+                "_type": "span",
+                "marks": [],
+                "text": " In addition to GROQ, you can query your content with "
+              },
+              {
+                "_type": "span",
+                "marks": ["96eb022755a1"],
+                "text": "GraphQL",
+                "_key": "f8000bc6c2cc2"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". If you want to change a deeply nested value or change running text, you can do so with the powerful ",
+                "_key": "f8000bc6c2cc3"
+              },
+              {
+                "_type": "span",
+                "marks": ["7318f97464f3"],
+                "text": "mutations API",
+                "_key": "f8000bc6c2cc4"
+              },
+              {"_type": "span", "marks": [], "text": ". The ", "_key": "f8000bc6c2cc5"},
+              {
+                "_type": "span",
+                "marks": ["ef62068d84b3"],
+                "text": "listener API",
+                "_key": "f8000bc6c2cc6"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " lets your apps subscribe to changes happening in your content in real-time. With the ",
+                "_key": "f8000bc6c2cc7"
+              },
+              {
+                "_type": "span",
+                "marks": ["2015bb11a8e1"],
+                "text": "Asset pipeline",
+                "_key": "f8000bc6c2cc8"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can get on-demand image transforms. With the ",
+                "_key": "f8000bc6c2cc9"
+              },
+              {
+                "_type": "span",
+                "marks": ["b108371134f2"],
+                "text": "History API",
+                "_key": "f8000bc6c2cc10"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", you can browse document revisions and see who did what. ",
+                "_key": "f8000bc6c2cc11"
+              },
+              {
+                "_type": "span",
+                "marks": ["699302d30793"],
+                "text": "Webhooks",
+                "_key": "f8000bc6c2cc12"
+              },
+              {
+                "text": " lets you integrate with other services.",
+                "_key": "f8000bc6c2cc13",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "ac857c26da44",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_key": "96eb022755a1",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/graphql"
+              },
+              {
+                "_key": "7318f97464f3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/http-mutations"
+              },
+              {
+                "_key": "ef62068d84b3",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/realtime-updates"
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/asset-pipeline",
+                "_key": "2015bb11a8e1",
+                "openInNewTab": true
+              },
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/history-api",
+                "_key": "b108371134f2",
+                "openInNewTab": true
+              },
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/webhooks_LEGACY",
+                "_key": "699302d30793",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ]
+          },
+          {
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/docs/api-cdn",
+                "_key": "5effc21937f2",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "The calm of no-ops",
+                "_key": "60f152de9ae60"
+              },
+              {
+                "marks": [],
+                "text": ". We offer you a scalable backend, both in terms of the amount of data, but also traffic, security, and availability. ",
+                "_key": "60f152de9ae61",
+                "_type": "span"
+              },
+              {
+                "text": "CDNs for assets and content delivery",
+                "_key": "60f152de9ae62",
+                "_type": "span",
+                "marks": ["5effc21937f2"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". Sanity Studio, the CMS, is a Single Page Application. We can host the HTML and the JavaScript file for you, or you can put it pretty much on any host. You can even deploy different studios connected to the same datastore if you want to build specialized editor experiences.",
+                "_key": "60f152de9ae63"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "1c02b32c603f",
+            "listItem": "bullet"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "linkType": "href",
+                "href": "https://www.sanity.io/pricing",
+                "_key": "71794103a7f7",
+                "openInNewTab": true,
+                "_type": "link"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Flexible, transparent pricing",
+                "_key": "0b6e3394738b0"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You won't be forced to change tiers because of traffic or usage. ",
+                "_key": "0b6e3394738b1"
+              },
+              {
+                "_key": "0b6e3394738b2",
+                "_type": "span",
+                "marks": ["71794103a7f7"],
+                "text": "All tiers are pay-as-you-go with modestly priced overages"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ". You can also add more datasets and users on all plans. The tiers differ on SLAs, support, and advanced features. There’s no hidden schemes or gotchas, it’s all on the website for you to scrutinize. We let you upgrade and downgrade whenever you want, and will prorate you for what you haven’t used if you downgrade before the month has ended. You don’t ",
+                "_key": "0b6e3394738b3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "have to", "_key": "0b6e3394738b4"},
+              {
+                "text": " talk to sales ever (but we sure love to if you want).",
+                "_key": "0b6e3394738b5",
+                "_type": "span",
+                "marks": []
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "8e80c9eb6199"
+          },
+          {
+            "style": "normal",
+            "_key": "efc861cba2eb",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/blog/a-rough-guide-to-running-a-gdpr-compliant-saas-business",
+                "_key": "1cfae7e0e4bb",
+                "openInNewTab": true
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "Privacy and GDPR.",
+                "_key": "12cf600307170"
+              },
+              {
+                "_key": "12cf600307171",
+                "_type": "span",
+                "marks": [],
+                "text": " Sanity.io host your data in the heart of GDPR land: Brussels. Sanity.io is designed with GDPR in mind so that it is easy for you to stay compliant. None of your content is shared with third-party services (not even your images). We also offer custom edit history retention if your business requires that. If this isn’t enough, we also "
+              },
+              {
+                "_type": "span",
+                "marks": ["1cfae7e0e4bb"],
+                "text": "blogged about how to run a GDPR compliant SaaS",
+                "_key": "12cf600307172"
+              }
+            ],
+            "level": 1,
+            "_type": "block"
+          },
+          {
+            "_key": "9a9acc4dee4d",
+            "listItem": "bullet",
+            "markDefs": [
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/case-studies/oma",
+                "_key": "2751faf930be"
+              },
+              {
+                "_key": "e4b70a04a7fc",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/att"
+              },
+              {
+                "_key": "59cbe6b65a1c",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/tecovas"
+              },
+              {
+                "_key": "e5e0d5d7d52b",
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/amplitude"
+              },
+              {
+                "openInNewTab": true,
+                "_type": "link",
+                "linkType": "href",
+                "href": "https://www.sanity.io/customers/morning-brew",
+                "_key": "193b3762fbae"
+              }
+            ],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A content platform that has been in production since 2015.",
+                "_key": "12245601a16d0"
+              },
+              {
+                "_key": "12245601a16d1",
+                "_type": "span",
+                "marks": [],
+                "text": " Although Sanity.io is a relatively new product on the market, it has been used in production by companies such as the renowned architecture firm "
+              },
+              {"_type": "span", "marks": ["2751faf930be"], "text": "OMA", "_key": "12245601a16d2"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": ", and one of Norway’s largest media companies, Amedia. Publicly launched in 2017. Sanity.io is now used by thousands of developers and companies including ",
+                "_key": "12245601a16d3"
+              },
+              {
+                "_type": "span",
+                "marks": ["e4b70a04a7fc"],
+                "text": "AT\u0026T",
+                "_key": "0fda6f062eba"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "9cf7212a8f89"},
+              {
+                "_key": "40e8def3484d",
+                "_type": "span",
+                "marks": ["59cbe6b65a1c"],
+                "text": "Tecovas"
+              },
+              {"_type": "span", "marks": [], "text": ", ", "_key": "e7b7bb453ddb"},
+              {
+                "_type": "span",
+                "marks": ["e5e0d5d7d52b"],
+                "text": "Amplitude",
+                "_key": "7e0dfa3067ee"
+              },
+              {"_key": "3fa730ff6ef0", "_type": "span", "marks": [], "text": ", "},
+              {
+                "_type": "span",
+                "marks": ["193b3762fbae"],
+                "text": "Morning Brew",
+                "_key": "b0b736d94caa"
+              },
+              {"_type": "span", "marks": [], "text": ", and lots more.", "_key": "a6efaf5a6352"}
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal"
+          },
+          {
+            "listItem": "bullet",
+            "markDefs": [],
+            "children": [
+              {
+                "_type": "span",
+                "marks": ["strong"],
+                "text": "A tool for modern content strategy and design processes",
+                "_key": "348e76282adc0"
+              },
+              {
+                "_key": "348e76282adc1",
+                "_type": "span",
+                "marks": [],
+                "text": ". If you look at the conversations happening within content strategy, you’ll quickly find "
+              },
+              {
+                "text": "structured content",
+                "_key": "348e76282adc2",
+                "_type": "span",
+                "marks": ["em"]
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " as a frequent topic. No wonder, since it’s a pattern that prevents duplicated content and tries to connect your text and media to the goals of your team and users. Sanity.io also makes ",
+                "_key": "348e76282adc3"
+              },
+              {"_type": "span", "marks": ["em"], "text": "content-first", "_key": "348e76282adc4"},
+              {
+                "_type": "span",
+                "marks": [],
+                "text": " approaches to design easier with rapid content modeling and having the content available instantly. This is perfect when you’re building component-based design systems. Which you should be doing!",
+                "_key": "348e76282adc5"
+              }
+            ],
+            "level": 1,
+            "_type": "block",
+            "style": "normal",
+            "_key": "fbc03667027e"
+          }
+        ],
+        "slug": {"current": "31", "_type": "slug"},
+        "_type": "post",
+        "author": {
+          "_updatedAt": "2024-11-15T12:30:02Z",
+          "picture": {
+            "_type": "image",
+            "alt": "Just a silly robot",
+            "asset": {
+              "_type": "reference",
+              "_ref": "image-96981f278bf65cc35d4c864b55c957ea68fc0881-128x128-jpg"
+            }
+          },
+          "firstName": "Sanity",
+          "lastName": "CMS",
+          "_createdAt": "2024-09-13T13:49:18Z",
+          "_rev": "N06nnxz6bPVwWf6YHioaMZ",
+          "_type": "person",
+          "_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2"
+        },
+        "_createdAt": "2024-11-15T15:02:39Z",
+        "coverImage": {
+          "asset": {
+            "_ref": "image-f878e3c26717cd6c945d9cd5fa3dceff3f33a9ea-2560x1440-jpg",
+            "_type": "reference"
+          },
+          "_type": "image",
+          "alt": "Pitching Sanity to your team"
+        },
+        "excerpt": "Need help to convince your developer team to build with Sanity.io? Here are some points that may be useful!",
+        "date": "2024-10-17T21:25:00.000Z"
+      }
+    ]
+  },
+  "resultSourceMap": {
+    "documents": [
+      {"_id": "011eba9a-1777-476b-8529-55a533fb83d3", "_type": "post"},
+      {"_id": "0297d6e3-f1e0-4223-80a4-8623aa67bfc0", "_type": "post"},
+      {"_id": "0627c001-bb4a-4bc7-8d23-b8b263af9c3d", "_type": "post"},
+      {"_id": "0a78332d-8860-415e-87c6-61f543e9cbf9", "_type": "post"},
+      {"_id": "0c10a30b-7faf-43bb-aa19-aa917880bc26", "_type": "post"},
+      {"_id": "0da613bc-e237-45b3-a3e1-8afb8e61e85b", "_type": "post"},
+      {"_id": "0dd7bbc2-eb2f-4432-bbab-c023ad375e76", "_type": "post"},
+      {"_id": "11a1e8e4-46e9-4cfc-8988-206de09c0b99", "_type": "post"},
+      {"_id": "17a9a1df-54e6-4d3d-a588-43a043bf5fe8", "_type": "post"},
+      {"_id": "18671bfe-7428-4141-b6ff-d95c2df5438a", "_type": "post"},
+      {"_id": "1961848e-64ef-4e80-a305-12002869d9d2", "_type": "post"},
+      {"_id": "3cbb297f-3e80-471d-a4e5-a2b92dfe8bc2", "_type": "person"}
+    ],
+    "paths": [
+      "$['_createdAt']",
+      "$['_id']",
+      "$['_rev']",
+      "$['_type']",
+      "$['_updatedAt']",
+      "$['content']",
+      "$['coverImage']",
+      "$['date']",
+      "$['excerpt']",
+      "$['firstName']",
+      "$['lastName']",
+      "$['picture']",
+      "$['slug']",
+      "$['title']"
+    ],
+    "mappings": {
+      "$['entries'][0]['_createdAt']": {
+        "source": {"document": 0, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['_id']": {
+        "source": {"document": 0, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['_rev']": {
+        "source": {"document": 0, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['_type']": {
+        "source": {"document": 0, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['_updatedAt']": {
+        "source": {"document": 0, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['content']": {
+        "source": {"document": 0, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['coverImage']": {
+        "source": {"document": 0, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['date']": {
+        "source": {"document": 0, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['excerpt']": {
+        "source": {"document": 0, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['slug']": {
+        "source": {"document": 0, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][0]['title']": {
+        "source": {"document": 0, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['_createdAt']": {
+        "source": {"document": 10, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['_id']": {
+        "source": {"document": 10, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['_rev']": {
+        "source": {"document": 10, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['_type']": {
+        "source": {"document": 10, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['_updatedAt']": {
+        "source": {"document": 10, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['content']": {
+        "source": {"document": 10, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['coverImage']": {
+        "source": {"document": 10, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['date']": {
+        "source": {"document": 10, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['excerpt']": {
+        "source": {"document": 10, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['slug']": {
+        "source": {"document": 10, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][10]['title']": {
+        "source": {"document": 10, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['_createdAt']": {
+        "source": {"document": 1, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['_id']": {
+        "source": {"document": 1, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['_rev']": {
+        "source": {"document": 1, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['_type']": {
+        "source": {"document": 1, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['_updatedAt']": {
+        "source": {"document": 1, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['content']": {
+        "source": {"document": 1, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['coverImage']": {
+        "source": {"document": 1, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['date']": {
+        "source": {"document": 1, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['excerpt']": {
+        "source": {"document": 1, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['slug']": {
+        "source": {"document": 1, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][1]['title']": {
+        "source": {"document": 1, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['_createdAt']": {
+        "source": {"document": 2, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['_id']": {
+        "source": {"document": 2, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['_rev']": {
+        "source": {"document": 2, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['_type']": {
+        "source": {"document": 2, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['_updatedAt']": {
+        "source": {"document": 2, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['content']": {
+        "source": {"document": 2, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['coverImage']": {
+        "source": {"document": 2, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['date']": {
+        "source": {"document": 2, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['excerpt']": {
+        "source": {"document": 2, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['slug']": {
+        "source": {"document": 2, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][2]['title']": {
+        "source": {"document": 2, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['_createdAt']": {
+        "source": {"document": 3, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['_id']": {
+        "source": {"document": 3, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['_rev']": {
+        "source": {"document": 3, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['_type']": {
+        "source": {"document": 3, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['_updatedAt']": {
+        "source": {"document": 3, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['content']": {
+        "source": {"document": 3, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['coverImage']": {
+        "source": {"document": 3, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['date']": {
+        "source": {"document": 3, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['excerpt']": {
+        "source": {"document": 3, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['slug']": {
+        "source": {"document": 3, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][3]['title']": {
+        "source": {"document": 3, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['_createdAt']": {
+        "source": {"document": 4, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['_id']": {
+        "source": {"document": 4, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['_rev']": {
+        "source": {"document": 4, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['_type']": {
+        "source": {"document": 4, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['_updatedAt']": {
+        "source": {"document": 4, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['content']": {
+        "source": {"document": 4, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['coverImage']": {
+        "source": {"document": 4, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['date']": {
+        "source": {"document": 4, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['excerpt']": {
+        "source": {"document": 4, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['slug']": {
+        "source": {"document": 4, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][4]['title']": {
+        "source": {"document": 4, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['_createdAt']": {
+        "source": {"document": 5, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['_id']": {
+        "source": {"document": 5, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['_rev']": {
+        "source": {"document": 5, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['_type']": {
+        "source": {"document": 5, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['_updatedAt']": {
+        "source": {"document": 5, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['content']": {
+        "source": {"document": 5, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['coverImage']": {
+        "source": {"document": 5, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['date']": {
+        "source": {"document": 5, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['excerpt']": {
+        "source": {"document": 5, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['slug']": {
+        "source": {"document": 5, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][5]['title']": {
+        "source": {"document": 5, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['_createdAt']": {
+        "source": {"document": 6, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['_id']": {
+        "source": {"document": 6, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['_rev']": {
+        "source": {"document": 6, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['_type']": {
+        "source": {"document": 6, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['_updatedAt']": {
+        "source": {"document": 6, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['content']": {
+        "source": {"document": 6, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['coverImage']": {
+        "source": {"document": 6, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['date']": {
+        "source": {"document": 6, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['excerpt']": {
+        "source": {"document": 6, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['slug']": {
+        "source": {"document": 6, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][6]['title']": {
+        "source": {"document": 6, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['_createdAt']": {
+        "source": {"document": 7, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['_id']": {
+        "source": {"document": 7, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['_rev']": {
+        "source": {"document": 7, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['_type']": {
+        "source": {"document": 7, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['_updatedAt']": {
+        "source": {"document": 7, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['content']": {
+        "source": {"document": 7, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['coverImage']": {
+        "source": {"document": 7, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['date']": {
+        "source": {"document": 7, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['excerpt']": {
+        "source": {"document": 7, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['slug']": {
+        "source": {"document": 7, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][7]['title']": {
+        "source": {"document": 7, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['_createdAt']": {
+        "source": {"document": 8, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['_id']": {
+        "source": {"document": 8, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['_rev']": {
+        "source": {"document": 8, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['_type']": {
+        "source": {"document": 8, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['_updatedAt']": {
+        "source": {"document": 8, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['content']": {
+        "source": {"document": 8, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['coverImage']": {
+        "source": {"document": 8, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['date']": {
+        "source": {"document": 8, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['excerpt']": {
+        "source": {"document": 8, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['slug']": {
+        "source": {"document": 8, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][8]['title']": {
+        "source": {"document": 8, "path": 13, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['_createdAt']": {
+        "source": {"document": 9, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['_id']": {
+        "source": {"document": 9, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['_rev']": {
+        "source": {"document": 9, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['_type']": {
+        "source": {"document": 9, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['_updatedAt']": {
+        "source": {"document": 9, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['_createdAt']": {
+        "source": {"document": 11, "path": 0, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['_id']": {
+        "source": {"document": 11, "path": 1, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['_rev']": {
+        "source": {"document": 11, "path": 2, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['_type']": {
+        "source": {"document": 11, "path": 3, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['_updatedAt']": {
+        "source": {"document": 11, "path": 4, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['firstName']": {
+        "source": {"document": 11, "path": 9, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['lastName']": {
+        "source": {"document": 11, "path": 10, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['author']['picture']": {
+        "source": {"document": 11, "path": 11, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['content']": {
+        "source": {"document": 9, "path": 5, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['coverImage']": {
+        "source": {"document": 9, "path": 6, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['date']": {
+        "source": {"document": 9, "path": 7, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['excerpt']": {
+        "source": {"document": 9, "path": 8, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['slug']": {
+        "source": {"document": 9, "path": 12, "type": "documentValue"},
+        "type": "value"
+      },
+      "$['entries'][9]['title']": {
+        "source": {"document": 9, "path": 13, "type": "documentValue"},
+        "type": "value"
+      }
+    }
+  },
+  "syncTags": ["s1:pcDn1g", "s1:9PCytQ"],
+  "ms": 48
+}


### PR DESCRIPTION
We got a report of a really slow request that only happens if stega is enabled, here's how to repro:
```
const {createClient, stegaEncodeSourceMap} = await import('https://esm.sh/@sanity/client/stega')

const client = createClient({
  projectId: '4n2hubkf',
  dataset: 'production',
  apiVersion: '2024-11-15',
  useCdn: true,
  stega: {studioUrl: '/studio'}
})

const {result, resultSourceMap} = await client.fetch(`{
    "entries": *[_type == "post"] | order(publishedAt desc) {
    ...,
    title,
    excerpt,
    date,
    author-> {
        ...,
    },
},
}`, {}, {resultSourceMap: 'withKeyArraySelector', filterResponse: false})

console.profile()
stegaEncodeSourceMap(result, resultSourceMap, {enabled: true, studioUrl: '/studio'})
console.profileEnd()
```
Turns out the root cause was a lot of portable text arrays that were deeply recursed.

This PR adds short circuit logic for when a PT `block` or `span` is detected, and traverses them more efficiently.
To measure the impact I've added a `npm run benchmark` command:
```bash
 ✓ test/stega/stegaEncodeSourceMap.bench.ts (2) 5795ms
   ✓ stegaEncodeSourceMap can handle Portable Text in a performant way (2) 5793ms
     name                       hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · @sanity/client@latest  4.3355  221.82  282.11  230.65  228.15  282.11  282.11  282.11  ±5.67%       10
   · src                    9.3105  105.54  109.67  107.41  107.81  109.67  109.67  109.67  ±0.84%       10   fastest
```
It uses the benchmarking feature in Vitest, so we can add more benchmarks in the future 🙌

As a side-effect of the more efficient recursion there's no longer a need to handle PT edge cases in the stega `filterDefault` function 😌 