### PR TITLE
fix: remove client side validation of api perspective

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,30 +28,15 @@ function validateApiVersion(apiVersion: string) {
   }
 }
 
-const VALID_PERSPECTIVE = /^[a-z0-9_]+$/i
-
 /**
  * @internal - it may have breaking changes in any release
  */
 export function validateApiPerspective(
   perspective: unknown,
 ): asserts perspective is ClientPerspective {
-  if (Array.isArray(perspective)) {
-    if (perspective.includes('raw')) {
-      throw new TypeError(
-        `Invalid API perspective value: "raw". The raw-perspective can not be combined with other perspectives`,
-      )
-    }
-  }
-
-  const invalid = (Array.isArray(perspective) ? perspective : [perspective]).filter(
-    (perspectiveName) =>
-      typeof perspectiveName !== 'string' || !VALID_PERSPECTIVE.test(perspectiveName),
-  )
-  if (invalid.length > 0) {
-    const formatted = invalid.map((v) => JSON.stringify(v))
+  if (Array.isArray(perspective) && perspective.length > 1 && perspective.includes('raw')) {
     throw new TypeError(
-      `Invalid API perspective value${invalid.length === 1 ? '' : 's'}: ${formatted.join(', ')}, expected \`published\`, \`drafts\`, \`raw\` or a release identifier string`,
+      `Invalid API perspective value: "raw". The raw-perspective can not be combined with other perspectives`,
     )
   }
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -180,12 +180,6 @@ describe('client', async () => {
       expect(() => createClient({projectId: 'abc123', perspective: undefined})).not.toThrow(
         /Invalid API perspective/,
       )
-      // no whitespace allowed
-      // @ts-expect-error -- we want to test that it throws an error
-      expect(() => createClient({projectId: 'abc123', perspective: 'preview drafts'})).toThrow(
-        /Invalid API perspective/,
-      )
-
       const validReleaseIdentifier = 'foobar'
       expect(() =>
         createClient({
@@ -193,13 +187,6 @@ describe('client', async () => {
           perspective: ['published', 'drafts', validReleaseIdentifier],
         }),
       ).not.toThrow(/Invalid API perspective/)
-
-      expect(() =>
-        createClient({
-          projectId: 'abc123',
-          perspective: ['published', 'drafts', 'this is not valid'],
-        }),
-      ).toThrow(/Invalid API perspective/)
 
       // special case – 'raw' can not be combined with multiple perspectives and is explicitly
       // banned by the backend


### PR DESCRIPTION
This removes our client side validation of release ids passed in the perspective array. Although it provides a slight education opportunity, and might help with debugging, it's probably better to leave this validation to the server, if we want it at all.