### PR TITLE
feat: add experimental support for resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/client",
-  "version": "6.28.4",
+  "version": "6.28.4-resources.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/client",
-      "version": "6.28.4",
+      "version": "6.28.4-resources.4",
       "license": "MIT",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,7 @@ export const initConfig = (
     ...defaultConfig,
     ...specifiedConfig,
   } as InitializedClientConfig
-  const projectBased = newConfig.useProjectHostname
+  const projectBased = newConfig.useProjectHostname && !newConfig['~experimental_resource']
 
   if (typeof Promise === 'undefined') {
     const helpUrl = generateHelpUrl('js-client-promise-polyfill')
@@ -72,6 +72,10 @@ export const initConfig = (
 
   if (projectBased && !newConfig.projectId) {
     throw new Error('Configuration must contain `projectId`')
+  }
+
+  if (newConfig['~experimental_resource']) {
+    validate.resourceConfig(newConfig)
   }
 
   if (typeof newConfig.perspective !== 'undefined') {
@@ -151,7 +155,7 @@ export const initConfig = (
   const host = hostParts[1]
   const cdnHost = newConfig.isDefaultApi ? defaultCdnHost : host
 
-  if (newConfig.useProjectHostname) {
+  if (projectBased) {
     newConfig.url = `${protocol}://${newConfig.projectId}.${host}/v${newConfig.apiVersion}`
     newConfig.cdnUrl = `${protocol}://${newConfig.projectId}.${cdnHost}/v${newConfig.apiVersion}`
   } else {

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -12,6 +12,7 @@ import type {
   SyncTag,
 } from '../types'
 import {shareReplayLatest} from '../util/shareReplayLatest'
+import * as validate from '../validators'
 import {_getDataUrl} from './dataMethods'
 import {connectEventSource} from './eventsource'
 import {eventSourcePolyfill} from './eventsourcePolyfill'
@@ -43,6 +44,7 @@ export class LiveClient {
      */
     tag?: string
   } = {}): Observable<LiveEvent> {
+    validate.resourceGuard('live', this.#client.config())
     const {
       projectId,
       apiVersion: _apiVersion,

--- a/src/datasets/DatasetsClient.ts
+++ b/src/datasets/DatasetsClient.ts
@@ -70,6 +70,7 @@ export class DatasetsClient {
    * @param options - Options for the dataset
    */
   create(name: string, options?: {aclMode?: DatasetAclMode}): Promise<DatasetResponse> {
+    validate.resourceGuard('dataset', this.#client.config())
     return lastValueFrom(
       _modify<DatasetResponse>(this.#client, this.#httpRequest, 'PUT', name, options),
     )
@@ -82,6 +83,7 @@ export class DatasetsClient {
    * @param options - New options for the dataset
    */
   edit(name: string, options?: {aclMode?: DatasetAclMode}): Promise<DatasetResponse> {
+    validate.resourceGuard('dataset', this.#client.config())
     return lastValueFrom(
       _modify<DatasetResponse>(this.#client, this.#httpRequest, 'PATCH', name, options),
     )
@@ -93,6 +95,7 @@ export class DatasetsClient {
    * @param name - Name of the dataset to delete
    */
   delete(name: string): Promise<{deleted: true}> {
+    validate.resourceGuard('dataset', this.#client.config())
     return lastValueFrom(_modify<{deleted: true}>(this.#client, this.#httpRequest, 'DELETE', name))
   }
 
@@ -100,6 +103,7 @@ export class DatasetsClient {
    * Fetch a list of datasets for the configured project
    */
   list(): Promise<DatasetsResponse> {
+    validate.resourceGuard('dataset', this.#client.config())
     return lastValueFrom(
       _request<DatasetsResponse>(this.#client, this.#httpRequest, {uri: '/datasets', tag: null}),
     )
@@ -113,6 +117,7 @@ function _modify<R = unknown>(
   name: string,
   options?: {aclMode?: DatasetAclMode},
 ) {
+  validate.resourceGuard('dataset', client.config())
   validate.dataset(name)
   return _request<R>(client, httpRequest, {
     method,

--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -3,6 +3,7 @@ import {lastValueFrom, type Observable} from 'rxjs'
 import {_request} from '../data/dataMethods'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import type {HttpRequest, SanityProject} from '../types'
+import * as validate from '../validators'
 
 /** @internal */
 export class ObservableProjectsClient {
@@ -24,6 +25,7 @@ export class ObservableProjectsClient {
   list(options?: {
     includeMembers?: boolean
   }): Observable<SanityProject[] | Omit<SanityProject, 'members'>[]> {
+    validate.resourceGuard('projects', this.#client.config())
     const uri = options?.includeMembers === false ? '/projects?includeMembers=false' : '/projects'
     return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri})
   }
@@ -34,6 +36,7 @@ export class ObservableProjectsClient {
    * @param projectId - ID of the project to fetch
    */
   getById(projectId: string): Observable<SanityProject> {
+    validate.resourceGuard('projects', this.#client.config())
     return _request<SanityProject>(this.#client, this.#httpRequest, {uri: `/projects/${projectId}`})
   }
 }
@@ -56,6 +59,7 @@ export class ProjectsClient {
   list(options?: {includeMembers?: true}): Promise<SanityProject[]>
   list(options?: {includeMembers?: false}): Promise<Omit<SanityProject, 'members'>[]>
   list(options?: {includeMembers?: boolean}): Promise<SanityProject[]> {
+    validate.resourceGuard('projects', this.#client.config())
     const uri = options?.includeMembers === false ? '/projects?includeMembers=false' : '/projects'
     return lastValueFrom(_request<SanityProject[]>(this.#client, this.#httpRequest, {uri}))
   }
@@ -66,6 +70,7 @@ export class ProjectsClient {
    * @param projectId - ID of the project to fetch
    */
   getById(projectId: string): Promise<SanityProject> {
+    validate.resourceGuard('projects', this.#client.config())
     return lastValueFrom(
       _request<SanityProject>(this.#client, this.#httpRequest, {uri: `/projects/${projectId}`}),
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,24 @@ export type ClientPerspective =
   | 'raw'
   | StackablePerspective[]
 
+type ClientConfigResource =
+  | {
+      type: 'canvas'
+      id: string
+    }
+  | {
+      type: 'media-library'
+      id: string
+    }
+  | {
+      type: 'dataset'
+      id: string
+    }
+  | {
+      type: 'dashboard'
+      id: string
+    }
+
 /** @public */
 export interface ClientConfig {
   projectId?: string
@@ -60,6 +78,9 @@ export interface ClientConfig {
   /** @defaultValue true */
   useCdn?: boolean
   token?: string
+
+  /** @internal */
+  '~experimental_resource'?: ClientConfigResource
 
   /**
    * What perspective to use for the client. See {@link https://www.sanity.io/docs/perspectives|perspective documentation}

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -76,3 +76,34 @@ export const requestTag = (tag: string) => {
 
   return tag
 }
+
+export const resourceConfig = (config: InitializedClientConfig): void => {
+  if (!config['~experimental_resource']) {
+    throw new Error('`resource` must be provided to perform resource queries')
+  }
+  const {type, id} = config['~experimental_resource']
+
+  switch (type) {
+    case 'dataset': {
+      const segments = id.split('.')
+      if (segments.length !== 2) {
+        throw new Error('Dataset resource ID must be in the format "project.dataset"')
+      }
+      return
+    }
+    case 'dashboard':
+    case 'media-library':
+    case 'canvas': {
+      return
+    }
+    default:
+      // @ts-expect-error - handle all supported resource types
+      throw new Error(`Unsupported resource type: ${type.toString()}`)
+  }
+}
+
+export const resourceGuard = (service: string, config: InitializedClientConfig): void => {
+  if (config['~experimental_resource']) {
+    throw new Error(`\`${service}\` does not support resource-based operations`)
+  }
+}


### PR DESCRIPTION
TL;DR:
Add support for resource data requests

Changes:
* Adds new optional config parameter `~experimental_resource`
* Uses `~` to get lower priority in IDEs
* Is mainly to configure access to data endpoints for resources
* Will throw an error if used with mgmt APIs, also dataset assets aren't available as a resource yet.