### PR TITLE
feat(csm): support releases in `applySourceDocuments`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.26.1",
+  "version": "6.27.0-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.26.1",
+      "version": "6.27.0-canary.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.26.1",
+  "version": "6.27.0-canary.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/csm/createSourceDocumentResolver.ts
+++ b/src/csm/createSourceDocumentResolver.ts
@@ -1,0 +1,54 @@
+import {getDraftId, getPublishedId, getVersionId} from './draftUtils'
+import {resolvePerspectives} from './resolvePerspectives'
+import type {ClientPerspective, ContentSourceMapDocuments, SanityDocument} from './types'
+
+/** @internal */
+export type ResolvedDocument = Partial<SanityDocument> &
+  Required<Pick<SanityDocument, '_id' | '_type'>>
+
+/** @internal */
+export type MatchedDocument = Partial<SanityDocument> &
+  Required<Pick<SanityDocument, '_id' | '_type' | '_originalId'>>
+
+/** @internal */
+export function createSourceDocumentResolver(
+  getCachedDocument: (
+    sourceDocument: ContentSourceMapDocuments[number],
+  ) => ResolvedDocument | null | undefined,
+  _perspective: Exclude<ClientPerspective, 'raw'>,
+) {
+  const perspectives = resolvePerspectives(_perspective)
+  function findDocument(sourceDocument: ContentSourceMapDocuments[number]) {
+    for (const perspective of perspectives) {
+      let match: ReturnType<typeof getCachedDocument> = null
+      if (perspective.startsWith('r')) {
+        match = getCachedDocument({
+          ...sourceDocument,
+          _id: getVersionId(sourceDocument._id, perspective),
+        })
+      }
+      if (perspective === 'drafts') {
+        match = getCachedDocument({
+          ...sourceDocument,
+          _id: getDraftId(sourceDocument._id),
+        })
+      }
+      if (perspective === 'published') {
+        match = getCachedDocument({
+          ...sourceDocument,
+          _id: getPublishedId(sourceDocument._id),
+        })
+      }
+      if (match) {
+        return {...match, _id: getPublishedId(match._id), _originalId: match._id}
+      }
+    }
+    return null
+  }
+  // define resolver that loops over source documents and perspectives
+  return function resolveSourceDocument(
+    sourceDocument: ContentSourceMapDocuments[number],
+  ): MatchedDocument | null {
+    return findDocument(sourceDocument)
+  }
+}

--- a/src/csm/resolvePerspectives.ts
+++ b/src/csm/resolvePerspectives.ts
@@ -1,0 +1,29 @@
+import {validateApiPerspective} from '../config'
+import type {ReleaseId} from '../types'
+import type {ClientPerspective} from './types'
+
+/**
+ * This resolves the perspectives to how documents should be resolved when applying optimistic updates,
+ * like in `applySourceDocuments`.
+ * @internal
+ */
+export function resolvePerspectives(
+  perspective: Exclude<ClientPerspective, 'raw'>,
+): ('published' | 'drafts' | ReleaseId)[] {
+  validateApiPerspective(perspective)
+
+  if (Array.isArray(perspective)) {
+    if (!perspective.includes('published')) {
+      return [...perspective, 'published']
+    }
+    return perspective
+  }
+  switch (perspective) {
+    case 'previewDrafts':
+    case 'drafts':
+      return ['drafts', 'published']
+    case 'published':
+    default:
+      return ['published']
+  }
+}

--- a/test/csm/applySourceDocuments.test.ts
+++ b/test/csm/applySourceDocuments.test.ts
@@ -3,6 +3,7 @@ import {
   type ContentSourceMap,
   type ContentSourceMapDocuments,
   getDraftId,
+  getVersionId,
   type SanityDocument,
 } from '@sanity/client/csm'
 import {diffString} from 'json-diff'
