### PR TITLE
feat(request): add flag to disable logging api warnings

### DIFF
--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -24,12 +24,13 @@ export default function defineCreateClientExports<
   ClassConstructor: new (httpRequest: HttpRequest, config: ClientConfigType) => SanityClientType,
 ) {
   // Set the http client to use for requests, and its environment specific middleware
-  const defaultRequester = defineHttpRequest(envMiddleware)
+  const defaultRequester = defineHttpRequest(envMiddleware, undefined)
 
-  const createClient = (config: ClientConfigType) =>
-    new ClassConstructor(
+  const createClient = (config: ClientConfigType) => {
+    const configRequester = defineHttpRequest(envMiddleware, config)
+    return new ClassConstructor(
       (options, requester) =>
-        (requester || defaultRequester)({
+        (requester || configRequester)({
           maxRedirects: 0,
           maxRetries: config.maxRetries,
           retryDelay: config.retryDelay,
@@ -37,6 +38,7 @@ export default function defineCreateClientExports<
         } as Any),
       config,
     )
+  }
 
   return {requester: defaultRequester, createClient}
 }

--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -24,13 +24,13 @@ export default function defineCreateClientExports<
   ClassConstructor: new (httpRequest: HttpRequest, config: ClientConfigType) => SanityClientType,
 ) {
   // Set the http client to use for requests, and its environment specific middleware
-  const defaultRequester = defineHttpRequest(envMiddleware, undefined)
+  const defaultRequester = defineHttpRequest(envMiddleware)
 
   const createClient = (config: ClientConfigType) => {
-    const configRequester = defineHttpRequest(envMiddleware, config)
+    const clientRequester = defineHttpRequest(envMiddleware)
     return new ClassConstructor(
       (options, requester) =>
-        (requester || configRequester)({
+        (requester || clientRequester)({
           maxRedirects: 0,
           maxRetries: config.maxRetries,
           retryDelay: config.retryDelay,

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,6 @@ export interface ClientConfig {
    */
   requestTagPrefix?: string
   ignoreBrowserTokenWarning?: boolean
-  ignoreSanityAPIWarnings?: boolean
   withCredentials?: boolean
   allowReconfigure?: boolean
   timeout?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface ClientConfig {
    */
   requestTagPrefix?: string
   ignoreBrowserTokenWarning?: boolean
+  ignoreSanityAPIWarnings?: boolean
   withCredentials?: boolean
   allowReconfigure?: boolean
   timeout?: number

--- a/test/warnings.test.ts
+++ b/test/warnings.test.ts
@@ -42,24 +42,26 @@ describe('Client config warnings', async () => {
     expect(warn).toHaveBeenCalledWith('Friction endures')
   })
 
-  test.skipIf(isEdge)(
-    'does not warns if server sends warning back and configured to ignore',
-    async () => {
-      expect.assertions(1)
+  test.skipIf(isEdge)('only warns once', async () => {
+    expect.assertions(2)
 
-      const {default: nock} = await import('nock')
+    const {default: nock} = await import('nock')
 
-      nock('https://abc123.api.sanity.io')
-        .get('/v1/users/me')
-        .reply(200, {}, {'X-Sanity-Warning': 'Friction endures'})
+    nock('https://abc123.api.sanity.io')
+      .get('/v1/users/me')
+      .times(2)
+      .reply(200, {}, {'X-Sanity-Warning': 'Friction endures'})
 
-      await createClient({
-        projectId: 'abc123',
-        useCdn: true,
-        apiVersion: '1',
-        ignoreSanityAPIWarnings: true,
-      }).users.getById('me')
-      expect(warn).not.toHaveBeenCalledWith('Friction endures')
-    },
-  )
+    const client = createClient({
+      projectId: 'abc123',
+      useCdn: true,
+      apiVersion: '1',
+    })
+
+    await client.users.getById('me')
+    await client.users.getById('me')
+
+    expect(warn).toHaveBeenCalledWith('Friction endures')
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
 })

--- a/test/warnings.test.ts
+++ b/test/warnings.test.ts
@@ -41,4 +41,25 @@ describe('Client config warnings', async () => {
     await createClient({projectId: 'abc123', useCdn: true, apiVersion: '1'}).users.getById('me')
     expect(warn).toHaveBeenCalledWith('Friction endures')
   })
+
+  test.skipIf(isEdge)(
+    'does not warns if server sends warning back and configured to ignore',
+    async () => {
+      expect.assertions(1)
+
+      const {default: nock} = await import('nock')
+
+      nock('https://abc123.api.sanity.io')
+        .get('/v1/users/me')
+        .reply(200, {}, {'X-Sanity-Warning': 'Friction endures'})
+
+      await createClient({
+        projectId: 'abc123',
+        useCdn: true,
+        apiVersion: '1',
+        ignoreSanityAPIWarnings: true,
+      }).users.getById('me')
+      expect(warn).not.toHaveBeenCalledWith('Friction endures')
+    },
+  )
 })


### PR DESCRIPTION
When using the client library and the `vX` api, it can be undesirable/noisy to log
```
This is a future API version, which may change without warning.
```
for every request.