### PR TITLE
fix: do not set `withCredentials` if token is set

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -122,7 +122,13 @@ export const initConfig = (
   const isBrowser = typeof window !== 'undefined' && window.location && window.location.hostname
   const isLocalhost = isBrowser && isLocal(window.location.hostname)
 
-  if (isBrowser && isLocalhost && newConfig.token && newConfig.ignoreBrowserTokenWarning !== true) {
+  const hasToken = Boolean(newConfig.token)
+  if (newConfig.withCredentials && hasToken) {
+    warnings.printCredentialedTokenWarning()
+    newConfig.withCredentials = false
+  }
+
+  if (isBrowser && isLocalhost && hasToken && newConfig.ignoreBrowserTokenWarning !== true) {
     warnings.printBrowserTokenWarning()
   } else if (typeof newConfig.useCdn === 'undefined') {
     warnings.printCdnWarning()

--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -84,7 +84,7 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
   const listenFor = options.events ? options.events : ['mutation']
 
   const esOptions: EventSourceInit & {headers?: Record<string, string>} = {}
-  if (token || withCredentials) {
+  if (withCredentials) {
     esOptions.withCredentials = true
   }
 

--- a/src/http/requestOptions.ts
+++ b/src/http/requestOptions.ts
@@ -18,7 +18,7 @@ export function requestOptions(config: Any, overrides: Any = {}): Omit<RequestOp
 
   const withCredentials = Boolean(
     typeof overrides.withCredentials === 'undefined'
-      ? config.token || config.withCredentials
+      ? config.withCredentials
       : overrides.withCredentials,
   )
 

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -33,6 +33,11 @@ export const printBrowserTokenWarning = createWarningPrinter([
   )} for more information and how to hide this warning.`,
 ])
 
+export const printCredentialedTokenWarning = createWarningPrinter([
+  'You have configured Sanity client to use a token, but also provided `withCredentials: true`.',
+  'This is no longer supported - only token will be used - remove `withCredentials: true`.',
+])
+
 export const printNoApiVersionSpecifiedWarning = createWarningPrinter([
   'Using the Sanity client without specifying an API version is deprecated.',
   `See ${generateHelpUrl('js-client-api-version')}`,

--- a/test/warnings.test.ts
+++ b/test/warnings.test.ts
@@ -29,6 +29,25 @@ describe('Client config warnings', async () => {
     global.window = restoreWindow
   })
 
+  test('warns if both token and `withCredentials` is set', () => {
+    const client = createClient({
+      projectId: 'abc123',
+      dataset: 'bar',
+      useCdn: false,
+      token: 'abc123',
+      withCredentials: true,
+      apiVersion: '1',
+    })
+    expect(warn).toHaveBeenCalledWith(
+      'You have configured Sanity client to use a token, but also provided `withCredentials: true`. This is no longer supported - only token will be used - remove `withCredentials: true`.',
+    )
+
+    expect(client.config()).toMatchObject({
+      token: 'abc123',
+      withCredentials: false,
+    })
+  })
+
   test.skipIf(isEdge)('warns if server sends warning back', async () => {
     expect.assertions(1)
 


### PR DESCRIPTION
If the user has a cookie _and_ sets a token, we end up sending both. This can be confusing, as it is not clear which one will actually be used.

With this PR, we warn if both options are provided, and favor the token (as this is the current behavior - token is used instead of cookie on the server side).
