### PR TITLE
fix: lift restriction on release perspective name

### DIFF
--- a/src/csm/resolvePerspectives.ts
+++ b/src/csm/resolvePerspectives.ts
@@ -1,5 +1,5 @@
 import {validateApiPerspective} from '../config'
-import type {ReleaseId} from '../types'
+import type {StackablePerspective} from '../types'
 import type {ClientPerspective} from './types'
 
 /**
@@ -9,7 +9,7 @@ import type {ClientPerspective} from './types'
  */
 export function resolvePerspectives(
   perspective: Exclude<ClientPerspective, 'raw'>,
-): ('published' | 'drafts' | ReleaseId)[] {
+): ('published' | 'drafts' | StackablePerspective)[] {
   validateApiPerspective(perspective)
 
   if (Array.isArray(perspective)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,14 @@ export interface RequestOptions {
   signal?: AbortSignal
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated – The `r`-prefix is not required, use `string` instead
+ */
 export type ReleaseId = `r${string}`
+
+/** @public */
+export type StackablePerspective = ('published' | 'drafts' | string) & {}
 
 /** @public */
 export type ClientPerspective =
@@ -40,7 +46,7 @@ export type ClientPerspective =
   | 'published'
   | 'drafts'
   | 'raw'
-  | ('published' | 'drafts' | ReleaseId)[]
+  | StackablePerspective[]
 
 /** @public */
 export interface ClientConfig {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -177,13 +177,16 @@ describe('client', async () => {
       expect(() => createClient({projectId: 'abc123', perspective: 'raw'})).not.toThrow(
         /Invalid API perspective/,
       )
+      expect(() => createClient({projectId: 'abc123', perspective: undefined})).not.toThrow(
+        /Invalid API perspective/,
+      )
+      // no whitespace allowed
       // @ts-expect-error -- we want to test that it throws an error
       expect(() => createClient({projectId: 'abc123', perspective: 'preview drafts'})).toThrow(
         /Invalid API perspective/,
       )
 
-      // valid because it begins with `r`
-      const validReleaseIdentifier = 'rfoobar'
+      const validReleaseIdentifier = 'foobar'
       expect(() =>
         createClient({
           projectId: 'abc123',
@@ -191,16 +194,17 @@ describe('client', async () => {
         }),
       ).not.toThrow(/Invalid API perspective/)
 
-      // special case – "raw" would be a valid release id given that it starts with ´r`
-      // but 'raw' is not possible to use with multiple perspectives and is explicitly
+      expect(() =>
+        createClient({
+          projectId: 'abc123',
+          perspective: ['published', 'drafts', 'this is not valid'],
+        }),
+      ).toThrow(/Invalid API perspective/)
+
+      // special case – 'raw' can not be combined with multiple perspectives and is explicitly
       // banned by the backend
       expect(() =>
         createClient({projectId: 'abc123', perspective: ['published', 'drafts', 'raw']}),
-      ).toThrow(/Invalid API perspective/)
-
-      expect(() =>
-        // @ts-expect-error -- we want to test that it throws an error
-        createClient({projectId: 'abc123', perspective: ['XyzAbC']}),
       ).toThrow(/Invalid API perspective/)
     })
 


### PR DESCRIPTION
We previously had a requirement on release perspectives that their names had to start with `r`. This restriction is no longer enforced on the backend, so it should not be required in the client either.

Note: the test failure is most likely unrelated and caused by flake. Have noticed it on PRs without code changes as well.