### PR TITLE
fix: deprecate `previewDrafts`-perspective in favor of `drafts`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,12 +37,17 @@ export interface RequestOptions {
  */
 export type ReleaseId = `r${string}`
 
+/**
+ * @deprecated use 'drafts' instead
+ */
+type DeprecatedPreviewDrafts = 'previewDrafts'
+
 /** @public */
 export type StackablePerspective = ('published' | 'drafts' | string) & {}
 
 /** @public */
 export type ClientPerspective =
-  | 'previewDrafts'
+  | DeprecatedPreviewDrafts
   | 'published'
   | 'drafts'
   | 'raw'

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -18,8 +18,12 @@ export const printCdnWarning = createWarningPrinter([
 ])
 
 export const printCdnPreviewDraftsWarning = createWarningPrinter([
-  `The Sanity client is configured with the \`perspective\` set to \`previewDrafts\`, which doesn't support the API-CDN.`,
+  `The Sanity client is configured with the \`perspective\` set to \`drafts\` or \`previewDrafts\`, which doesn't support the API-CDN.`,
   `The Live API will be used instead. Set \`useCdn: false\` in your configuration to hide this warning.`,
+])
+
+export const printPreviewDraftsDeprecationWarning = createWarningPrinter([
+  `The \`previewDrafts\` perspective has been renamed to  \`drafts\` and will be removed in a future API version`,
 ])
 
 export const printBrowserTokenWarning = createWarningPrinter([


### PR DESCRIPTION
The `previewDrafts`-perspective has been renamed to `drafts`. This change already in effect on all API versions that supports perspectives (>=v2021-03-25).

This PR marks usage of `previewDrafts` as deprecated by:
- Printing a console warning if `previewDrafts` is used as value for `perspective`
- Updating readme examples previously using `previewDrafts` to now use `drafts`

In addition, the readme slightly prepares for an upcoming change by adding a separate section for the `raw` perspective, which previously has been assumed.

Note: CI failure is unrelated and due to flake