### PR TITLE
fix: only allow non-nullable values in search params

### DIFF
--- a/src/data/encodeQueryString.ts
+++ b/src/data/encodeQueryString.ts
@@ -18,7 +18,7 @@ export const encodeQueryString = ({
 
   // Iterate params, the keys are prefixed with `$` and their values JSON stringified
   for (const [key, value] of Object.entries(params)) {
-    searchParams.append(`$${key}`, JSON.stringify(value))
+    if (value !== undefined) searchParams.append(`$${key}`, JSON.stringify(value))
   }
   // Options are passed as-is
   for (const [key, value] of Object.entries(opts)) {

--- a/test/encodeQueryString.test.ts
+++ b/test/encodeQueryString.test.ts
@@ -43,9 +43,7 @@ test('can encode null nested values', () => {
   )
 })
 
-// eslint-disable-next-line no-warning-comments
-// @TODO handled in https://github.com/sanity-io/client/pull/1043
-test.skip('skips encoding undefined params', () => {
+test('skips encoding undefined params', () => {
   const query = '*[defined(slug.current) && slug.current == $slug]'
   expect(encodeQueryString({query, params: {slug: undefined}})).toEqual(
     '?query=*%5Bdefined%28slug.current%29+%26%26+slug.current+%3D%3D+%24slug%5D',


### PR DESCRIPTION
Sanity Client accepts both nullable and non-nullable search parameters. Due to the fact that our API rejects values that are `undefined`, it is best that we filter them out and thus only allow nun-nullable values.