### PR TITLE
refactor: enable verbatim module syntax

### DIFF
--- a/src/csm/types.ts
+++ b/src/csm/types.ts
@@ -1,6 +1,6 @@
 import type {ContentSourceMap, ContentSourceMapDocuments, SanityDocument} from '@sanity/client'
 
-import {Path} from './studioPath'
+import {type Path} from './studioPath'
 
 export type {IndexTuple, KeyedSegment, Path, PathSegment} from './studioPath'
 export type {

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,4 +1,4 @@
-import {getIt, type Middlewares, Requester} from 'get-it'
+import {getIt, type Middlewares, type Requester} from 'get-it'
 import {jsonRequest, jsonResponse, observable, progress, retry} from 'get-it/middleware'
 import {Observable} from 'rxjs'
 

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,4 +1,4 @@
-import defineCreateClientExports, {ClientConfig, SanityClient} from './defineCreateClient'
+import defineCreateClientExports, {type ClientConfig, SanityClient} from './defineCreateClient'
 import {defineDeprecatedCreateClient} from './defineDeprecatedCreateClient'
 import envMiddleware from './http/browserMiddleware'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import defineCreateClientExports, {ClientConfig, SanityClient} from './defineCreateClient'
+import defineCreateClientExports, {type ClientConfig, SanityClient} from './defineCreateClient'
 import {defineDeprecatedCreateClient} from './defineDeprecatedCreateClient'
 import envMiddleware from './http/nodeMiddleware'
 

--- a/src/stega/stegaEncodeSourceMap.ts
+++ b/src/stega/stegaEncodeSourceMap.ts
@@ -6,7 +6,11 @@ import {resolveStudioBaseRoute} from '../csm/resolveEditInfo'
 import {reKeySegment, toString as studioPathToString} from '../csm/studioPath'
 import {encodeIntoResult} from './encodeIntoResult'
 import {filterDefault} from './filterDefault'
-import {ContentSourceMap, ContentSourceMapParsedPath, InitializedStegaConfig} from './types'
+import {
+  type ContentSourceMap,
+  type ContentSourceMapParsedPath,
+  type InitializedStegaConfig,
+} from './types'
 
 const TRUNCATE_LENGTH = 20
 

--- a/src/util/pick.ts
+++ b/src/util/pick.ts
@@ -1,4 +1,4 @@
-import {Any} from '../types'
+import {type Any} from '../types'
 
 export const pick = (obj: Any, props: Any) =>
   props.reduce((selection: Any, prop: Any) => {

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -1,5 +1,5 @@
 import {generateHelpUrl} from './generateHelpUrl'
-import {Any} from './types'
+import {type Any} from './types'
 import {once} from './util/once'
 
 const createWarningPrinter = (message: string[]) =>

--- a/test/client.test-d.ts
+++ b/test/client.test-d.ts
@@ -1,10 +1,10 @@
 import {
-  ContentSourceMap,
+  type ContentSourceMap,
   createClient,
-  QueryOptions,
-  QueryParams,
-  QueryWithoutParams,
-  RawQueryResponse,
+  type QueryOptions,
+  type QueryParams,
+  type QueryWithoutParams,
+  type RawQueryResponse,
 } from '@sanity/client'
 import {describe, expectTypeOf, test} from 'vitest'
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,23 +2,23 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import {
-  BaseActionOptions,
+  type BaseActionOptions,
   type ClientConfig,
   ClientError,
-  ContentSourceMap,
-  CreateAction,
+  type ContentSourceMap,
+  type CreateAction,
   createClient,
   type DatasetsResponse,
-  DeleteAction,
-  DiscardAction,
-  EditAction,
+  type DeleteAction,
+  type DiscardAction,
+  type EditAction,
   Patch,
-  PublishAction,
-  ReplaceDraftAction,
+  type PublishAction,
+  type ReplaceDraftAction,
   type SanityProject,
   ServerError,
   Transaction,
-  UnpublishAction,
+  type UnpublishAction,
 } from '@sanity/client'
 import {firstValueFrom, lastValueFrom, of as observableOf, toArray} from 'rxjs'
 import {filter} from 'rxjs/operators'

--- a/test/csm/studioPath.test.ts
+++ b/test/csm/studioPath.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, test} from 'vitest'
 
 import {jsonPathToStudioPath} from '../../src/csm/jsonPath'
 import {fromString, get, toString} from '../../src/csm/studioPath'
-import {ContentSourceMapParsedPath} from '../../src/csm/types'
+import {type ContentSourceMapParsedPath} from '../../src/csm/types'
 
 const srcObject = {
   title: 'Hei',

--- a/test/stega/client.test-d.ts
+++ b/test/stega/client.test-d.ts
@@ -1,6 +1,6 @@
 import {createClient, SanityClient} from '@sanity/client'
 import {
-  ContentSourceMap,
+  type ContentSourceMap,
   createClient as createStegaClient,
   SanityStegaClient,
 } from '@sanity/client/stega'

--- a/test/stega/client.test.ts
+++ b/test/stega/client.test.ts
@@ -1,4 +1,4 @@
-import {ClientConfig, ContentSourceMap, createClient, SanityClient} from '@sanity/client'
+import {type ClientConfig, type ContentSourceMap, createClient, SanityClient} from '@sanity/client'
 import {
   vercelStegaCombine,
   vercelStegaDecode,

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -21,6 +21,7 @@
     "strictPropertyInitialization": false,
     "noImplicitThis": true,
     "alwaysStrict": true,
+    "verbatimModuleSyntax": true,
 
     // Additional checks
     "noUnusedLocals": true,


### PR DESCRIPTION
Verbatim module syntax enforces explicit type imports/exports which ensures predictable compilation. [Details](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax)