### PR TITLE
fix(docs): invalid changelog url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const requester = exp.requester
 
 /**
  * @remarks
- * As of API version `v2025-02-19`, the default perspective used by the client has changed from `raw` to `published`. {@link https://www.sanity.io/changelog/e93a2d5a-9cee-4801-829e-8d3394bfed85|Changelog}
+ * As of API version `v2025-02-19`, the default perspective used by the client has changed from `raw` to `published`. {@link https://www.sanity.io/changelog/676aaa9d-2da6-44fb-abe5-580f28047c10|Changelog}
  * @public
  */
 export const createClient = exp.createClient

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface ClientConfig {
   /**
    * What perspective to use for the client. See {@link https://www.sanity.io/docs/perspectives|perspective documentation}
    * @remarks
-   * As of API version `v2025-02-19`, the default perspective has changed from `raw` to `published`. {@link https://www.sanity.io/changelog/e93a2d5a-9cee-4801-829e-8d3394bfed85|Changelog}
+   * As of API version `v2025-02-19`, the default perspective has changed from `raw` to `published`. {@link https://www.sanity.io/changelog/676aaa9d-2da6-44fb-abe5-580f28047c10|Changelog}
    * @defaultValue 'published'
    */
   perspective?: ClientPerspective
@@ -72,7 +72,7 @@ export interface ClientConfig {
 
   /**
    @remarks
-   * As of API version `v2025-02-19`, the default perspective has changed from `raw` to `published`. {@link https://www.sanity.io/changelog/e93a2d5a-9cee-4801-829e-8d3394bfed85|Changelog}
+   * As of API version `v2025-02-19`, the default perspective has changed from `raw` to `published`. {@link https://www.sanity.io/changelog/676aaa9d-2da6-44fb-abe5-580f28047c10|Changelog}
    */
   apiVersion?: string
   proxy?: string
@@ -944,7 +944,7 @@ export interface ListenOptions {
 
   /**
    * Whether to include events for drafts and versions. As of API Version >= v2025-02-19, only events
-   * for published documents will be included by default (see {@link https://www.sanity.io/changelog/e93a2d5a-9cee-4801-829e-8d3394bfed85|Changelog})
+   * for published documents will be included by default (see {@link https://www.sanity.io/changelog/676aaa9d-2da6-44fb-abe5-580f28047c10|Changelog})
    * If you need events from drafts and versions, set this to `true`.
    * Note: Keep in mind that additional document variants may be introduced in the future, so it's
    * recommended to respond to events in a way that's tolerant of potential future variants, e.g. by


### PR DESCRIPTION
This pull request corrects the URL to the changelog for the default perspective change.