### PR TITLE
fix(stega): append `perspective` to edit links

### DIFF
--- a/src/csm/createEditUrl.ts
+++ b/src/csm/createEditUrl.ts
@@ -1,4 +1,4 @@
-import {getPublishedId, isDraftId} from './draftUtils'
+import {getPublishedId, getVersionFromId, isDraftId, isPublishedId, isVersionId} from './draftUtils'
 import {jsonPathToStudioPath} from './jsonPath'
 import * as studioPath from './studioPath'
 import type {CreateEditUrlOptions, EditIntentUrl, StudioBaseUrl} from './types'
@@ -55,6 +55,12 @@ export function createEditUrl(options: CreateEditUrlOptions): `${StudioBaseUrl}$
   }
   if (dataset) {
     searchParams.set('dataset', dataset)
+  }
+  if (isPublishedId(_id)) {
+    searchParams.set('perspective', 'published')
+  } else if (isVersionId(_id)) {
+    const versionId = getVersionFromId(_id)!
+    searchParams.set('perspective', versionId)
   }
   if (isDraftId(_id)) {
     searchParams.set('isDraft', '')

--- a/test/csm/createEditUrl.test.ts
+++ b/test/csm/createEditUrl.test.ts
@@ -1,3 +1,4 @@
+import {getPublishedId, getVersionId} from '@sanity/client/csm'
 import {expect, test} from 'vitest'
 
 import {createEditUrl} from '../../src/csm/createEditUrl'
@@ -35,6 +36,26 @@ const cases = [
     path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
     expected:
       '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content&projectId=a1b2c3d4&dataset=production&isDraft=',
+  },
+  {
+    context: {baseUrl: '/', workspace, tool, id: getPublishedId(id), type, projectId, dataset},
+    path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
+    expected:
+      '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content&projectId=a1b2c3d4&dataset=production&perspective=published',
+  },
+  {
+    context: {
+      baseUrl: '/',
+      workspace,
+      tool,
+      id: getVersionId(id, 'rABC123'),
+      type,
+      projectId,
+      dataset,
+    },
+    path: parseJsonPath("$['foo'][?(@._key=='section-1')][0]"),
+    expected:
+      '/staging/intent/edit/mode=presentation;id=homepage;type=page;path=foo[_key=="section-1"][0];tool=content?baseUrl=/&id=homepage&type=page&path=foo[_key=="section-1"][0]&workspace=staging&tool=content&projectId=a1b2c3d4&dataset=production&perspective=rABC123',
   },
 ]
 

--- a/test/csm/resolveEditUrl.test.ts
+++ b/test/csm/resolveEditUrl.test.ts
@@ -1,4 +1,4 @@
-import {type ContentSourceMap, resolveEditUrl} from '@sanity/client/csm'
+import {type ContentSourceMap, getDraftId, getVersionId, resolveEditUrl} from '@sanity/client/csm'
 import {expect, test} from 'vitest'
 
 const mock = {
@@ -233,23 +233,23 @@ const mock = {
   resultSourceMap: {
     documents: [
       {
-        _id: 'drafts.462efcc6-3c8b-47c6-8474-5544e1a4acde',
+        _id: '462efcc6-3c8b-47c6-8474-5544e1a4acde',
         _type: 'product',
       },
       {
-        _id: 'drafts.807cc05c-8c4c-443a-a9c1-198fd3fd7b16',
+        _id: getDraftId('807cc05c-8c4c-443a-a9c1-198fd3fd7b16'),
         _type: 'product',
       },
       {
-        _id: 'drafts.a643da0c-2cc6-439e-92b7-9f31c822ee05',
+        _id: getVersionId('a643da0c-2cc6-439e-92b7-9f31c822ee05', 'rABC123'),
         _type: 'product',
       },
       {
-        _id: 'drafts.c9de5527-ebd9-4f90-8c30-a26e3439ca2d',
+        _id: 'c9de5527-ebd9-4f90-8c30-a26e3439ca2d',
         _type: 'product',
       },
       {
-        _id: 'drafts.e1bf9f1f-efdb-4105-8c26-6b64f897e9c1',
+        _id: 'e1bf9f1f-efdb-4105-8c26-6b64f897e9c1',
         _type: 'product',
       },
       {
@@ -501,19 +501,55 @@ const cases = [
     path: 'products[0].title',
     studioUrl: 'https://test.sanity.studio',
     expected:
-      'https://test.sanity.studio/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=title?baseUrl=https://test.sanity.studio&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=title&isDraft=',
+      'https://test.sanity.studio/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=title?baseUrl=https://test.sanity.studio&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=title&perspective=published',
   },
   {
     path: 'products[0].media.alt',
     studioUrl: '/',
     expected:
-      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=media[_key=="cee5fbb69da2"].alt?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=media[_key=="cee5fbb69da2"].alt&isDraft=',
+      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=media[_key=="cee5fbb69da2"].alt?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=media[_key=="cee5fbb69da2"].alt&perspective=published',
   },
   {
     path: 'products[0].description[0].children[0].text',
     studioUrl: '/',
     expected:
-      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=description[0].children[0].text?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=description[0].children[0].text&isDraft=',
+      '/intent/edit/mode=presentation;id=462efcc6-3c8b-47c6-8474-5544e1a4acde;type=product;path=description[0].children[0].text?baseUrl=/&id=462efcc6-3c8b-47c6-8474-5544e1a4acde&type=product&path=description[0].children[0].text&perspective=published',
+  },
+  {
+    path: 'products[1].title',
+    studioUrl: 'https://test.sanity.studio',
+    expected:
+      'https://test.sanity.studio/intent/edit/mode=presentation;id=807cc05c-8c4c-443a-a9c1-198fd3fd7b16;type=product;path=title?baseUrl=https://test.sanity.studio&id=807cc05c-8c4c-443a-a9c1-198fd3fd7b16&type=product&path=title&isDraft=',
+  },
+  {
+    path: 'products[1].media.alt',
+    studioUrl: '/',
+    expected:
+      '/intent/edit/mode=presentation;id=807cc05c-8c4c-443a-a9c1-198fd3fd7b16;type=product;path=media[_key=="55659c72ec46"].alt?baseUrl=/&id=807cc05c-8c4c-443a-a9c1-198fd3fd7b16&type=product&path=media[_key=="55659c72ec46"].alt&isDraft=',
+  },
+  {
+    path: 'products[1].description[0].children[0].text',
+    studioUrl: '/',
+    expected:
+      '/intent/edit/mode=presentation;id=807cc05c-8c4c-443a-a9c1-198fd3fd7b16;type=product;path=description[0].children[0].text?baseUrl=/&id=807cc05c-8c4c-443a-a9c1-198fd3fd7b16&type=product&path=description[0].children[0].text&isDraft=',
+  },
+  {
+    path: 'products[2].title',
+    studioUrl: 'https://test.sanity.studio',
+    expected:
+      'https://test.sanity.studio/intent/edit/mode=presentation;id=a643da0c-2cc6-439e-92b7-9f31c822ee05;type=product;path=title?baseUrl=https://test.sanity.studio&id=a643da0c-2cc6-439e-92b7-9f31c822ee05&type=product&path=title&perspective=rABC123',
+  },
+  {
+    path: 'products[2].media.alt',
+    studioUrl: '/',
+    expected:
+      '/intent/edit/mode=presentation;id=a643da0c-2cc6-439e-92b7-9f31c822ee05;type=product;path=media[_key=="f304342d5bb0"].alt?baseUrl=/&id=a643da0c-2cc6-439e-92b7-9f31c822ee05&type=product&path=media[_key=="f304342d5bb0"].alt&perspective=rABC123',
+  },
+  {
+    path: 'products[2].description[0].children[0].text',
+    studioUrl: '/',
+    expected:
+      '/intent/edit/mode=presentation;id=a643da0c-2cc6-439e-92b7-9f31c822ee05;type=product;path=description[0].children[0].text?baseUrl=/&id=a643da0c-2cc6-439e-92b7-9f31c822ee05&type=product&path=description[0].children[0].text&perspective=rABC123',
   },
 ]
 

--- a/test/stega/client.test.ts
+++ b/test/stega/client.test.ts
@@ -146,18 +146,18 @@ describe('@sanity/client/stega', async () => {
       expect(vercelStegaSplit(res[0].title).cleaned).toBe(result[0].title)
       expect(vercelStegaDecode(res[0].title)).toMatchInlineSnapshot(`
         {
-          "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title",
+          "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title&perspective=published",
           "origin": "sanity.io",
         }
       `)
       expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot(`
         [
           {
-            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title",
+            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title&perspective=published",
             "origin": "sanity.io",
           },
           {
-            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=country",
+            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=country&perspective=published",
             "origin": "sanity.io",
           },
         ]