@@ -432,6 +433,11 @@ describe('handling perspectives', () => {
     it: 'c8338be2-97b4-4782-bee7-09397c780478',
     windsWinter: '8b671177-113d-4249-ae23-6b50dc017e9e',
   } as const
+  const releases = {
+    one: 'rABC123',
+    two: 'rDEF456',
+    three: 'rGHI789',
+  } as const
 
   const dataset = [
     {
@@ -440,6 +446,14 @@ describe('handling perspectives', () => {
       _type: 'author',
       name: 'George Martin (published)',
       _id: ids.george,
+      _updatedAt: '2024-01-09T15:58:47Z',
+    },
+    {
+      _createdAt: '2024-01-09T11:10:46Z',
+      _rev: 'D3N5P3XyAZ16DNFKjiRI0q',
+      _type: 'author',
+      name: `George Martin (${releases.one})`,
+      _id: getVersionId(ids.george, releases.one),
       _updatedAt: '2024-01-09T15:58:47Z',
     },
     {
@@ -455,6 +469,18 @@ describe('handling perspectives', () => {
       _updatedAt: '2024-01-09T16:00:04Z',
     },
     {
+      author: {
+        _ref: ids.terry,
+        _type: 'reference',
+      },
+      _createdAt: '2024-01-09T13:46:42Z',
+      _rev: '4CNIu3sfkQOfiJtCaJf66J',
+      _type: 'book',
+      _id: getVersionId(ids.goodOmens, releases.three),
+      title: `Good Omens (${releases.three})`,
+      _updatedAt: '2024-01-09T16:00:04Z',
+    },
+    {
       title: 'Fire & Ice (published)',
       _updatedAt: '2024-01-09T15:59:33Z',
       author: {
@@ -467,10 +493,30 @@ describe('handling perspectives', () => {
       _id: ids.fireIce,
     },
     {
+      title: `Fire & Ice (${releases.two})`,
+      _updatedAt: '2024-01-09T15:59:33Z',
+      author: {
+        _ref: ids.george,
+        _type: 'reference',
+      },
+      _createdAt: '2024-01-09T10:58:07Z',
+      _rev: '4CNIu3sfkQOfiJtCaJf4ix',
+      _type: 'book',
+      _id: getVersionId(ids.fireIce, releases.two),
+    },
+    {
       _rev: '4CNIu3sfkQOfiJtCaJf0OF',
       _type: 'author',
       name: 'Terry Pratchett (published)',
       _id: ids.terry,
+      _updatedAt: '2024-01-09T15:58:08Z',
+      _createdAt: '2024-01-09T13:45:33Z',
+    },
+    {
+      _rev: '4CNIu3sfkQOfiJtCaJf0OF',
+      _type: 'author',
+      name: `Terry Pratchett (${releases.three})`,
+      _id: getVersionId(ids.terry, releases.three),
       _updatedAt: '2024-01-09T15:58:08Z',
       _createdAt: '2024-01-09T13:45:33Z',
     },
@@ -499,6 +545,22 @@ describe('handling perspectives', () => {
       _updatedAt: '2024-01-09T15:59:48Z',
     },
     {
+      author: {
+        _strengthenOnPublish: {
+          type: 'author',
+        },
+        _weak: true,
+        _ref: ids.stephen,
+        _type: 'reference',
+      },
+      _createdAt: '2024-01-09T10:58:07Z',
+      _rev: '3480a3e1-d8b4-49c9-8da8-70b85489dd05',
+      _type: 'book',
+      _id: getVersionId(ids.it, releases.two),
+      title: `It (${releases.two})`,
+      _updatedAt: '2024-01-09T15:59:48Z',
+    },
+    {
       _updatedAt: '2024-01-09T16:00:13Z',
       author: {
         _ref: ids.george,
@@ -517,6 +579,14 @@ describe('handling perspectives', () => {
       _type: 'author',
       name: 'Stephen King (draft)',
       _id: getDraftId(ids.stephen),
+    },
+    {
+      _updatedAt: '2024-01-09T15:58:16Z',
+      _createdAt: '2024-01-09T11:17:15Z',
+      _rev: 'bfa045fa-4936-4eb3-978a-bdd9316ba837',
+      _type: 'author',
+      name: `Stephen King (${releases.one})`,
+      _id: getVersionId(ids.stephen, releases.one),
     },
   ] as const satisfies SanityDocument[]
   const getCachedDocument: (
@@ -974,25 +1044,23 @@ describe('handling perspectives', () => {
          {
            _id: "c8338be2-97b4-4782-bee7-09397c780478"
            _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
-      -    title: "It"
-      +    title: "It (draft)"
+           title: "It"
            author: {
              _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
              _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
-      -      name: "Stephen King"
-      +      name: "Stephen King (draft)"
+             name: "Stephen King"
            }
          }
          {
            _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
            _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
-      -    title: "The Winds of Winter"
-      +    title: "The Winds of Winter (draft)"
+           title: "The Winds of Winter"
            author: {
              _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
-             _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      +      _originalId: "294709c3-710d-4dc6-8f6f-f36c4786611a"
       -      name: "George R.R. Martin"
-      +      name: "George R.R. Martin (draft)"
+      +      name: "George Martin (published)"
            }
          }
        ]
@@ -1046,6 +1114,669 @@ describe('handling perspectives', () => {
              _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
       -      name: "George R.R. Martin"
       +      name: "George R.R. Martin (draft)"
+           }
+         }
+       ]
+      "
+    `)
+  })
+
+  test('perspective: rABC123,rDFG456,drafts', () => {
+    const mock = {
+      query: '*[_type == "book"]{\n  _id,_originalId,title,author->{_id,_originalId,name}\n}',
+      result: [
+        {
+          _id: ids.goodOmens,
+          _originalId: getVersionId(ids.goodOmens, releases.three),
+          title: `Good Omens (${releases.three})`,
+          author: {
+            _id: ids.terry,
+            _originalId: getVersionId(ids.terry, releases.three),
+            name: `Terry Pratchett (${releases.three})`,
+          },
+        },
+        {
+          _id: ids.it,
+          _originalId: getDraftId(ids.it),
+          title: 'It',
+          author: {
+            _id: ids.stephen,
+            _originalId: getDraftId(ids.stephen),
+            name: 'Stephen King',
+          },
+        },
+        {
+          _id: ids.windsWinter,
+          _originalId: getDraftId(ids.windsWinter),
+          title: 'The Winds of Winter',
+          author: {
+            _id: ids.george,
+            _originalId: getDraftId(ids.george),
+            name: 'George R.R. Martin',
+          },
+        },
+      ],
+      resultSourceMap: {
+        documents: [
+          {
+            _id: getVersionId(ids.goodOmens, releases.three),
+            _type: 'book',
+          },
+          {
+            _id: getVersionId(ids.terry, releases.three),
+            _type: 'author',
+          },
+          {
+            _id: getDraftId(ids.it),
+            _type: 'book',
+          },
+          {
+            _id: getDraftId(ids.stephen),
+            _type: 'author',
+          },
+          {
+            _id: getDraftId(ids.windsWinter),
+            _type: 'book',
+          },
+          {
+            _id: getDraftId(ids.george),
+            _type: 'author',
+          },
+        ],
+        paths: ["$['_id']", "$['_originalId']", "$['title']", "$['name']"],
+        mappings: {
+          "$[0]['_id']": {
+            source: {
+              document: 0,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[0]['_originalId']": {
+            source: {
+              document: 0,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[0]['author']['_id']": {
+            source: {
+              document: 1,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[0]['author']['_originalId']": {
+            source: {
+              document: 1,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[0]['author']['name']": {
+            source: {
+              document: 1,
+              path: 3,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[0]['title']": {
+            source: {
+              document: 0,
+              path: 2,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[1]['_id']": {
+            source: {
+              document: 2,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[1]['_originalId']": {
+            source: {
+              document: 2,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[1]['author']['_id']": {
+            source: {
+              document: 3,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[1]['author']['_originalId']": {
+            source: {
+              document: 3,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[1]['author']['name']": {
+            source: {
+              document: 3,
+              path: 3,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[1]['title']": {
+            source: {
+              document: 2,
+              path: 2,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[2]['_id']": {
+            source: {
+              document: 4,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[2]['_originalId']": {
+            source: {
+              document: 4,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[2]['author']['_id']": {
+            source: {
+              document: 5,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[2]['author']['_originalId']": {
+            source: {
+              document: 5,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[2]['author']['name']": {
+            source: {
+              document: 5,
+              path: 3,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[2]['title']": {
+            source: {
+              document: 4,
+              path: 2,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+        },
+      },
+      ms: 2881,
+    } as const satisfies {
+      query: string
+      result: unknown
+      resultSourceMap: ContentSourceMap
+      ms: number
+    }
+
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          'published',
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+      +    _originalId: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    title: "Good Omens (rGHI789)"
+      +    title: "Good Omens (published)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      +      _originalId: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      name: "Terry Pratchett (rGHI789)"
+      +      name: "Terry Pratchett (published)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+           _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+           title: "It"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+             _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+             name: "Stephen King"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+           title: "The Winds of Winter"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      +      _originalId: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George Martin (published)"
+           }
+         }
+       ]
+      "
+    `)
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          ['drafts'],
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+      +    _originalId: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    title: "Good Omens (rGHI789)"
+      +    title: "Good Omens (published)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      +      _originalId: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      name: "Terry Pratchett (rGHI789)"
+      +      name: "Terry Pratchett (published)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+           _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+      -    title: "It"
+      +    title: "It (draft)"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+             _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      name: "Stephen King"
+      +      name: "Stephen King (draft)"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+      -    title: "The Winds of Winter"
+      +    title: "The Winds of Winter (draft)"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+             _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George R.R. Martin (draft)"
+           }
+         }
+       ]
+      "
+    `)
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          [releases.one],
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+      +    _originalId: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    title: "Good Omens (rGHI789)"
+      +    title: "Good Omens (published)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      +      _originalId: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      name: "Terry Pratchett (rGHI789)"
+      +      name: "Terry Pratchett (published)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+           _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+           title: "It"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+      +      _originalId: "versions.rABC123.de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      name: "Stephen King"
+      +      name: "Stephen King (rABC123)"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+           title: "The Winds of Winter"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      +      _originalId: "versions.rABC123.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George Martin (rABC123)"
+           }
+         }
+       ]
+      "
+    `)
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          [releases.two],
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+      +    _originalId: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    title: "Good Omens (rGHI789)"
+      +    title: "Good Omens (published)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      +      _originalId: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      name: "Terry Pratchett (rGHI789)"
+      +      name: "Terry Pratchett (published)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+      -    _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+      +    _originalId: "versions.rDEF456.c8338be2-97b4-4782-bee7-09397c780478"
+      -    title: "It"
+      +    title: "It (rDEF456)"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+             _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+             name: "Stephen King"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+           title: "The Winds of Winter"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      +      _originalId: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George Martin (published)"
+           }
+         }
+       ]
+      "
+    `)
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          [releases.one, 'drafts'],
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+      +    _originalId: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    title: "Good Omens (rGHI789)"
+      +    title: "Good Omens (published)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      +      _originalId: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      name: "Terry Pratchett (rGHI789)"
+      +      name: "Terry Pratchett (published)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+           _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+      -    title: "It"
+      +    title: "It (draft)"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+      +      _originalId: "versions.rABC123.de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      name: "Stephen King"
+      +      name: "Stephen King (rABC123)"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+      -    title: "The Winds of Winter"
+      +    title: "The Winds of Winter (draft)"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      +      _originalId: "versions.rABC123.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George Martin (rABC123)"
+           }
+         }
+       ]
+      "
+    `)
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          [releases.two, 'drafts'],
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+      +    _originalId: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    title: "Good Omens (rGHI789)"
+      +    title: "Good Omens (published)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      +      _originalId: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      name: "Terry Pratchett (rGHI789)"
+      +      name: "Terry Pratchett (published)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+      -    _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+      +    _originalId: "versions.rDEF456.c8338be2-97b4-4782-bee7-09397c780478"
+      -    title: "It"
+      +    title: "It (rDEF456)"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+             _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      name: "Stephen King"
+      +      name: "Stephen King (draft)"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+      -    title: "The Winds of Winter"
+      +    title: "The Winds of Winter (draft)"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+             _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George R.R. Martin (draft)"
+           }
+         }
+       ]
+      "
+    `)
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          [releases.one, releases.two, 'drafts'],
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+      +    _originalId: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+      -    title: "Good Omens (rGHI789)"
+      +    title: "Good Omens (published)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      +      _originalId: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+      -      name: "Terry Pratchett (rGHI789)"
+      +      name: "Terry Pratchett (published)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+      -    _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+      +    _originalId: "versions.rDEF456.c8338be2-97b4-4782-bee7-09397c780478"
+      -    title: "It"
+      +    title: "It (rDEF456)"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+      +      _originalId: "versions.rABC123.de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      name: "Stephen King"
+      +      name: "Stephen King (rABC123)"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+      -    title: "The Winds of Winter"
+      +    title: "The Winds of Winter (draft)"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      +      _originalId: "versions.rABC123.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George Martin (rABC123)"
+           }
+         }
+       ]
+      "
+    `)
+    expect(
+      diffString(
+        mock.result,
+        applySourceDocuments(
+          mock.result,
+          mock.resultSourceMap,
+          getCachedDocument,
+          (changedValue) => changedValue,
+          [releases.one, releases.two, releases.three, 'drafts'],
+        ),
+        {color: false, full: true},
+      ),
+    ).toMatchInlineSnapshot(`
+      " [
+         {
+           _id: "2c1de490-e7ed-413c-8d23-163d4432bb63"
+           _originalId: "versions.rGHI789.2c1de490-e7ed-413c-8d23-163d4432bb63"
+           title: "Good Omens (rGHI789)"
+           author: {
+             _id: "d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+             _originalId: "versions.rGHI789.d7e0f612-ab9b-4fbb-ad1e-090f6e9d0a74"
+             name: "Terry Pratchett (rGHI789)"
+           }
+         }
+         {
+           _id: "c8338be2-97b4-4782-bee7-09397c780478"
+      -    _originalId: "drafts.c8338be2-97b4-4782-bee7-09397c780478"
+      +    _originalId: "versions.rDEF456.c8338be2-97b4-4782-bee7-09397c780478"
+      -    title: "It"
+      +    title: "It (rDEF456)"
+           author: {
+             _id: "de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      _originalId: "drafts.de2baea7-4df7-4eb0-841e-db20103279fc"
+      +      _originalId: "versions.rABC123.de2baea7-4df7-4eb0-841e-db20103279fc"
+      -      name: "Stephen King"
+      +      name: "Stephen King (rABC123)"
+           }
+         }
+         {
+           _id: "8b671177-113d-4249-ae23-6b50dc017e9e"
+           _originalId: "drafts.8b671177-113d-4249-ae23-6b50dc017e9e"
+      -    title: "The Winds of Winter"
+      +    title: "The Winds of Winter (draft)"
+           author: {
+             _id: "294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      _originalId: "drafts.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      +      _originalId: "versions.rABC123.294709c3-710d-4dc6-8f6f-f36c4786611a"
+      -      name: "George R.R. Martin"
+      +      name: "George Martin (rABC123)"
            }
          }
        ]

--- a/test/csm/createSourceDocumentResolver.test.ts
+++ b/test/csm/createSourceDocumentResolver.test.ts
@@ -1,0 +1,205 @@
+import {
+  type ClientPerspective,
+  type ContentSourceMapDocuments,
+  getDraftId,
+  getPublishedId,
+  getVersionId,
+} from '@sanity/client/csm'
+import {describe, expect, test} from 'vitest'
+
+import {
+  createSourceDocumentResolver,
+  type ResolvedDocument,
+} from '../../src/csm/createSourceDocumentResolver'
+
+const ids = {
+  published: '462efcc6-3c8b-47c6-8474-5544e1a4acde',
+  draft: 'e1bf9f1f-efdb-4105-8c26-6b64f897e9c1',
+  version: '807cc05c-8c4c-443a-a9c1-198fd3fd7b16',
+  release: 'rABC123',
+} as const
+
+const mockContentSourceMapDocuments = {
+  published: {
+    _id: ids.published,
+    _type: 'product',
+  },
+  draft: {
+    _id: getDraftId(ids.draft),
+    _type: 'product',
+  },
+  version: {
+    _id: getVersionId(ids.version, ids.release),
+    _type: 'product',
+  },
+} satisfies Record<string, ContentSourceMapDocuments[number]>
+
+function expectingToPass(
+  perspective: Exclude<ClientPerspective, 'raw'>,
+  sourceDocument: ContentSourceMapDocuments[number],
+  expectedDocument: ResolvedDocument,
+) {
+  const resolver = createSourceDocumentResolver(
+    (_sourceDocument) => (_sourceDocument._id === expectedDocument._id ? expectedDocument : null),
+    perspective,
+  )
+  const document = resolver(sourceDocument)!
+  expect(document, 'Resolves to a document').not.toBeNull()
+  expect(document._id, 'The returned ID needs to be the published ID').toEqual(
+    getPublishedId(document._id),
+  )
+  expect(document._id, 'The returned _id needs to match the source document').toEqual(
+    getPublishedId(sourceDocument._id),
+  )
+  expect(document._originalId, 'The _originalId needs to match the resolved document id').toEqual(
+    expectedDocument._id,
+  )
+}
+function expectingToMiss(
+  perspective: Exclude<ClientPerspective, 'raw'>,
+  sourceDocument: ContentSourceMapDocuments[number],
+  expectedDocument: ResolvedDocument,
+) {
+  const resolver = createSourceDocumentResolver(
+    (_sourceDocument) => (_sourceDocument._id === expectedDocument._id ? expectedDocument : null),
+    perspective,
+  )
+  expect(resolver(sourceDocument), 'No document should be resolved').toBeNull()
+}
+
+describe('perspectives: ["published"]', () => {
+  test.each([
+    [
+      'resolve a published document from a published document',
+      mockContentSourceMapDocuments.published,
+      {_id: ids.published, _type: 'product'},
+    ],
+    [
+      'resolve a published document from a draft document',
+      mockContentSourceMapDocuments.draft,
+      {_id: ids.draft, _type: 'product'},
+    ],
+    [
+      'resolve a published document from a versioned document',
+      mockContentSourceMapDocuments.version,
+      {_id: ids.version, _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToPass('published', sourceDocument, expectedDocument)
+  })
+  test.each([
+    [
+      'drafts are filtered out when published',
+      mockContentSourceMapDocuments.published,
+      {_id: getDraftId(ids.published), _type: 'product'},
+    ],
+    [
+      'versioned documents are filtered out when published',
+      mockContentSourceMapDocuments.published,
+      {_id: getVersionId(ids.published, ids.release), _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToMiss('published', sourceDocument, expectedDocument)
+  })
+})
+
+describe('perspectives: ["drafts", "published"]', () => {
+  test.each([
+    [
+      'resolve a published document from a published document',
+      mockContentSourceMapDocuments.published,
+      {_id: ids.published, _type: 'product'},
+    ],
+    [
+      'resolve a published document from a draft document',
+      mockContentSourceMapDocuments.published,
+      {_id: getDraftId(ids.published), _type: 'product'},
+    ],
+    [
+      'resolve a draft document from a published document',
+      mockContentSourceMapDocuments.draft,
+      {_id: ids.draft, _type: 'product'},
+    ],
+    [
+      'resolve a draft document from a draft document',
+      mockContentSourceMapDocuments.draft,
+      {_id: getDraftId(ids.draft), _type: 'product'},
+    ],
+    [
+      'resolve a versioned document from a published document',
+      mockContentSourceMapDocuments.version,
+      {_id: ids.version, _type: 'product'},
+    ],
+    [
+      'resolve a versioned document from a draft document',
+      mockContentSourceMapDocuments.version,
+      {_id: getDraftId(ids.version), _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToPass('drafts', sourceDocument, expectedDocument)
+  })
+  test.each([
+    [
+      'a release is filtered out when filtering only drafts',
+      mockContentSourceMapDocuments.published,
+      {_id: getVersionId(ids.published, ids.release), _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToMiss('drafts', sourceDocument, expectedDocument)
+  })
+  test('prefers drafts over published', () => {
+    const mocks = [
+      {_id: ids.published, _type: 'product'},
+      {_id: getDraftId(ids.published), _type: 'product'},
+    ]
+    const resolver = createSourceDocumentResolver(
+      (_sourceDocument) => mocks.find((mock) => mock._id === _sourceDocument._id),
+      'drafts',
+    )
+    expect(resolver(mockContentSourceMapDocuments.published)!._originalId).toEqual(
+      getDraftId(ids.published),
+    )
+  })
+})
+
+describe(`perspectives: ["${ids.release}", "published"]`, () => {
+  test.each([
+    [
+      'resolve a published document from a versioned document',
+      mockContentSourceMapDocuments.published,
+      {_id: getVersionId(ids.published, ids.release), _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToPass([ids.release], sourceDocument, expectedDocument)
+  })
+  test.each([
+    [
+      'drafts are filtered out when filtering only a release',
+      mockContentSourceMapDocuments.published,
+      {_id: getDraftId(ids.published), _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToMiss([ids.release], sourceDocument, expectedDocument)
+  })
+})
+
+describe(`perspectives: ["${ids.release}", "drafts", "published"]`, () => {
+  test.each([
+    [
+      'resolve a published document from a versioned document',
+      mockContentSourceMapDocuments.published,
+      {_id: getVersionId(ids.published, ids.release), _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToPass([ids.release, 'drafts'], sourceDocument, expectedDocument)
+  })
+  test.each([
+    [
+      'a different release is filtered out',
+      mockContentSourceMapDocuments.published,
+      {_id: getVersionId(ids.published, 'rDFG456'), _type: 'product'},
+    ],
+  ])('%s', (_, sourceDocument, expectedDocument) => {
+    expectingToMiss([ids.release, 'drafts'], sourceDocument, expectedDocument)
+  })
+})

--- a/test/csm/resolvePerspectives.test.ts
+++ b/test/csm/resolvePerspectives.test.ts
@@ -1,0 +1,22 @@
+import {expect, test} from 'vitest'
+
+import {resolvePerspectives} from '../../src/csm/resolvePerspectives'
+
+test.each([
+  ['previewDrafts', ['drafts', 'published']],
+  ['drafts', ['drafts', 'published']],
+  ['published', ['published']],
+  [['drafts'], ['drafts', 'published']],
+  [['published'], ['published']],
+  [['rABC123'], ['rABC123', 'published']],
+  [
+    ['rABC123', 'drafts'],
+    ['rABC123', 'drafts', 'published'],
+  ],
+  [
+    ['rABC123', 'drafts', 'published'],
+    ['rABC123', 'drafts', 'published'],
+  ],
+])('resolvePerspectives(%s)', (perspective, shouldEqual) => {
+  expect(resolvePerspectives(perspective as unknown as any)).toEqual(shouldEqual)
+})


### PR DESCRIPTION
## What's changed, introduced etc

With the introduction of Content Releases we now have the concept of documents having a version ID, in addition to a published ID and draft ID. And with it it's possible to set an array of perspective values for specific releases, which is "overlayed" on draft documents, overlayed on published documents.
This PR teaches `applySourceDocuments` to support these cases, by letting you set its perspective argument in the same way you would when fetching data:
```ts
import {applySourceDocuments} from '@sanity/client/csm'

const {result, resultSourceMap} = await client.fetch(query, params,
  {
    resultSourceMap: 'withKeyArraySelector',
    // Required, otherwise you can't access `resultSourceMap`
    filterResponse: false
  },
)

// This is still supported
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, 'published'
)
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, 'previewDrafts'
)
// Now fully supported
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, ['rABC123','rDFG456']
)
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, ['rABC123','drafts']
)
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, ['drafts']
)
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, 'drafts'
)
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, ['published']
)
// No longer supported
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map, 'raw'
)
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get, map
)
const optimisticResult = applySourceDocuments(
  result, resultSourceMap, get
)
```

Here's a more elaborate example:
```ts
import {createClient} from '@sanity/client'
import {applySourceDocuments, getDraftId, getVersionId, type ContentSourceMapDocuments} from '@sanity/client/csm'

