### PR TITLE
chore: actually solve edge runtime flake

### DIFF
--- a/test/stega/client.test.ts
+++ b/test/stega/client.test.ts
@@ -261,41 +261,36 @@ describe('@sanity/client', () => {
       ).not.toThrow()
     })
   })
-  describe('client.fetch', async () => {
+  describe.skipIf(typeof EdgeRuntime === 'string')('client.fetch', async () => {
     const client = createClient(clientConfig)
-    const isEdge = typeof EdgeRuntime === 'string'
-    let nock: typeof import('nock') = (() => {
-      throw new Error('Not supported in EdgeRuntime')
-    }) as any
-    if (!isEdge) {
-      const _nock = await import('nock')
-      nock = _nock.default
+    const nock = (await import('nock')).default
 
-      nock(projectHost())
-        .get(`/v1/data/query/foo?query=*`)
-        .reply(200, {ms: 123, query: '*', result: []})
-    }
+    nock(projectHost())
+      .get(`/v1/data/query/foo?query=*`)
+      .reply(200, {ms: 123, query: '*', result: []})
 
-    test('allows passing stega: undefined', () => {
-      expect(() =>
-        client.fetch(
-          '*',
-          {},
-          {
-            stega: undefined,
-          },
-        ),
+    test('allows passing stega: undefined', async () => {
+      await expect(
+        async () =>
+          await client.fetch(
+            '*',
+            {},
+            {
+              stega: undefined,
+            },
+          ),
       ).not.toThrow()
     })
-    test('allows passing stega: false', () => {
-      expect(() =>
-        client.fetch(
-          '*',
-          {},
-          {
-            stega: false,
-          },
-        ),
+    test('allows passing stega: false', async () => {
+      await expect(
+        async () =>
+          await client.fetch(
+            '*',
+            {},
+            {
+              stega: false,
+            },
+          ),
       ).not.toThrow()
     })
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,21 @@
 // This is the default config, runs with Node.js globals and doesn't require `npm run build` before executing tests
 
-import {configDefaults, defineConfig, type ViteUserConfig} from 'vitest/config'
+import {configDefaults, defineConfig} from 'vitest/config'
 
 import pkg from './package.json'
 
-export const sharedConfig: ViteUserConfig['test'] = {
-  // don't use vitest to run Bun and Deno tests
-  exclude: [...configDefaults.exclude, 'runtimes/**', 'test-next/**'],
-  // Allow switching test runs from using the source TS or compiled ESM
-  alias: {
-    '@sanity/client/csm': new URL(pkg.exports['./csm'].source, import.meta.url).pathname,
-    '@sanity/client/stega': new URL(pkg.exports['./stega'].source, import.meta.url).pathname,
-    '@sanity/client': new URL(pkg.exports['.'].source, import.meta.url).pathname,
-  },
-  typecheck: {
-    enabled: true,
-  },
-}
-
 export default defineConfig({
-  test: sharedConfig,
+  test: {
+    // don't use vitest to run Bun and Deno tests
+    exclude: [...configDefaults.exclude, 'runtimes/**', 'test-next/**'],
+    // Allow switching test runs from using the source TS or compiled ESM
+    alias: {
+      '@sanity/client/csm': new URL(pkg.exports['./csm'].source, import.meta.url).pathname,
+      '@sanity/client/stega': new URL(pkg.exports['./stega'].source, import.meta.url).pathname,
+      '@sanity/client': new URL(pkg.exports['.'].source, import.meta.url).pathname,
+    },
+    typecheck: {
+      enabled: true,
+    },
+  },
 })

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,26 +1,28 @@
 // Simulates a browser environment until `@vitest/browser` is ready for production and
 // we can run the tests in a real browser
 
-import {defineConfig} from 'vitest/config'
+import {defineConfig, mergeConfig} from 'vitest/config'
 
 import pkg from './package.json'
-import {sharedConfig} from './vite.config'
+import viteConfig from './vite.config'
 
-export default defineConfig({
-  test: {
-    ...sharedConfig,
-    environment: 'happy-dom',
-    alias: {
-      '@sanity/client/csm': new URL(pkg.exports['./csm'].source, import.meta.url).pathname,
-      '@sanity/client/stega': new URL(pkg.exports['./stega'].browser.source, import.meta.url)
-        .pathname,
-      '@sanity/client': new URL(pkg.exports['.'].browser.source, import.meta.url).pathname,
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'happy-dom',
+      alias: {
+        '@sanity/client/csm': new URL(pkg.exports['./csm'].source, import.meta.url).pathname,
+        '@sanity/client/stega': new URL(pkg.exports['./stega'].browser.source, import.meta.url)
+          .pathname,
+        '@sanity/client': new URL(pkg.exports['.'].browser.source, import.meta.url).pathname,
+      },
+      typecheck: {
+        enabled: false,
+      },
     },
-    typecheck: {
-      enabled: false,
+    resolve: {
+      conditions: ['browser', 'module', 'import'],
     },
-  },
-  resolve: {
-    conditions: ['browser', 'module', 'import'],
-  },
-})
+  }),
+)

--- a/vitest.edge.config.ts
+++ b/vitest.edge.config.ts
@@ -1,27 +1,29 @@
 // Run tests in the Vercel Edge Runtime, and using its resolution algorithm that
 // chooses worker exports if they exist, if not it tries to look for browser exports.
 
-import {defineConfig} from 'vitest/config'
+import {defineConfig, mergeConfig} from 'vitest/config'
 
 import pkg from './package.json'
-import {sharedConfig} from './vite.config'
+import viteConfig from './vite.config'
 
-export default defineConfig({
-  test: {
-    ...sharedConfig,
-    environment: 'edge-runtime',
-    alias: {
-      '@sanity/client/csm': new URL(pkg.exports['./csm'].source, import.meta.url).pathname,
-      '@sanity/client/stega': new URL(pkg.exports['./stega'].browser.source, import.meta.url)
-        .pathname,
-      '@sanity/client': new URL(pkg.exports['.'].browser.source, import.meta.url).pathname,
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'edge-runtime',
+      alias: {
+        '@sanity/client/csm': new URL(pkg.exports['./csm'].source, import.meta.url).pathname,
+        '@sanity/client/stega': new URL(pkg.exports['./stega'].browser.source, import.meta.url)
+          .pathname,
+        '@sanity/client': new URL(pkg.exports['.'].browser.source, import.meta.url).pathname,
+      },
+      typecheck: {
+        enabled: false,
+      },
     },
-    typecheck: {
-      enabled: false,
+    resolve: {
+      // https://github.com/vercel/next.js/blob/95322649ffb2ad0d6423481faed188dd7b1f7ff2/packages/next/src/build/webpack-config.ts#L1079-L1084
+      conditions: ['edge-light', 'worker', 'browser', 'module', 'import', 'node'],
     },
-  },
-  resolve: {
-    // https://github.com/vercel/next.js/blob/95322649ffb2ad0d6423481faed188dd7b1f7ff2/packages/next/src/build/webpack-config.ts#L1079-L1084
-    conditions: ['edge-light', 'worker', 'browser', 'module', 'import', 'node'],
-  },
-})
+  }),
+)

--- a/vitest.next.config.ts
+++ b/vitest.next.config.ts
@@ -1,18 +1,20 @@
 // Runs typecheck tests with Next.js App Router typings for fetch `cache`, `next.revalidate` and `next.tags` typings
 
-import {configDefaults, defineConfig} from 'vitest/config'
+import {configDefaults, defineConfig, mergeConfig} from 'vitest/config'
 
-import {sharedConfig} from './vite.config'
+import viteConfig from './vite.config'
 
-export default defineConfig({
-  test: {
-    ...sharedConfig,
-    // Only run tests in the text-next directory
-    exclude: [...configDefaults.exclude, 'runtimes/**', 'test/**'],
-    typecheck: {
-      enabled: true,
-      tsconfig: 'test-next/tsconfig.json',
-      exclude: ['test/**'],
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      // Only run tests in the text-next directory
+      exclude: [...configDefaults.exclude, 'runtimes/**', 'test/**'],
+      typecheck: {
+        enabled: true,
+        tsconfig: 'test-next/tsconfig.json',
+        exclude: ['test/**'],
+      },
     },
-  },
-})
+  }),
+)


### PR DESCRIPTION
Seems like a couple of tests have always either failed silently, or failed hard.
By always skipping over them (since nock doesn't work in the edge runtime) the flake is finally gone.