@@ -192,11 +192,11 @@ describe('@sanity/client/stega', async () => {
       expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot(`
         [
           {
-            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title",
+            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=title&perspective=published",
             "origin": "sanity.io",
           },
           {
-            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=country",
+            "href": "/studio/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fstudio&id=njgNkngskjg&type=beer&path=country&perspective=published",
             "origin": "sanity.io",
           },
         ]
@@ -229,11 +229,11 @@ describe('@sanity/client/stega', async () => {
       expect(vercelStegaDecodeAll(JSON.stringify(res))).toMatchInlineSnapshot(`
         [
           {
-            "href": "/admin/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fadmin&id=njgNkngskjg&type=beer&path=title",
+            "href": "/admin/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=title?baseUrl=%2Fadmin&id=njgNkngskjg&type=beer&path=title&perspective=published",
             "origin": "sanity.io",
           },
           {
-            "href": "/admin/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fadmin&id=njgNkngskjg&type=beer&path=country",
+            "href": "/admin/intent/edit/mode=presentation;id=njgNkngskjg;type=beer;path=country?baseUrl=%2Fadmin&id=njgNkngskjg&type=beer&path=country&perspective=published",
             "origin": "sanity.io",
           },
         ]


### PR DESCRIPTION
Relates to COREL, ensuring that `Open in Studio` links in Overlays (as seen on [this demo](https://sanity-template-remix-clean.sanity.build/)) can open the Studio with the same "perspective" as the content you clicked on.

Most of the time these overlays are shown when previewing draft content, even if previewing drafts it's possible that published content is clicked.
If the user clicks on a heading that says `Hello world!`, as it's the published document, but then the document opened by the Studio (it doesn't matter if it's by Presentation Tool or Structure Tool, they behave the same) loads the draft it's quite jarring to see a completely different header.
It's better if the user can opt-in to viewing the draft version, so it's clear what they're looking at and doing.

With Content Releases it'll also be possible to make a deployment that previews a specific release (or list of releases), in this context it's even more important that the "Open in Studio" link that's clicked on takes you to the same version of the document that you're looking at. The way this works is that the content release that's used is extracted from the document ID reported as the source document by the Content Source Map (CSM). The CSM reports the original id of the document, and fully supports the `drafts` perspective.