const client = createClient({
  //  ... standard client config
  resultSourceMap: 'withKeyArraySelector',
})

// Query data as if documents in the `rPRIDE` release, and all draft documents, are published
const perspective = ['rPRIDE', 'drafts']

const {result, resultSourceMap} = await client.fetch(
  `*[_type == "author" && slug.current == $slug][0]{_id,_originalId,name}`,
  {slug: 'john-doe'},
  {
    perspective,
    // Required, otherwise you can't access `resultSourceMap`
    filterResponse: false
  },
)

// The `result` looks like this:
const result = {
  _id: '462efcc6-3c8b-47c6-8474-5544e1a4acde',
  _originalId: '462efcc6-3c8b-47c6-8474-5544e1a4acde',
  name: 'john doe',
}
// And `resultSourceMap`
const resultSourceMap = {
  documents: [{_id: '462efcc6-3c8b-47c6-8474-5544e1a4acde', _type: 'author'}],
  paths: ["$['_id']","$['_originalId']","$['name']"],
  mappings: {
      "$['_id']": {
        source: {
          document: 0,
          path: 0,
          type: 'documentValue',
        },
        type: 'value',
      },
      "$['_originalId']": {
        source: {
          document: 0,
          path: 1,
          type: 'documentValue',
        },
        type: 'value',
      },
      "$['name']": {
        source: {
          document: 0,
          path: 2,
          type: 'documentValue',
        },
        type: 'value',
      },
  }
}

