### PR TITLE
feat(query): add support for release perspectives

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,28 @@ function validateApiVersion(apiVersion: string) {
   }
 }
 
-export const validateApiPerspective = function validateApiPerspective(perspective: string) {
+export const validateApiPerspective = function validateApiPerspective(perspective: unknown) {
+  if (Array.isArray(perspective)) {
+    for (const perspectiveValue of perspective) {
+      if (perspectiveValue === 'published') {
+        continue
+      }
+      if (perspectiveValue === 'drafts') {
+        continue
+      }
+      if (
+        typeof perspectiveValue === 'string' &&
+        perspectiveValue.startsWith('r') &&
+        perspectiveValue !== 'raw'
+      ) {
+        continue
+      }
+      throw new TypeError(
+        'Invalid API perspective value, expected `published`, `drafts` or a valid release identifier string',
+      )
+    }
+    return
+  }
   switch (perspective as ClientPerspective) {
     case 'previewDrafts':
     case 'published':
@@ -74,7 +95,7 @@ export const initConfig = (
     throw new Error('Configuration must contain `projectId`')
   }
 
-  if (typeof newConfig.perspective === 'string') {
+  if (typeof newConfig.perspective !== 'undefined') {
     validateApiPerspective(newConfig.perspective)
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,7 @@ export const validateApiPerspective = function validateApiPerspective(perspectiv
   }
   switch (perspective as ClientPerspective) {
     case 'previewDrafts':
+    case 'drafts':
     case 'published':
     case 'raw':
       return

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -405,12 +405,17 @@ export function _requestObservable<R>(
     if (resultSourceMap !== undefined && resultSourceMap !== false) {
       options.query = {resultSourceMap, ...options.query}
     }
-    const perspective = options.perspective || config.perspective
-    if (typeof perspective === 'string' && perspective !== 'raw') {
-      validateApiPerspective(perspective)
-      options.query = {perspective, ...options.query}
+    const perspectiveOption = options.perspective || config.perspective
+    if (typeof perspectiveOption !== 'undefined') {
+      validateApiPerspective(perspectiveOption)
+      options.query = {
+        perspective: Array.isArray(perspectiveOption)
+          ? perspectiveOption.join(',')
+          : perspectiveOption,
+        ...options.query,
+      }
       // If the perspective is set to `previewDrafts` we can't use the CDN, the API will throw
-      if (perspective === 'previewDrafts' && useCdn) {
+      if (perspectiveOption === 'previewDrafts' && useCdn) {
         useCdn = false
         printCdnPreviewDraftsWarning()
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export type ReleaseId = `r${string}`
 export type ClientPerspective =
   | 'previewDrafts'
   | 'published'
+  | 'drafts'
   | 'raw'
   | ('published' | 'drafts' | ReleaseId)[]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,14 @@ export interface RequestOptions {
 }
 
 /** @public */
-export type ClientPerspective = 'previewDrafts' | 'published' | 'raw'
+export type ReleaseId = `r${string}`
+
+/** @public */
+export type ClientPerspective =
+  | 'previewDrafts'
+  | 'published'
+  | 'raw'
+  | ('published' | 'drafts' | ReleaseId)[]
 
 /** @public */
 export interface ClientConfig {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -178,6 +178,27 @@ describe('client', async () => {
       expect(() => createClient({projectId: 'abc123', perspective: 'preview drafts'})).toThrow(
         /Invalid API perspective/,
       )
+
+      // valid because it begins with `r`
+      const validReleaseIdentifier = 'rfoobar'
+      expect(() =>
+        createClient({
+          projectId: 'abc123',
+          perspective: ['published', 'drafts', validReleaseIdentifier],
+        }),
+      ).not.toThrow(/Invalid API perspective/)
+
+      // special case – "raw" would be a valid release id given that it starts with ´r`
+      // but 'raw' is not possible to use with multiple perspectives and is explicitly
+      // banned by the backend
+      expect(() =>
+        createClient({projectId: 'abc123', perspective: ['published', 'drafts', 'raw']}),
+      ).toThrow(/Invalid API perspective/)
+
+      expect(() =>
+        // @ts-expect-error -- we want to test that it throws an error
+        createClient({projectId: 'abc123', perspective: ['XyzAbC']}),
+      ).toThrow(/Invalid API perspective/)
     })
 
     test('throws on invalid project ids', () => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -171,6 +171,9 @@ describe('client', async () => {
       expect(() => createClient({projectId: 'abc123', perspective: 'previewDrafts'})).not.toThrow(
         /Invalid API perspective/,
       )
+      expect(() => createClient({projectId: 'abc123', perspective: 'drafts'})).not.toThrow(
+        /Invalid API perspective/,
+      )
       expect(() => createClient({projectId: 'abc123', perspective: 'raw'})).not.toThrow(
         /Invalid API perspective/,
       )


### PR DESCRIPTION
This opens up for passing multiple perspectives to `client.fetch()` et al., enabling support for releases.

So far, only additional perspectives we support must be a ReleaseId, which by convention must start with the character `r`.

See unit tests for more details.

Multiple perspectives will be applied in order of significance.

e.g. `perspective=rABC,drafts` will return the following under the given scenarios:
- Dataset includes documents `[{_id: "foo", …}, {_id: "drafts.foo", …}, {_id: "versions.rABC.foo", …}]`
  - returns `[{_id: "versions.rABC.foo", …}]`
- Dataset includes documents `[{_id: "foo", …}, {_id: "drafts.foo", …}]`
  - returns `[{_id: "drafts.foo", …}]`
- Dataset includes documents `[{_id: "foo", …}]`
  - returns `[{_id: "foo", …}]`(since published documents are included by default)