### PR TITLE
chore(internal): adds support for resource configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ umd
 # MacOS
 .DS_Store
 tsconfig.vitest-temp.json
+
+# JetBrains stuff
+.idea
+*.iml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "6.28.0",
+  "version": "6.28.0-resources.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -7,7 +7,11 @@ import {_listen} from './data/listen'
 import {LiveClient} from './data/live'
 import {ObservablePatch, Patch} from './data/patch'
 import {ObservableTransaction, Transaction} from './data/transaction'
-import {DatasetsClient, ObservableDatasetsClient} from './datasets/DatasetsClient'
+import {
+  DatasetsClient,
+  ObservableDatasetsClient,
+  ThrowingDatasetsClient,
+} from './datasets/DatasetsClient'
 import {ObservableProjectsClient, ProjectsClient} from './projects/ProjectsClient'
 import type {
   Action,
@@ -756,7 +760,10 @@ export class SanityClient {
     this.#httpRequest = httpRequest
 
     this.assets = new AssetsClient(this, this.#httpRequest)
-    this.datasets = new DatasetsClient(this, this.#httpRequest)
+    this.datasets = this.#clientConfig.experimental_resource
+      ? new ThrowingDatasetsClient(this, this.#httpRequest)
+      : new DatasetsClient(this, this.#httpRequest)
+
     this.live = new LiveClient(this)
     this.projects = new ProjectsClient(this, this.#httpRequest)
     this.users = new UsersClient(this, this.#httpRequest)

--- a/src/assets/AssetsClient.ts
+++ b/src/assets/AssetsClient.ts
@@ -149,7 +149,8 @@ function _upload(
     meta = ['none']
   }
 
-  const dataset = validators.hasDataset(client.config())
+  const config = client.config()
+  const dataset = config.experimental_resource ? undefined : validators.hasDataset(config)
   const assetEndpoint = assetType === 'image' ? 'images' : 'files'
   const options = optionsFromFile(opts, body)
   const {tag, label, title, description, creditLine, filename, source} = options
@@ -170,7 +171,7 @@ function _upload(
     tag,
     method: 'POST',
     timeout: options.timeout || 0,
-    uri: `/assets/${assetEndpoint}/${dataset}`,
+    uri: dataset ? `/assets/${assetEndpoint}/${dataset}` : `/assets/${assetEndpoint}`,
     headers: options.contentType ? {'Content-Type': options.contentType} : {},
     query,
     body,

--- a/src/assets/AssetsClient.ts
+++ b/src/assets/AssetsClient.ts
@@ -150,7 +150,8 @@ function _upload(
   }
 
   const config = client.config()
-  const dataset = config.experimental_resource ? undefined : validators.hasDataset(config)
+  const resource = config.experimental_resource
+  const dataset = resource ? undefined : validators.hasDataset(config)
   const assetEndpoint = assetType === 'image' ? 'images' : 'files'
   const options = optionsFromFile(opts, body)
   const {tag, label, title, description, creditLine, filename, source} = options
@@ -171,7 +172,9 @@ function _upload(
     tag,
     method: 'POST',
     timeout: options.timeout || 0,
-    uri: dataset ? `/assets/${assetEndpoint}/${dataset}` : `/assets/${assetEndpoint}`,
+    uri: resource
+      ? `/assets/${resource.type}/${resource.id}/${assetEndpoint}`
+      : `/assets/${assetEndpoint}/${dataset}`,
     headers: options.contentType ? {'Content-Type': options.contentType} : {},
     query,
     body,

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,25 @@ export const initConfig = (
     ...defaultConfig,
     ...specifiedConfig,
   } as InitializedClientConfig
+
+  const projectId = newConfig.projectId
+
+  //this "feature" is meant for internal Sanity use only. Do not use.
+  if (projectId?.startsWith('resource.')) {
+    const [, resourceType, resourceId] = projectId.split('.')
+    if (resourceType && resourceId) {
+      newConfig.experimental_resource = {
+        type: resourceType,
+        id: resourceId,
+      }
+    }
+  }
+  // resource oriented clients should not use project hostname in base url
+  const experimentalResource = newConfig.experimental_resource
+  if (experimentalResource) {
+    newConfig.useProjectHostname = false
+  }
+
   const projectBased = newConfig.useProjectHostname
 
   if (typeof Promise === 'undefined') {
@@ -166,6 +185,12 @@ export const initConfig = (
   } else {
     newConfig.url = `${newConfig.apiHost}/v${newConfig.apiVersion}`
     newConfig.cdnUrl = newConfig.url
+  }
+
+  if (experimentalResource) {
+    const resourceSuffix = `${experimentalResource.type}/${experimentalResource.id}`
+    newConfig.url = `${newConfig.url}/${resourceSuffix}`
+    newConfig.cdnUrl = `${newConfig.cdnUrl}/${resourceSuffix}`
   }
 
   return newConfig

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -528,7 +528,7 @@ export function _getUrl(
   let base = canUseCdn ? cdnUrl : url
 
   if (experimental_resource) {
-    if (uri.indexOf('/users') !== -1) {
+    if (uri.indexOf('/users') !== -1 || uri.indexOf('/assets') !== -1) {
       base = base.replace(_resourceBase(experimental_resource), '')
     }
   }

--- a/src/datasets/DatasetsClient.ts
+++ b/src/datasets/DatasetsClient.ts
@@ -106,6 +106,28 @@ export class DatasetsClient {
   }
 }
 
+export class ThrowingDatasetsClient extends DatasetsClient {
+  constructor(client: SanityClient, httpRequest: HttpRequest) {
+    super(client, httpRequest)
+  }
+
+  create(): Promise<DatasetResponse> {
+    throw new Error('cannot create dataset with the current client configuration')
+  }
+
+  edit(): Promise<DatasetResponse> {
+    throw new Error('cannot edit dataset with the current client configuration')
+  }
+
+  delete(): Promise<{deleted: true}> {
+    throw new Error('cannot delete dataset with the current client configuration')
+  }
+
+  list(): Promise<DatasetsResponse> {
+    throw new Error('cannot list dataset with the current client configuration')
+  }
+}
+
 function _modify<R = unknown>(
   client: SanityClient | ObservableSanityClient,
   httpRequest: HttpRequest,

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,14 @@ export interface ClientConfig {
    * Options for how, if enabled, Content Source Maps are encoded into query results using steganography
    */
   stega?: StegaConfig | boolean
+
+  /**
+   * @deprecated Don't use
+   */
+  experimental_resource?: {
+    id: string
+    type: string
+  }
 }
 
 /** @public */

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2878,7 +2878,7 @@ describe('client', async () => {
         Buffer.from(body, 'hex').compare(fs.readFileSync(fixturePath)) === 0
 
       nock(`https://${apiHost}`)
-        .post('/v1/resource/res-id/assets/images', isImage)
+        .post('/v1/assets/resource/res-id/images', isImage)
         .reply(201, {document: {url: 'https://some.asset.url'}})
 
       const document = await getClient({


### PR DESCRIPTION
### THIS IS NOT THE BRANCH YOU ARE LOOING FOR

## [THIS IS](https://github.com/sanity-io/client/pull/1040)

Temp branch to explore resource targets in the api.

Current tagged release: 6.28.0-resources.0

See  added unit-tests tests for what I've tested.

## Caveats
Current impl takes `experimental_resource` or `projectId` `resource.r<esourceType>.<resourceId>` (which then sets `experimental_resource` config)

The client then is forced into `useProjectHostname: false`

 Then _all_ requests get /<resourceType>/<resourceId> prepended (urls are changed)

This is probably not what we want for `client.request` that currently use `useProjectHostname`.