const optimisticDataset = [
  {
    _id: getDraftId('462efcc6-3c8b-47c6-8474-5544e1a4acde'),
    // resolves to `_id: 'drafts.462efcc6-3c8b-47c6-8474-5544e1a4acde'`
    name: 'John Doe'
  },
  {
    _id: getVersionId('462efcc6-3c8b-47c6-8474-5544e1a4acde', 'rPRIDE'),
    // resolves to `_id: 'versions.rPRIDE.462efcc6-3c8b-47c6-8474-5544e1a4acde'`
    name: 'John Doe 🏳️‍🌈'
  }
]


const optimisticResult = applySourceDocuments(result, resultSourceMap, get, map, ['drafts'])
// The `optimisticResult` looks like this
const optimisticResult = {
  _id: '462efcc6-3c8b-47c6-8474-5544e1a4acde',
  _originalId: 'drafts.462efcc6-3c8b-47c6-8474-5544e1a4acde',
  name: 'John Doe',
}
const optimisticResult = applySourceDocuments(result, resultSourceMap, get, map, ['rPRIDE','drafts'])
// The `optimisticResult` looks like this
const optimisticResult = {
  _id: '462efcc6-3c8b-47c6-8474-5544e1a4acde',
  _originalId: 'versions.rPRIDE.462efcc6-3c8b-47c6-8474-5544e1a4acde',
  name: 'John Doe 🏳️‍🌈',
}


