### PR TITLE
feat(listener): add support for includeAllVersions

### DIFF
--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -26,6 +26,7 @@ const possibleOptions = [
   'includePreviousRevision',
   'includeResult',
   'includeMutations',
+  'includeAllVersions',
   'visibility',
   'effectFormat',
   'tag',

--- a/src/types.ts
+++ b/src/types.ts
@@ -927,12 +927,7 @@ export interface ListenOptions {
   includePreviousRevision?: boolean
 
   /**
-   * Whether to include events for drafts and versions. As of API Version >= v2025-02-19, only events
-   * for published documents will be included by default.
-   * If you need events from drafts and versions, set this to `true`.
-   * Note: Keep in mind that additional document variants may be introduced in the future, so it's
-   * recommended to respond to events in a way that's tolerant of potential future variants, e.g. by
-   * explicitly checking whether the event is for a draft or a version.
+   * @internal
    * @defaultValue `false`
    */
   includeAllVersions?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -927,6 +927,17 @@ export interface ListenOptions {
   includePreviousRevision?: boolean
 
   /**
+   * Whether to include events for drafts and versions. As of API Version >= v2025-02-19, only events
+   * for published documents will be included by default.
+   * If you need events from drafts and versions, set this to `true`.
+   * Note: Keep in mind that additional document variants may be introduced in the future, so it's
+   * recommended to respond to events in a way that's tolerant of potential future variants, e.g. by
+   * explicitly checking whether the event is for a draft or a version.
+   * @defaultValue `false`
+   */
+  includeAllVersions?: boolean
+
+  /**
    * Whether events should be sent as soon as a transaction has been committed (`transaction`, default),
    * or only after they are available for queries (query). Note that this is on a best-effort basis,
    * and listeners with `query` may in certain cases (notably with deferred transactions) receive events

--- a/test/listen.test.ts
+++ b/test/listen.test.ts
@@ -83,6 +83,22 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       server.close()
     })
 
+    test('listener sends includeAllVersions=true if given', async () => {
+      expect.assertions(1)
+
+      const {server, client} = await testSse(({request, channel}) => {
+        expect(request.url).toContain('includeAllVersions=true')
+
+        channel!.send({event: 'welcome'})
+      })
+
+      await firstValueFrom(
+        client.listen('*', {}, {events: ['welcome'], includeAllVersions: true}),
+        {defaultValue: null},
+      )
+      server.close()
+    })
+
     test('reconnects if disconnected', async () => {
       expect.assertions(1)
 


### PR DESCRIPTION
Adds support for passing the `includeAllVersions` param to `client.listen()`. Docs TBD