### PR TITLE
fix(types): add (abort) signal to raw request typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1114,6 +1114,7 @@ export interface RawRequestOptions {
   proxy?: string
   body?: Any
   maxRedirects?: number
+  signal?: AbortSignal
 }
 
 /** @internal */


### PR DESCRIPTION
When using `client.request()`, `signal` was not listed as an allowed property - but it works just fine.