function get(sourceDocument: ContentSourceMapDocuments[number]) {
  return optimisticDataset.find(document => document._id === sourceDocument._id)
}
function map(changed: unknown) {
  return changed
}
```

## Shouldn't these changes be done as a major version update?
The `applySourceDocuments` utility is used by us in 3 cases:
- `sanity/presentation` [uses it](https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LoaderQueries.tsx#L526-L561) to drive live previews [that depend on `@sanity/core-loader`, like `@sanity/react-loader`](https://www.npmjs.com/browse/depended/@sanity/core-loader)
- `@sanity/preview-kit` [uses it](https://github.com/sanity-io/preview-kit/blob/e7ef115ee52cab8948c6ba5c16fcd22784ed6af3/packages/preview-kit/src/LiveQueryProvider/LiveQueryProvider.tsx#L481-L511), which is what's exposed on `next-sanity/preview` currently.
- `sanity/presentation` [will continue to use it](https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LiveQueries.tsx#L463-L487) when [Sanity Live for draft content](https://www.sanity.io/live) no longer requires `apiVersion: 'vX'`

There's also a [third party library using it](https://github.com/limitless-angular/limitless-angular/blob/c636f505643c10b0b7735fc483c395465e9811e5/packages/sanity/preview-kit/src/live-preview.service.ts#L170-L207), much the same way `@sanity/preview-kit` is.

To these libraries the changes in this PR isn't considered breaking.
Additionally, we've marked the `applySourceDocuments` as `@alpha`, and intentionally not documented it as it's considered to be an internal API that is subject to change in potentially breaking ways within the same major version of the client.
That's why these changes are done as a minor version update instead of a major.

## "Breaking" changes

The 5th argument, the `perspective`, is no longer optional, it used to be `'raw'` by default.
Due to that the 4th argument is also no longer optional, it used to be `(changedValue: unknown) => changedValue` by default.
Libraries that use `applySourceDocuments` already declare the 4th argument:
- https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LoaderQueries.tsx#L552-L559
- https://github.com/sanity-io/preview-kit/blob/e7ef115ee52cab8948c6ba5c16fcd22784ed6af3/packages/preview-kit/src/LiveQueryProvider/LiveQueryProvider.tsx#L500-L509
- https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LiveQueries.tsx#L478-L485
- https://github.com/limitless-angular/limitless-angular/blob/c636f505643c10b0b7735fc483c395465e9811e5/packages/sanity/preview-kit/src/live-preview.service.ts#L193-L204

In addition to now being required, the `perspective` argument no longer allows specifying `raw`.
Supporting `raw` was initially required to give folks an escape hatch if they hit the max number of draft documents limit (1k) that used to apply to `previewDrafts`. [We've since removed this limit](https://www.sanity.io/changelog/aafa1942-9aec-4453-a94f-a32fef056e9c), so there isn't a need to support `raw` any longer.
Libraries haven't used `raw`, an already either hardcode it to `previewDrafts`:
- https://github.com/limitless-angular/limitless-angular/blob/c636f505643c10b0b7735fc483c395465e9811e5/packages/sanity/preview-kit/src/live-preview.service.ts#L205
- https://github.com/limitless-angular/limitless-angular/blob/c636f505643c10b0b7735fc483c395465e9811e5/packages/sanity/preview-kit/src/live-preview.service.ts#L205

Or allowed passthrough of either `published` or `previewDrafts`
- https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LoaderQueries.tsx#L560
- https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LiveQueries.tsx#L486

Libraries that passthrough `perspective`, already disallow `raw`:
- https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LiveQueries.tsx#L460-L462
- https://github.com/sanity-io/sanity/blob/bc1b7c3b9132d9acf772cdcdc0edc8b8d263994f/packages/sanity/src/presentation/loader/LoaderQueries.tsx#L523-L525