### PR TITLE
chore: sapp 2454 release version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,8 @@ export async function updateDocumentTitle(_id, title) {
     - [Action options](#action-options)
     - [Create Action](#create-action)
     - [Delete Action](#delete-action)
-    - [Discard Action](#discard-action)
     - [Edit Action](#edit-action)
     - [Publish Action](#publish-action)
-    - [ReplaceDraft Action](#replacedraft-action)
     - [Unpublish Action](#unpublish-action)
     - [Version actions](#version-actions)
       - [Create Version Action](#create-version)
@@ -1458,27 +1456,6 @@ client
   })
 ```
 
-#### Discard Action
-
-A draft document can be deleted by specifying a discard action type:
-
-```js
-client
-  .action(
-    {
-      actionType: 'sanity.action.document.discard',
-      draftId: 'draft.bike-123',
-    },
-    actionOptions,
-  )
-  .then(() => {
-    console.log('Bike draft deleted')
-  })
-  .catch((err) => {
-    console.error('Discard failed: ', err.message)
-  })
-```
-
 #### Edit Action
 
 A patch can be applied to an existing document draft or create a new one by specifying an edit action type:
@@ -1522,28 +1499,6 @@ client
   })
   .catch((err) => {
     console.error('Publish draft failed: ', err.message)
-  })
-```
-
-#### ReplaceDraft Action
-
-An existing document draft can be deleted and replaced by a new one by specifying a replaceDraft action type:
-
-```js
-client
-  .action(
-    {
-      actionType: 'sanity.action.document.replaceDraft',
-      publishedId: 'bike-123',
-      attributes: {name: 'Sanity Tandem Extraordinaire', _type: 'bike', seats: 1},
-    },
-    actionOptions,
-  )
-  .then(() => {
-    console.log('Bike draft replaced')
-  })
-  .catch((err) => {
-    console.error('Replace draft failed: ', err.message)
   })
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ export async function updateDocumentTitle(_id, title) {
   - [Delete documents](#delete-documents)
   - [Multiple mutations in a transaction](#multiple-mutations-in-a-transaction)
   - [Clientless patches \& transactions](#clientless-patches--transactions)
+  - [Release and version operations](#release-and-version-operations)
   - [Uploading assets](#uploading-assets)
     - [Examples: Uploading assets from Node.js](#examples-uploading-assets-from-nodejs)
     - [Examples: Uploading assets from the Browser](#examples-uploading-assets-from-the-browser)
@@ -111,6 +112,20 @@ export async function updateDocumentTitle(_id, title) {
     - [Publish Action](#publish-action)
     - [ReplaceDraft Action](#replacedraft-action)
     - [Unpublish Action](#unpublish-action)
+    - [Version actions](#version-actions)
+      - [Create Version Action](#create-version)
+      - [Discard Version Action](#discard-version)
+      - [Replace Version Action](#replace-version)
+      - [Unpublish Version Action](#unpublish-action)
+    - [Release Actions](#release-actions)
+      - [Create Release Action](#create-release)
+      - [Edit Release Action](#edit-release)
+      - [Published Release Action](#publish-release)
+      - [Schedule Release Action](#schedule-release)
+      - [Unschedule Release Action](#unarchive-release)
+      - [Archive Release Action](#archive-release)
+      - [Unarchive Release Action](#unarchive-release)
+      - [Delete Release Action](#delete-release)
 - [License](#license)
 - [From `v5`](#from-v5)
   - [The default `useCdn` is changed to `true`](#the-default-usecdn-is-changed-to-true)
@@ -1284,6 +1299,106 @@ client.mutate(transaction)
 
 An important note on this approach is that you cannot call `commit()` on transactions or patches instantiated this way, instead you have to pass them to `client.mutate()`
 
+### Release and version operations
+
+Release and version actions can be taken directly using the client's [actions API](#version-actions). Additionally, helper methods are provided which abstract some esoteric nomenclature with the release and version processing.
+
+0. Setup the client
+```js
+import {createClient} from '@sanity/client'
+
+const client = createClient({
+  projectId: 'your-project-id',
+  dataset: 'bikeshop',
+})
+```
+
+1. Create a new release
+```js
+const {releaseId} = client.release.create({
+  metadata: {
+    title: 'New bike drop'
+    releaseType: 'scheduled'
+  }
+})
+```
+
+2. Create a new document into the release
+```js
+client.createVersion({
+  document: {
+    _type: 'bike',
+    name: 'Upgraded black bike'
+  },
+  releaseId,
+  publishedId: 'bike-123'
+})
+```
+
+3. Mark a document to be unpublished when the release is run
+```js
+client.unpublishVersion({
+  publishedId: 'old-red-bike',
+  releaseId
+})
+```
+
+4. List the release and all the documents within the release
+```js
+const newBikesRelease = client.releases.get({releaseId})
+/**
+ * {
+ *   _type: 'system.release',
+ *   _id: '_.releases.releaseId',
+ *   name: 'releaseId',
+ *   state: 'active',
+ *   metadata: {
+ *     name: 'New bike drop',
+ *     releaseType: 'scheduled'
+ *   }
+ * }
+ */
+
+const releaseDocuments = client.releases.getDocuments({
+  releaseId
+})
+
+/**
+ * Returns a list of documents eg.
+ * 
+ * [{
+ *   _type: 'bike',
+ *   _id: 'versions.releaseId.bike-123',
+ *   name: 'Upgraded black bike',
+ *   ...
+ * },
+ * {
+ *   _type: 'bike',
+ *   _id: 'versions.releaseId.old-red-bike',
+ *   _system: {
+ *     delete: true
+ * }
+ * }]
+ */
+```
+
+5. Schedule the release (to run in 1 hours time)
+```js
+client.release.schedule({
+  releaseId,
+  publishAt: new Date(Date.now() + 3600000).toISOString()
+})
+```
+
+6. After the release has run, check and delete the release
+```js
+const runRelease = await client.releases.get({releaseId})
+
+if (runRelease.state === 'published' && !runRelease.error) {
+  client.releases.delete({releaseId})
+}
+```
+
 ### Actions
 
 The Actions API provides a new interface for creating, updating and publishing documents. It is a wrapper around the [Actions API](https://www.sanity.io/docs/http-actions).
@@ -1452,6 +1567,211 @@ client
   .catch((err) => {
     console.error('Unpublish draft failed: ', err.message)
   })
+```
+
+## Version actions
+### Create version
+Create a draft or release version of a published document.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.document.version.create',
+    publishedId: 'bike-123',
+    document: {
+      _id: 'versions.new-bike-release.bike-123'
+      _type: 'bike'
+    }
+  }
+).then(() => {
+  console.log('Copy of published `bike-123` created in release `new-bike-release`')
+}).catch((err) => {
+  console.error('Create version failed: ', err.message)
+})
+```
+> [!NOTE]
+> Replacing `versions.<releaseId>` with `drafts` will create a new draft version from the published document.
+
+### Discard version
+Discard a draft or release version.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.document.version.discard',
+    versionId: 'versions.new-bike-release.bike-123'
+  }
+).then(() => {
+  console.log('Discarded the version of `bike-123` within the `new-bike-release` release')
+}).catch((err) => {
+  console.error('Discard version failed: ', err.message)
+})
+```
+
+### Replace version
+Replaces the contents of an existing draft or release version document.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.document.version.replace',
+    document: {
+      _id: 'versions.new-bike-release.bike-123',
+      color: 'red',
+      _type: 'bike'
+    }
+  }
+).then(() => {
+  console.log('Replaced the existing `bike-123` document within the `new-bike-release` release')
+}).catch((err) => {
+  console.error('Replace version failed: ', err.message)
+})
+```
+
+### Unpublish version
+Marks a document to be unpublished when the release it is part of is run.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.document.version.unpublish',
+    publishedId: 'bike-123',
+    versionId: 'versions.new-bike-release.bike-123'
+  }
+).then(() => {
+  console.log('`bike-123` will be unpublished when `new-bike-release` release is run')
+}).catch((err) => {
+  console.error('Unpublish version failed: ', err.message)
+})
+```
+
+## Release Actions
+### Create release
+Create a new release.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.create',
+    releaseId: 'new-bikes-release',
+    metadata: {
+      title: 'New bikes',
+      releaseType: 'undecided'
+    }
+  }
+).then(() => {
+  console.log('`new-bikes-release` created')
+}).catch((err) => {
+  console.error('Create release failed: ', err.message)
+})
+```
+
+### Edit release
+Edit the metadata on an existing release.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.edit',
+    releaseId: 'new-bikes-release',
+    patch: {
+      set: {
+        metadata: {
+          releaseType: 'asap'
+        }
+      }
+    }
+  }
+).then(() => {
+  console.log('`new-bikes-release` changed to `asap` release type')
+}).catch((err) => {
+  console.error('Edit release failed: ', err.message)
+})
+```
+
+### Publish release
+Publish all document versions within a release.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.publish',
+    releaseId: 'new-bikes-release',
+  }
+).then(() => {
+  console.log('`new-bikes-release` published')
+}).catch((err) => {
+  console.error('Publish release failed: ', err.message)
+})
+```
+
+### Schedule release
+Schedule a release to be run now or in the future
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.schedule',
+    releaseId: 'new-bikes-release',
+    publishAt: '2025-01-01T00:00:00.000Z'
+  }
+).then(() => {
+  console.log('`new-bikes-release` scheduled')
+}).catch((err) => {
+  console.error('Schedule release failed: ', err.message)
+})
+```
+
+### Unschedule release
+Unschedule a currently scheduled release, to stop the release being run.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.unschedule',
+    releaseId: 'new-bikes-release',
+  }
+).then(() => {
+  console.log('`new-bikes-release` unscheduled')
+}).catch((err) => {
+  console.error('Unschedule release failed: ', err.message)
+})
+```
+
+### Archive release
+Mark an active (not published) release as archived.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.archive',
+    releaseId: 'new-bikes-release',
+  }
+).then(() => {
+  console.log('`new-bikes-release` archived')
+}).catch((err) => {
+  console.error('Archive release failed: ', err.message)
+})
+```
+
+### Unarchive release
+Once a release has been archived, the archive process may be undone by unarchiving the release.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.unarchive',
+    releaseId: 'new-bikes-release',
+  }
+).then(() => {
+  console.log('`new-bikes-release` unarchived')
+}).catch((err) => {
+  console.error('Unarchive release failed: ', err.message)
+})
+```
+
+### Delete release
+An archived release can be deleted, which will remove the system release document permanently from the dataset.
+```js
+client.action(
+  {
+    actionType: 'sanity.action.release.delete',
+    releaseId: 'new-bikes-release',
+  }
+).then(() => {
+  console.log('`new-bikes-release` deleted')
+}).catch((err) => {
+  console.error('Delete release failed: ', err.message)
+})
 ```
 
 ### Uploading assets

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -466,10 +466,10 @@ export class ObservableSanityClient {
    *
    * @category Versions
    *
-   * @param param - version action parameters.
-   * @param param.document - The document to create as a new version (must include `_type`).
-   * @param param.publishedId - The ID of the published document being versioned.
-   * @param param.releaseId - The ID of the release to create the version for.
+   * @param params - Version action parameters:
+   *   - `document` - The document to create as a new version (must include `_type`).
+   *   - `publishedId` - The ID of the published document being versioned.
+   *   - `releaseId` - The ID of the release to create the version for.
    * @param options - Additional action options.
    * @returns an observable that resolves to the `transactionId`.
    *
@@ -693,9 +693,9 @@ export class ObservableSanityClient {
    * * Discarding a version with no `releaseId` will discard the draft version of the published document.
    * * If the draft or release version does not exist, any error will throw.
    *
-   * @param param - version action parameters.
-   * @param param.releaseId - The ID of the release to discard the document from.
-   * @param param.publishedId - The published ID of the document to discard.
+   * @param params - Version action parameters:
+   *   - `releaseId` - The ID of the release to discard the document from.
+   *   - `publishedId` - The published ID of the document to discard.
    * @param purge - if `true` the document history is also discarded.
    * @param options - Additional action options.
    * @returns an observable that resolves to the `transactionId`.
@@ -734,10 +734,10 @@ export class ObservableSanityClient {
    * * Replacing a version with no `releaseId` will replace the draft version of the published document.
    * * At least one of the **version** or **published** documents must exist.
    *
-   * @param param - version action parameters.
-   * @param param.document - The new document to replace the version with.
-   * @param param.releaseId - The ID of the release where the document version is replaced.
-   * @param param.publishedId - The ID of the published document to replace.
+   * @param params - Version action parameters:
+   *   - `document` - The new document to replace the version with.
+   *   - `releaseId` - The ID of the release where the document version is replaced.
+   *   - `publishedId` - The ID of the published document to replace.
    * @param options - Additional action options.
    * @returns an observable that resolves to the `transactionId`.
    *
@@ -835,9 +835,9 @@ export class ObservableSanityClient {
    * @remarks
    * * If the published document does not exist, an error will be thrown.
    *
-   * @param param - version action parameters.
-   * @param param.releaseId - The ID of the release to unpublish the document from.
-   * @param param.publishedId - The published ID of the document to unpublish.
+   * @param params - Version action parameters:
+   *   - `releaseId` - The ID of the release to unpublish the document from.
+   *   - `publishedId` - The published ID of the document to unpublish.
    * @param options - Additional action options.
    * @returns an observable that resolves to the `transactionId`.
    *
@@ -1434,15 +1434,17 @@ export class SanityClient {
    *
    * @remarks
    * * Requires a document with a `_type` property.
+   * * Creating a version with no `releaseId` will create a new draft version of the published document.
+   * * If the `document._id` is defined, it should be a draft or release version ID that matches the version ID generated from `publishedId` and `releaseId`.
+   * * If the `document._id` is not defined, it will be generated from `publishedId` and `releaseId`.
    * * To create a version of an unpublished document, use the `client.create` method.
    *
    * @category Versions
    *
-   * @param param - version action parameters.
-   * @param param.document - The document to create as a new version (must include `_type`).
-   * >- if defined `_id` will be overridden by the version ID generated from `publishedId` and `releaseId`.
-   * @param param.publishedId - The ID of the published document being versioned.
-   * @param param.releaseId - The ID of the release to create the version for.
+   * @param params - Version action parameters:
+   *   - document - The document to create as a new version (must include `_type`).
+   *   - publishedId - The ID of the published document being versioned.
+   *   - releaseId - The ID of the release to create the version for.
    * @param options - Additional action options.
    * @returns an observable that resolves to the `transactionId`.
    *
@@ -1476,6 +1478,22 @@ export class SanityClient {
    * //   _type: 'myDocument',
    * //   title: 'My Document',
    * // }
+   * ```
+   *
+   * @example Creating a new draft version of a published document
+   * ```ts
+   * const transactionId = await client.createVersion({
+   *   document: {_type: 'myDocument', title: 'My Document'},
+   *   publishedId: 'myDocument',
+   * })
+   *
+   * // The following document will be created:
+   * // {
+   * //   _id: 'drafts.myDocument',
+   * //   _type: 'myDocument',
+   * //   title: 'My Document',
+   * // }
+   * ```
    */
   createVersion<R extends Record<string, Any>>(
     args: {
@@ -1644,13 +1662,32 @@ export class SanityClient {
   }
 
   /**
-   * used to delete the draft or release version of a document.
-   * It is an error if it does not exist.
-   * If the `purge`flag is set, the document history is also deleted.
+   * @public
    *
+   * Deletes the draft or release version of a document.
+   *
+   * @remarks
+   * * Discarding a version with no `releaseId` will discard the draft version of the published document.
+   * * If the draft or release version does not exist, any error will throw.
+   *
+   * @param params - Version action parameters:
+   *   - releaseId - The ID of the release to discard the document from.
+   *   - publishedId - The published ID of the document to discard.
+   * @param purge - if `true` the document history is also discarded.
+   * @param options - Additional action options.
    * @returns a promise that resolves to the `transactionId`.
    *
+   * @example Discarding a release version of a document
+   * ```ts
+   * client.discardVersion({publishedId: 'myDocument', releaseId: 'myRelease'})
+   * // The document with the ID `versions.myRelease.myDocument` will be discarded.
+   * ```
    *
+   * @example Discarding a draft version of a document
+   * ```ts
+   * client.discardVersion({publishedId: 'myDocument'})
+   * // The document with the ID `drafts.myDocument` will be discarded.
+   * ```
    */
   discardVersion(
     {releaseId, publishedId}: {releaseId?: string; publishedId: string},
@@ -1665,15 +1702,71 @@ export class SanityClient {
   }
 
   /**
+   * @public
+   *
    * Replaces an existing version document.
    *
-   * At least one of the **version** or **published** documents must exist.
-   * If the `releaseId` is provided, the version will be stored under the corresponding release.
-   * Otherwise, the **draft version** of the document will be replaced.
+   * @remarks
+   * * Requires a document with a `_type` property.
+   * * If the `document._id` is defined, it should be a draft or release version ID that matches the version ID generated from `publishedId` and `releaseId`.
+   * * If the `document._id` is not defined, it will be generated from `publishedId` and `releaseId`.
+   * * Replacing a version with no `releaseId` will replace the draft version of the published document.
+   * * At least one of the **version** or **published** documents must exist.
    *
-   * @returns an promise that resolves to the `transactionId`.
+   * @param params - Version action parameters:
+   *   - document - The new document to replace the version with.
+   *   - releaseId - The ID of the release where the document version is replaced.
+   *   - publishedId - The ID of the published document to replace.
+   * @param options - Additional action options.
+   * @returns a promise that resolves to the `transactionId`.
    *
+   * @example Replacing a release version of a published document with a generated version ID
+   * ```ts
+   * await client.replaceVersion({
+   *   document: {_type: 'myDocument', title: 'My Document'},
+   *   publishedId: 'myDocument',
+   *   releaseId: 'myRelease',
+   * })
+   *
+   * // The following document will be patched:
+   * // {
+   * //   _id: 'versions.myRelease.myDocument',
+   * //   _type: 'myDocument',
+   * //   title: 'My Document',
+   * // }
+   * ```
+   *
+   * @example Replacing a release version of a published document with a specified version ID
+   * ```ts
+   * await client.replaceVersion({
+   *   document: {_type: 'myDocument', _id: 'versions.myRelease.myDocument', title: 'My Document'},
+   *   // `publishedId` and `releaseId` are not required since `document._id` has been specified
+   * })
+   *
+   * // The following document will be patched:
+   * // {
+   * //   _id: 'versions.myRelease.myDocument',
+   * //   _type: 'myDocument',
+   * //   title: 'My Document',
+   * // }
+   * ```
+   *
+   * @example Replacing a draft version of a published document
+   * ```ts
+   * await client.replaceVersion({
+   *   document: {_type: 'myDocument', title: 'My Document'},
+   *   publishedId: 'myDocument',
+   * })
+   *
+   * // The following document will be patched:
+   * // {
+   * //   _id: 'drafts.myDocument',
+   * //   _type: 'myDocument',
+   * //   title: 'My Document',
+   * // }
+   * ```
    */
+
   replaceVersion<R extends Record<string, Any>>(
     args: {
       document: SanityDocumentStub<R>
@@ -1716,12 +1809,25 @@ export class SanityClient {
   }
 
   /**
+   * @public
+   *
    * Used to indicate when a document within a release should be unpublished when
-   * the release is published.
-   * Note that `publishedId` must currently exist.
+   * the release is run.
    *
-   * @returns an promise that resolves to the `transactionId`.
+   * @remarks
+   * * If the published document does not exist, an error will be thrown.
    *
+   * @param params - Version action parameters:
+   *   - `releaseId` - The ID of the release to unpublish the document from.
+   *   - `publishedId` - The published ID of the document to unpublish.
+   * @param options - Additional action options.
+   * @returns a promise that resolves to the `transactionId`.
+   *
+   * @example Unpublishing a release version of a published document
+   * ```ts
+   * await client.unpublishVersion({publishedId: 'myDocument', releaseId: 'myRelease'})
+   * // The document with the ID `versions.myRelease.myDocument` will be unpublished. when `myRelease` is run.
+   * ```
    */
   unpublishVersion(
     {releaseId, publishedId}: {releaseId: string; publishedId: string},

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -1442,9 +1442,9 @@ export class SanityClient {
    * @category Versions
    *
    * @param params - Version action parameters:
-   *   - document - The document to create as a new version (must include `_type`).
-   *   - publishedId - The ID of the published document being versioned.
-   *   - releaseId - The ID of the release to create the version for.
+   *   - `document` - The document to create as a new version (must include `_type`).
+   *   - `publishedId` - The ID of the published document being versioned.
+   *   - `releaseId` - The ID of the release to create the version for.
    * @param options - Additional action options.
    * @returns an observable that resolves to the `transactionId`.
    *
@@ -1671,8 +1671,8 @@ export class SanityClient {
    * * If the draft or release version does not exist, any error will throw.
    *
    * @param params - Version action parameters:
-   *   - releaseId - The ID of the release to discard the document from.
-   *   - publishedId - The published ID of the document to discard.
+   *   - `releaseId` - The ID of the release to discard the document from.
+   *   - `publishedId` - The published ID of the document to discard.
    * @param purge - if `true` the document history is also discarded.
    * @param options - Additional action options.
    * @returns a promise that resolves to the `transactionId`.
@@ -1714,9 +1714,9 @@ export class SanityClient {
    * * At least one of the **version** or **published** documents must exist.
    *
    * @param params - Version action parameters:
-   *   - document - The new document to replace the version with.
-   *   - releaseId - The ID of the release where the document version is replaced.
-   *   - publishedId - The ID of the published document to replace.
+   *   - `document` - The new document to replace the version with.
+   *   - `releaseId` - The ID of the release where the document version is replaced.
+   *   - `publishedId` - The ID of the published document to replace.
    * @param options - Additional action options.
    * @returns a promise that resolves to the `transactionId`.
    *

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -219,6 +219,132 @@ export class ObservableReleasesClient {
   ): Observable<RawQueryResponse<SanityDocument[]>> {
     return _getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options)
   }
+
+  /**
+   * Edits an existing release, updating the metadata.
+   *
+   * @param releaseId - The id of the release to edit (with no prefix)
+   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
+   */
+  edit(
+    releaseId: string,
+    patch: PatchMutationOperation,
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const editAction: EditReleaseAction = {
+      actionType: 'sanity.action.release.edit',
+      releaseId,
+      patch,
+    }
+
+    return _action(this.#client, this.#httpRequest, editAction, options)
+  }
+
+  /**
+   * Publishes all documents in a release at once. For larger releases the effect of the publish
+   * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
+   * documents and creation of the corresponding published documents with the new content may
+   * take some time.
+   *
+   * During this period both the source and target documents are locked and cannot be
+   * modified through any other means.
+   *
+   * @param releaseId - The id of the release to publish (with no prefix)
+   */
+  publish(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
+    const publishAction: PublishReleaseAction = {
+      actionType: 'sanity.action.release.publish',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, publishAction, options)
+  }
+
+  /**
+   * An archive action is used to remove an active release. The documents that comprise the release
+   * are deleted and therefore no longer queryable.
+   *
+   * While the documents remain in retention the last version can still be accessed using document history endpoint.
+   *
+   * @param releaseId - The id of the release to archive (with no prefix)
+   */
+  archive(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
+    const archiveAction: ArchiveReleaseAction = {
+      actionType: 'sanity.action.release.archive',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, archiveAction, options)
+  }
+
+  /**
+   * An unarchive action is used to restore an archived release and all documents
+   * with the content they had just prior to archiving.
+   *
+   * @param releaseId - The id of the release to unarchive (with no prefix)
+   */
+  unarchive(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
+    const unarchiveAction: UnarchiveReleaseAction = {
+      actionType: 'sanity.action.release.unarchive',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, unarchiveAction, options)
+  }
+
+  /**
+   * A schedule action queues a release for publishing at the given future time.
+   * The release is locked such that no documents in the release can be modified and
+   * no documents that it references can be deleted as this would make the publish fail.
+   * At the given time, the same logic as for the publish action is triggered.
+   *
+   * @param releaseId - The id of the release to schedule (with no prefix)
+   */
+  schedule(
+    releaseId: string,
+    publishAt: string,
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const scheduleAction: ScheduleReleaseAction = {
+      actionType: 'sanity.action.release.schedule',
+      releaseId,
+      publishAt,
+    }
+
+    return _action(this.#client, this.#httpRequest, scheduleAction, options)
+  }
+
+  /**
+   * An unschedule action is used to stop a release from being published.
+   * The documents in the release are considered unlocked and can be edited again.
+   * This may fail if another release is scheduled to be published after this one and
+   * has a reference to a document created by this one.
+   *
+   * @param releaseId - The id of the release to unschedule (with no prefix)
+   */
+  unschedule(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
+    const unscheduleAction: UnscheduleReleaseAction = {
+      actionType: 'sanity.action.release.unschedule',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, unscheduleAction, options)
+  }
+
+  /**
+   * A delete action is used to delete a published or archived release.
+   * The backing system document will be removed from the dataset.
+   *
+   * @param releaseId - The id of the release to delete (with no prefix)
+   */
+  delete(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
+    const deleteAction: DeleteReleaseAction = {
+      actionType: 'sanity.action.release.delete',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, deleteAction, options)
+  }
 }
 
 /** @public */
@@ -419,5 +545,131 @@ export class ReleasesClient {
     options?: BaseMutationOptions,
   ): Promise<RawQueryResponse<SanityDocument[]>> {
     return lastValueFrom(_getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options))
+  }
+
+  /**
+   * Edits an existing release, updating the metadata.
+   *
+   * @param releaseId - The id of the release to edit (with no prefix)
+   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
+   */
+  edit(
+    releaseId: string,
+    patch: PatchMutationOperation,
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const editAction: EditReleaseAction = {
+      actionType: 'sanity.action.release.edit',
+      releaseId,
+      patch,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, editAction, options))
+  }
+
+  /**
+   * Publishes all documents in a release at once. For larger releases the effect of the publish
+   * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
+   * documents and creation of the corresponding published documents with the new content may
+   * take some time.
+   *
+   * During this period both the source and target documents are locked and cannot be
+   * modified through any other means.
+   *
+   * @param releaseId - The id of the release to publish (with no prefix)
+   */
+  publish(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
+    const publishAction: PublishReleaseAction = {
+      actionType: 'sanity.action.release.publish',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, publishAction, options))
+  }
+
+  /**
+   * An archive action is used to remove an active release. The documents that comprise the release
+   * are deleted and therefore no longer queryable.
+   *
+   * While the documents remain in retention the last version can still be accessed using document history endpoint.
+   *
+   * @param releaseId - The id of the release to archive (with no prefix)
+   */
+  archive(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
+    const archiveAction: ArchiveReleaseAction = {
+      actionType: 'sanity.action.release.archive',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, archiveAction, options))
+  }
+
+  /**
+   * An unarchive action is used to restore an archived release and all documents
+   * with the content they had just prior to archiving.
+   *
+   * @param releaseId - The id of the release to unarchive (with no prefix)
+   */
+  unarchive(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
+    const unarchiveAction: UnarchiveReleaseAction = {
+      actionType: 'sanity.action.release.unarchive',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, unarchiveAction, options))
+  }
+
+  /**
+   * A schedule action queues a release for publishing at the given future time.
+   * The release is locked such that no documents in the release can be modified and
+   * no documents that it references can be deleted as this would make the publish fail.
+   * At the given time, the same logic as for the publish action is triggered.
+   *
+   * @param releaseId - The id of the release to schedle (with no prefix)
+   */
+  schedule(
+    releaseId: string,
+    publishAt: string,
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const scheduleAction: ScheduleReleaseAction = {
+      actionType: 'sanity.action.release.schedule',
+      releaseId,
+      publishAt,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, scheduleAction, options))
+  }
+
+  /**
+   * An unschedule action is used to stop a release from being published.
+   * The documents in the release are considered unlocked and can be edited again.
+   * This may fail if another release is scheduled to be published after this one and
+   * has a reference to a document created by this one.
+   *
+   * @param releaseId - The id of the release to unschedule (with no prefix)
+   */
+  unschedule(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
+    const unscheduleAction: UnscheduleReleaseAction = {
+      actionType: 'sanity.action.release.unschedule',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, unscheduleAction, options))
+  }
+
+  /**
+   * A delete action is used to delete a published or archived release.
+   * The backing system document will be removed from the dataset.
+   *
+   * @param releaseId - The id of the release to delete (with no prefix)
+   */
+  delete(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
+    const deleteAction: DeleteReleaseAction = {
+      actionType: 'sanity.action.release.delete',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, deleteAction, options))
   }
 }

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -30,6 +30,33 @@ export class ObservableReleasesClient {
     this.#httpRequest = httpRequest
   }
 
+  /**
+   * @public
+   *
+   * Retrieve a release by id.
+   *
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to retrieve.
+   * @param options - Additional query options including abort signal and query tag.
+   * @returns An observable that resolves to the release document {@link ReleaseDocument}.
+   *
+   * @example Retrieving a release by id
+   * ```ts
+   * client.observable.releases.get({releaseId: 'my-release'}).pipe(
+   *   tap((release) => console.log(release)),
+   *   // {
+   *   //   _id: '_.releases.my-release',
+   *   //   name: 'my-release'
+   *   //   _type: 'system.release',
+   *   //   metadata: {releaseType: 'asap'},
+   *   //   _createdAt: '2021-01-01T00:00:00.000Z',
+   *   //   ...
+   *   // }
+   * ).subscribe()
+   * ```
+   */
   get(
     {releaseId}: {releaseId: string},
     options?: {signal?: AbortSignal; tag?: string},
@@ -43,11 +70,59 @@ export class ObservableReleasesClient {
   }
 
   /**
+   * @public
+   *
    * Creates a new release under the given id, with metadata.
    *
-   * @param releaseId - The id of the release to create (with no prefix)
-   * @param metadata - The metadata to associate with the release {@link ReleaseDocument}
-   * Must include a `releaseType` {@link ReleaseType}
+   * @remarks
+   * * If no releaseId is provided, a release id will be generated.
+   * * If no metadata is provided, then an `undecided` releaseType will be used.
+   *
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to create.
+   * @param param.metadata - The metadata to associate with the release {@link ReleaseDocument}.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId` and the release id and metadata.
+   *
+   * @example Creating a release with a custom id and metadata
+   * ```ts
+   * const releaseId = 'my-release'
+   * const metadata: ReleaseDocument['metadata'] = {
+   *   releaseType: 'asap',
+   * }
+   *
+   * client.observable.releases.create({releaseId, metadata}).pipe(
+   *   tap(({transactionId, releaseId, metadata}) => console.log(transactionId, releaseId, metadata)),
+   *   // {
+   *   //   transactionId: 'transaction-id',
+   *   //   releaseId: 'my-release',
+   *   //   metadata: {releaseType: 'asap'},
+   *   // }
+   * ).subscribe()
+   * ```
+   *
+   * @example Creating a release with generated id and metadata
+   * ```ts
+   * client.observable.releases.create().pipe(
+   *   tap(({metadata}) => console.log(metadata)),
+   *   // {
+   *   //   metadata: {releaseType: 'undecided'},
+   *   // }
+   * ).subscribe()
+   * ```
+   *
+   * @example Creating a release using a custom transaction id
+   * ```ts
+   * client.observable.releases.create({transactionId: 'my-transaction-id'}).pipe(
+   *   tap(({transactionId, metadata}) => console.log(transactionId, metadata)),
+   *   // {
+   *   //   transactionId: 'my-transaction-id',
+   *   //   metadata: {releaseType: 'undecided'},
+   *   // }
+   * ).subscribe()
+   * ```
    */
   create(
     options: BaseActionOptions,
@@ -75,10 +150,17 @@ export class ObservableReleasesClient {
   }
 
   /**
+   * @public
+   *
    * Edits an existing release, updating the metadata.
    *
-   * @param releaseId - The id of the release to edit (with no prefix)
-   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to edit.
+   * @param param.patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId`.
    */
   edit(
     {releaseId, patch}: {releaseId: string; patch: PatchOperations},
@@ -94,6 +176,8 @@ export class ObservableReleasesClient {
   }
 
   /**
+   * @public
+   *
    * Publishes all documents in a release at once. For larger releases the effect of the publish
    * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
    * documents and creation of the corresponding published documents with the new content may
@@ -102,7 +186,12 @@ export class ObservableReleasesClient {
    * During this period both the source and target documents are locked and cannot be
    * modified through any other means.
    *
-   * @param releaseId - The id of the release to publish (with no prefix)
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to publish.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId`.
    */
   publish(
     {releaseId}: {releaseId: string},
@@ -117,12 +206,19 @@ export class ObservableReleasesClient {
   }
 
   /**
-   * An archive action is used to remove an active release. The documents that comprise the release
+   * @public
+   *
+   * An archive action removes an active release. The documents that comprise the release
    * are deleted and therefore no longer queryable.
    *
    * While the documents remain in retention the last version can still be accessed using document history endpoint.
    *
-   * @param releaseId - The id of the release to archive (with no prefix)
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to archive.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId`.
    */
   archive(
     {releaseId}: {releaseId: string},
@@ -137,10 +233,17 @@ export class ObservableReleasesClient {
   }
 
   /**
-   * An unarchive action is used to restore an archived release and all documents
+   * @public
+   *
+   * An unarchive action restores an archived release and all documents
    * with the content they had just prior to archiving.
    *
-   * @param releaseId - The id of the release to unarchive (with no prefix)
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to unarchive.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId`.
    */
   unarchive(
     {releaseId}: {releaseId: string},
@@ -155,12 +258,21 @@ export class ObservableReleasesClient {
   }
 
   /**
+   * @public
+   *
    * A schedule action queues a release for publishing at the given future time.
    * The release is locked such that no documents in the release can be modified and
    * no documents that it references can be deleted as this would make the publish fail.
    * At the given time, the same logic as for the publish action is triggered.
    *
-   * @param releaseId - The id of the release to schedule (with no prefix)
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to schedule.
+   * @param param.publishAt -
+   * The serialised date and time to publish the release. If the `publishAt` is in the past, the release will be published immediately.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId`.
    */
   schedule(
     {releaseId, publishAt}: {releaseId: string; publishAt: string},
@@ -176,12 +288,19 @@ export class ObservableReleasesClient {
   }
 
   /**
-   * An unschedule action is used to stop a release from being published.
+   * @public
+   *
+   * An unschedule action stops a release from being published.
    * The documents in the release are considered unlocked and can be edited again.
    * This may fail if another release is scheduled to be published after this one and
    * has a reference to a document created by this one.
    *
-   * @param releaseId - The id of the release to unschedule (with no prefix)
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to unschedule.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId`.
    */
   unschedule(
     {releaseId}: {releaseId: string},
@@ -196,10 +315,17 @@ export class ObservableReleasesClient {
   }
 
   /**
-   * A delete action is used to delete a published or archived release.
+   * @public
+   *
+   * A delete action removes a published or archived release.
    * The backing system document will be removed from the dataset.
    *
-   * @param releaseId - The id of the release to delete (with no prefix)
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to delete.
+   * @param options - Additional action options.
+   * @returns An observable that resolves to the `transactionId`.
    */
   delete(
     {releaseId}: {releaseId: string},
@@ -213,6 +339,18 @@ export class ObservableReleasesClient {
     return _action(this.#client, this.#httpRequest, deleteAction, options)
   }
 
+  /**
+   * @public
+   *
+   * Get the documents in a release by release id.
+   *
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to get documents for.
+   * @param options - Additional mutation options {@link BaseMutationOptions}.
+   * @returns An observable that resolves to the documents in the release.
+   */
   getDocuments(
     {releaseId}: {releaseId: string},
     options?: BaseMutationOptions,
@@ -356,6 +494,32 @@ export class ReleasesClient {
     this.#httpRequest = httpRequest
   }
 
+  /**
+   * @public
+   *
+   * Retrieve a release by id.
+   *
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to retrieve.
+   * @param options - Additional query options including abort signal and query tag.
+   * @returns A promise that resolves to the release document {@link ReleaseDocument}.
+   *
+   * @example Retrieving a release by id
+   * ```ts
+   * const release = await client.releases.get({releaseId: 'my-release'})
+   * console.log(release)
+   * // {
+   * //   _id: '_.releases.my-release',
+   * //   name: 'my-release'
+   * //   _type: 'system.release',
+   * //   metadata: {releaseType: 'asap'},
+   * //   _createdAt: '2021-01-01T00:00:00.000Z',
+   * //   ...
+   * // }
+   * ```
+   */
   get(
     {releaseId}: {releaseId: string},
     options?: {signal?: AbortSignal; tag?: string},
@@ -371,11 +535,51 @@ export class ReleasesClient {
   }
 
   /**
+   * @public
+   *
    * Creates a new release under the given id, with metadata.
    *
-   * @param releaseId - The id of the release to create
-   * @param metadata - The metadata to associate with the release {@link ReleaseDocument}.
-   * Must include a `releaseType` {@link ReleaseType}
+   * @remarks
+   * * If no releaseId is provided, a release id will be generated.
+   * * If no metadata is provided, then an `undecided` releaseType will be used.
+   *
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to create.
+   * @param param.metadata - The metadata to associate with the release {@link ReleaseDocument}.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId` and the release id and metadata.
+   *
+   * @example Creating a release with a custom id and metadata
+   * ```ts
+   * const releaseId = 'my-release'
+   * const releaseMetadata: ReleaseDocument['metadata'] = {
+   *   releaseType: 'asap',
+   * }
+   *
+   * const result =
+   *   await client.releases.create({releaseId, metadata: releaseMetadata})
+   * console.log(result)
+   * // {
+   * //   transactionId: 'transaction-id',
+   * //   releaseId: 'my-release',
+   * //   metadata: {releaseType: 'asap'},
+   * // }
+   * ```
+   *
+   * @example Creating a release with generated id and metadata
+   * ```ts
+   * const {metadata} = await client.releases.create()
+   * console.log(metadata.releaseType) // 'undecided'
+   * ```
+   *
+   * @example Creating a release with a custom transaction id
+   * ```ts
+   * const {transactionId, metadata} = await client.releases.create({transactionId: 'my-transaction-id'})
+   * console.log(metadata.releaseType) // 'undecided'
+   * console.log(transactionId) // 'my-transaction-id'
+   * ```
    */
   async create(
     options: BaseActionOptions,
@@ -401,10 +605,17 @@ export class ReleasesClient {
   }
 
   /**
+   * @public
+   *
    * Edits an existing release, updating the metadata.
    *
-   * @param releaseId - The id of the release to edit
-   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to edit.
+   * @param param.patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId`.
    */
   edit(
     {releaseId, patch}: {releaseId: string; patch: PatchOperations},
@@ -420,6 +631,8 @@ export class ReleasesClient {
   }
 
   /**
+   * @public
+   *
    * Publishes all documents in a release at once. For larger releases the effect of the publish
    * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
    * documents and creation of the corresponding published documents with the new content may
@@ -428,7 +641,12 @@ export class ReleasesClient {
    * During this period both the source and target documents are locked and cannot be
    * modified through any other means.
    *
-   * @param releaseId - The id of the release to publish
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to publish.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId`.
    */
   publish(
     {releaseId}: {releaseId: string},
@@ -443,12 +661,19 @@ export class ReleasesClient {
   }
 
   /**
-   * An archive action is used to remove an active release. The documents that comprise the release
+   * @public
+   *
+   * An archive action removes an active release. The documents that comprise the release
    * are deleted and therefore no longer queryable.
    *
    * While the documents remain in retention the last version can still be accessed using document history endpoint.
    *
-   * @param releaseId - The id of the release to archive
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to archive.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId`.
    */
   archive(
     {releaseId}: {releaseId: string},
@@ -463,10 +688,17 @@ export class ReleasesClient {
   }
 
   /**
-   * An unarchive action is used to restore an archived release and all documents
+   * @public
+   *
+   * An unarchive action restores an archived release and all documents
    * with the content they had just prior to archiving.
    *
-   * @param releaseId - The id of the release to unarchive
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to unarchive.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId`.
    */
   unarchive(
     {releaseId}: {releaseId: string},
@@ -481,12 +713,21 @@ export class ReleasesClient {
   }
 
   /**
+   * @public
+   *
    * A schedule action queues a release for publishing at the given future time.
    * The release is locked such that no documents in the release can be modified and
    * no documents that it references can be deleted as this would make the publish fail.
    * At the given time, the same logic as for the publish action is triggered.
    *
-   * @param releaseId - The id of the release to schedule
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to schedule.
+   * @param param.publishAt -
+   * The serialised date and time to publish the release. If the `publishAt` is in the past, the release will be published immediately.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId`.
    */
   schedule(
     {releaseId, publishAt}: {releaseId: string; publishAt: string},
@@ -502,12 +743,19 @@ export class ReleasesClient {
   }
 
   /**
-   * An unschedule action is used to stop a release from being published.
+   * @public
+   *
+   * An unschedule action stops a release from being published.
    * The documents in the release are considered unlocked and can be edited again.
    * This may fail if another release is scheduled to be published after this one and
    * has a reference to a document created by this one.
    *
-   * @param releaseId - The id of the release to unschedule
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to unschedule.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId`.
    */
   unschedule(
     {releaseId}: {releaseId: string},
@@ -522,11 +770,17 @@ export class ReleasesClient {
   }
 
   /**
-   * A delete action is used to delete a published or archived release.
+   * @public
+   *
+   * A delete action removes a published or archived release.
    * The backing system document will be removed from the dataset.
    *
-   * @param params - Object containing:
-   * - `releaseId` - The id of the release to delete
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to delete.
+   * @param options - Additional action options.
+   * @returns A promise that resolves to the `transactionId`.
    */
   delete(
     {releaseId}: {releaseId: string},
@@ -540,6 +794,18 @@ export class ReleasesClient {
     return lastValueFrom(_action(this.#client, this.#httpRequest, deleteAction, options))
   }
 
+  /**
+   * @public
+   *
+   * Get the documents in a release by release id.
+   *
+   * @category Releases
+   *
+   * @param param - release action parameters.
+   * @param param.releaseId - The id of the release to get documents for.
+   * @param options - Additional mutation options {@link BaseMutationOptions}.
+   * @returns A promise that resolves to the documents in the release.
+   */
   getDocuments(
     {releaseId}: {releaseId: string},
     options?: BaseMutationOptions,

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -1,7 +1,7 @@
-import { lastValueFrom, map, Observable } from 'rxjs'
+import {lastValueFrom, map, Observable} from 'rxjs'
 
-import { _action, _getDocument, _getReleaseDocuments } from '../data/dataMethods'
-import type { ObservableSanityClient, SanityClient } from '../SanityClient'
+import {_action, _getDocument, _getReleaseDocuments} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import type {
   ArchiveReleaseAction,
   BaseActionOptions,
@@ -19,7 +19,7 @@ import type {
   UnarchiveReleaseAction,
   UnscheduleReleaseAction,
 } from '../types'
-import { createRelease } from './createRelease'
+import {createRelease} from './createRelease'
 
 /** @public */
 export class ObservableReleasesClient {
@@ -58,8 +58,8 @@ export class ObservableReleasesClient {
    * ```
    */
   get(
-    { releaseId }: { releaseId: string },
-    options?: { signal?: AbortSignal; tag?: string },
+    {releaseId}: {releaseId: string},
+    options?: {signal?: AbortSignal; tag?: string},
   ): Observable<ReleaseDocument | undefined> {
     return _getDocument<ReleaseDocument>(
       this.#client,
@@ -126,19 +126,19 @@ export class ObservableReleasesClient {
    */
   create(
     options: BaseActionOptions,
-  ): Observable<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
+  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
   create(
-    release: { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> },
+    release: {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>},
     options?: BaseActionOptions,
-  ): Observable<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
+  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
   create(
     releaseOrOptions?:
-      | { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> }
+      | {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>}
       | BaseActionOptions,
     maybeOptions?: BaseActionOptions,
-  ): Observable<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }> {
-    const { action, options } = createRelease(releaseOrOptions, maybeOptions)
-    const { releaseId, metadata } = action
+  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}> {
+    const {action, options} = createRelease(releaseOrOptions, maybeOptions)
+    const {releaseId, metadata} = action
 
     return _action(this.#client, this.#httpRequest, action, options).pipe(
       map((actionResult) => ({
@@ -163,7 +163,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   edit(
-    { releaseId, patch }: { releaseId: string; patch: PatchOperations },
+    {releaseId, patch}: {releaseId: string; patch: PatchOperations},
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const editAction: EditReleaseAction = {
@@ -194,7 +194,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   publish(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const publishAction: PublishReleaseAction = {
@@ -221,7 +221,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   archive(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const archiveAction: ArchiveReleaseAction = {
@@ -246,7 +246,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   unarchive(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const unarchiveAction: UnarchiveReleaseAction = {
@@ -274,7 +274,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   schedule(
-    { releaseId, publishAt }: { releaseId: string; publishAt: string },
+    {releaseId, publishAt}: {releaseId: string; publishAt: string},
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const scheduleAction: ScheduleReleaseAction = {
@@ -302,7 +302,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   unschedule(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const unscheduleAction: UnscheduleReleaseAction = {
@@ -327,7 +327,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   delete(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const deleteAction: DeleteReleaseAction = {
@@ -351,7 +351,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the documents in the release.
    */
   getDocuments(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseMutationOptions,
   ): Observable<RawQueryResponse<SanityDocument[]>> {
     return _getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options)
@@ -394,8 +394,8 @@ export class ReleasesClient {
    * ```
    */
   get(
-    { releaseId }: { releaseId: string },
-    options?: { signal?: AbortSignal; tag?: string },
+    {releaseId}: {releaseId: string},
+    options?: {signal?: AbortSignal; tag?: string},
   ): Promise<ReleaseDocument | undefined> {
     return lastValueFrom(
       _getDocument<ReleaseDocument>(
@@ -456,25 +456,25 @@ export class ReleasesClient {
    */
   async create(
     options: BaseActionOptions,
-  ): Promise<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
+  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
   async create(
-    release: { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> },
+    release: {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>},
     options?: BaseActionOptions,
-  ): Promise<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
+  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
   async create(
     releaseOrOptions?:
-      | { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> }
+      | {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>}
       | BaseActionOptions,
     maybeOptions?: BaseActionOptions,
-  ): Promise<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }> {
-    const { action, options } = createRelease(releaseOrOptions, maybeOptions)
-    const { releaseId, metadata } = action
+  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}> {
+    const {action, options} = createRelease(releaseOrOptions, maybeOptions)
+    const {releaseId, metadata} = action
 
     const actionResult = await lastValueFrom(
       _action(this.#client, this.#httpRequest, action, options),
     )
 
-    return { ...actionResult, releaseId, metadata }
+    return {...actionResult, releaseId, metadata}
   }
 
   /**
@@ -491,7 +491,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   edit(
-    { releaseId, patch }: { releaseId: string; patch: PatchOperations },
+    {releaseId, patch}: {releaseId: string; patch: PatchOperations},
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const editAction: EditReleaseAction = {
@@ -522,7 +522,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   publish(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const publishAction: PublishReleaseAction = {
@@ -549,7 +549,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   archive(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const archiveAction: ArchiveReleaseAction = {
@@ -574,7 +574,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   unarchive(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const unarchiveAction: UnarchiveReleaseAction = {
@@ -602,7 +602,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   schedule(
-    { releaseId, publishAt }: { releaseId: string; publishAt: string },
+    {releaseId, publishAt}: {releaseId: string; publishAt: string},
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const scheduleAction: ScheduleReleaseAction = {
@@ -630,7 +630,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   unschedule(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const unscheduleAction: UnscheduleReleaseAction = {
@@ -655,7 +655,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   delete(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const deleteAction: DeleteReleaseAction = {
@@ -679,7 +679,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the documents in the release.
    */
   getDocuments(
-    { releaseId }: { releaseId: string },
+    {releaseId}: {releaseId: string},
     options?: BaseMutationOptions,
   ): Promise<RawQueryResponse<SanityDocument[]>> {
     return lastValueFrom(_getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options))

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -37,8 +37,8 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to retrieve.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to retrieve.
    * @param options - Additional query options including abort signal and query tag.
    * @returns An observable that resolves to the release document {@link ReleaseDocument}.
    *
@@ -80,9 +80,9 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to create.
-   * @param param.metadata - The metadata to associate with the release {@link ReleaseDocument}.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to create.
+   *   - `metadata` - The metadata to associate with the release {@link ReleaseDocument}.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId` and the release id and metadata.
    *
@@ -156,9 +156,9 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to edit.
-   * @param param.patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to edit.
+   *   - `patch` - The patch operation to apply on the release metadata {@link PatchMutationOperation}.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId`.
    */
@@ -188,8 +188,8 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to publish.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to publish.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId`.
    */
@@ -215,8 +215,8 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to archive.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to archive.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId`.
    */
@@ -240,8 +240,8 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to unarchive.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to unarchive.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId`.
    */
@@ -267,10 +267,9 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to schedule.
-   * @param param.publishAt -
-   * The serialised date and time to publish the release. If the `publishAt` is in the past, the release will be published immediately.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to schedule.
+   *   - `publishAt` - The serialised date and time to publish the release. If the `publishAt` is in the past, the release will be published immediately.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId`.
    */
@@ -297,8 +296,8 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to unschedule.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to unschedule.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId`.
    */
@@ -322,8 +321,8 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to delete.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to delete.
    * @param options - Additional action options.
    * @returns An observable that resolves to the `transactionId`.
    */
@@ -346,8 +345,8 @@ export class ObservableReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to get documents for.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to get documents for.
    * @param options - Additional mutation options {@link BaseMutationOptions}.
    * @returns An observable that resolves to the documents in the release.
    */
@@ -501,8 +500,8 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to retrieve.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to retrieve.
    * @param options - Additional query options including abort signal and query tag.
    * @returns A promise that resolves to the release document {@link ReleaseDocument}.
    *
@@ -545,9 +544,9 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to create.
-   * @param param.metadata - The metadata to associate with the release {@link ReleaseDocument}.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to create.
+   *   - `metadata` - The metadata to associate with the release {@link ReleaseDocument}.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId` and the release id and metadata.
    *
@@ -611,9 +610,9 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to edit.
-   * @param param.patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to edit.
+   *   - `patch` - The patch operation to apply on the release metadata {@link PatchMutationOperation}.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId`.
    */
@@ -643,8 +642,8 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to publish.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to publish.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId`.
    */
@@ -670,8 +669,8 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to archive.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to archive.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId`.
    */
@@ -695,8 +694,8 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to unarchive.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to unarchive.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId`.
    */
@@ -722,10 +721,9 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to schedule.
-   * @param param.publishAt -
-   * The serialised date and time to publish the release. If the `publishAt` is in the past, the release will be published immediately.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to schedule.
+   *   - `publishAt` - The serialised date and time to publish the release. If the `publishAt` is in the past, the release will be published immediately.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId`.
    */
@@ -752,8 +750,8 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to unschedule.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to unschedule.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId`.
    */
@@ -777,8 +775,8 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to delete.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to delete.
    * @param options - Additional action options.
    * @returns A promise that resolves to the `transactionId`.
    */
@@ -801,8 +799,8 @@ export class ReleasesClient {
    *
    * @category Releases
    *
-   * @param param - release action parameters.
-   * @param param.releaseId - The id of the release to get documents for.
+   * @param params - Release action parameters:
+   *   - `releaseId` - The id of the release to get documents for.
    * @param options - Additional mutation options {@link BaseMutationOptions}.
    * @returns A promise that resolves to the documents in the release.
    */

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -1,7 +1,7 @@
-import {lastValueFrom, map, Observable} from 'rxjs'
+import { lastValueFrom, map, Observable } from 'rxjs'
 
-import {_action, _getDocument, _getReleaseDocuments} from '../data/dataMethods'
-import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import { _action, _getDocument, _getReleaseDocuments } from '../data/dataMethods'
+import type { ObservableSanityClient, SanityClient } from '../SanityClient'
 import type {
   ArchiveReleaseAction,
   BaseActionOptions,
@@ -19,7 +19,7 @@ import type {
   UnarchiveReleaseAction,
   UnscheduleReleaseAction,
 } from '../types'
-import {createRelease} from './createRelease'
+import { createRelease } from './createRelease'
 
 /** @public */
 export class ObservableReleasesClient {
@@ -58,8 +58,8 @@ export class ObservableReleasesClient {
    * ```
    */
   get(
-    {releaseId}: {releaseId: string},
-    options?: {signal?: AbortSignal; tag?: string},
+    { releaseId }: { releaseId: string },
+    options?: { signal?: AbortSignal; tag?: string },
   ): Observable<ReleaseDocument | undefined> {
     return _getDocument<ReleaseDocument>(
       this.#client,
@@ -126,19 +126,19 @@ export class ObservableReleasesClient {
    */
   create(
     options: BaseActionOptions,
-  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  ): Observable<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
   create(
-    release: {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>},
+    release: { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> },
     options?: BaseActionOptions,
-  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  ): Observable<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
   create(
     releaseOrOptions?:
-      | {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>}
+      | { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> }
       | BaseActionOptions,
     maybeOptions?: BaseActionOptions,
-  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}> {
-    const {action, options} = createRelease(releaseOrOptions, maybeOptions)
-    const {releaseId, metadata} = action
+  ): Observable<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }> {
+    const { action, options } = createRelease(releaseOrOptions, maybeOptions)
+    const { releaseId, metadata } = action
 
     return _action(this.#client, this.#httpRequest, action, options).pipe(
       map((actionResult) => ({
@@ -163,7 +163,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   edit(
-    {releaseId, patch}: {releaseId: string; patch: PatchOperations},
+    { releaseId, patch }: { releaseId: string; patch: PatchOperations },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const editAction: EditReleaseAction = {
@@ -194,7 +194,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   publish(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const publishAction: PublishReleaseAction = {
@@ -221,7 +221,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   archive(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const archiveAction: ArchiveReleaseAction = {
@@ -246,7 +246,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   unarchive(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const unarchiveAction: UnarchiveReleaseAction = {
@@ -274,7 +274,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   schedule(
-    {releaseId, publishAt}: {releaseId: string; publishAt: string},
+    { releaseId, publishAt }: { releaseId: string; publishAt: string },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const scheduleAction: ScheduleReleaseAction = {
@@ -302,7 +302,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   unschedule(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const unscheduleAction: UnscheduleReleaseAction = {
@@ -327,7 +327,7 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the `transactionId`.
    */
   delete(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult> {
     const deleteAction: DeleteReleaseAction = {
@@ -351,136 +351,10 @@ export class ObservableReleasesClient {
    * @returns An observable that resolves to the documents in the release.
    */
   getDocuments(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseMutationOptions,
   ): Observable<RawQueryResponse<SanityDocument[]>> {
     return _getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options)
-  }
-
-  /**
-   * Edits an existing release, updating the metadata.
-   *
-   * @param releaseId - The id of the release to edit (with no prefix)
-   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
-   */
-  edit(
-    releaseId: string,
-    patch: PatchMutationOperation,
-    options?: BaseActionOptions,
-  ): Observable<SingleActionResult> {
-    const editAction: EditReleaseAction = {
-      actionType: 'sanity.action.release.edit',
-      releaseId,
-      patch,
-    }
-
-    return _action(this.#client, this.#httpRequest, editAction, options)
-  }
-
-  /**
-   * Publishes all documents in a release at once. For larger releases the effect of the publish
-   * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
-   * documents and creation of the corresponding published documents with the new content may
-   * take some time.
-   *
-   * During this period both the source and target documents are locked and cannot be
-   * modified through any other means.
-   *
-   * @param releaseId - The id of the release to publish (with no prefix)
-   */
-  publish(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
-    const publishAction: PublishReleaseAction = {
-      actionType: 'sanity.action.release.publish',
-      releaseId,
-    }
-
-    return _action(this.#client, this.#httpRequest, publishAction, options)
-  }
-
-  /**
-   * An archive action is used to remove an active release. The documents that comprise the release
-   * are deleted and therefore no longer queryable.
-   *
-   * While the documents remain in retention the last version can still be accessed using document history endpoint.
-   *
-   * @param releaseId - The id of the release to archive (with no prefix)
-   */
-  archive(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
-    const archiveAction: ArchiveReleaseAction = {
-      actionType: 'sanity.action.release.archive',
-      releaseId,
-    }
-
-    return _action(this.#client, this.#httpRequest, archiveAction, options)
-  }
-
-  /**
-   * An unarchive action is used to restore an archived release and all documents
-   * with the content they had just prior to archiving.
-   *
-   * @param releaseId - The id of the release to unarchive (with no prefix)
-   */
-  unarchive(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
-    const unarchiveAction: UnarchiveReleaseAction = {
-      actionType: 'sanity.action.release.unarchive',
-      releaseId,
-    }
-
-    return _action(this.#client, this.#httpRequest, unarchiveAction, options)
-  }
-
-  /**
-   * A schedule action queues a release for publishing at the given future time.
-   * The release is locked such that no documents in the release can be modified and
-   * no documents that it references can be deleted as this would make the publish fail.
-   * At the given time, the same logic as for the publish action is triggered.
-   *
-   * @param releaseId - The id of the release to schedule (with no prefix)
-   */
-  schedule(
-    releaseId: string,
-    publishAt: string,
-    options?: BaseActionOptions,
-  ): Observable<SingleActionResult> {
-    const scheduleAction: ScheduleReleaseAction = {
-      actionType: 'sanity.action.release.schedule',
-      releaseId,
-      publishAt,
-    }
-
-    return _action(this.#client, this.#httpRequest, scheduleAction, options)
-  }
-
-  /**
-   * An unschedule action is used to stop a release from being published.
-   * The documents in the release are considered unlocked and can be edited again.
-   * This may fail if another release is scheduled to be published after this one and
-   * has a reference to a document created by this one.
-   *
-   * @param releaseId - The id of the release to unschedule (with no prefix)
-   */
-  unschedule(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
-    const unscheduleAction: UnscheduleReleaseAction = {
-      actionType: 'sanity.action.release.unschedule',
-      releaseId,
-    }
-
-    return _action(this.#client, this.#httpRequest, unscheduleAction, options)
-  }
-
-  /**
-   * A delete action is used to delete a published or archived release.
-   * The backing system document will be removed from the dataset.
-   *
-   * @param releaseId - The id of the release to delete (with no prefix)
-   */
-  delete(releaseId: string, options?: BaseActionOptions): Observable<SingleActionResult> {
-    const deleteAction: DeleteReleaseAction = {
-      actionType: 'sanity.action.release.delete',
-      releaseId,
-    }
-
-    return _action(this.#client, this.#httpRequest, deleteAction, options)
   }
 }
 
@@ -520,8 +394,8 @@ export class ReleasesClient {
    * ```
    */
   get(
-    {releaseId}: {releaseId: string},
-    options?: {signal?: AbortSignal; tag?: string},
+    { releaseId }: { releaseId: string },
+    options?: { signal?: AbortSignal; tag?: string },
   ): Promise<ReleaseDocument | undefined> {
     return lastValueFrom(
       _getDocument<ReleaseDocument>(
@@ -582,25 +456,25 @@ export class ReleasesClient {
    */
   async create(
     options: BaseActionOptions,
-  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  ): Promise<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
   async create(
-    release: {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>},
+    release: { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> },
     options?: BaseActionOptions,
-  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  ): Promise<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }>
   async create(
     releaseOrOptions?:
-      | {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>}
+      | { releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']> }
       | BaseActionOptions,
     maybeOptions?: BaseActionOptions,
-  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}> {
-    const {action, options} = createRelease(releaseOrOptions, maybeOptions)
-    const {releaseId, metadata} = action
+  ): Promise<SingleActionResult & { releaseId: string; metadata: ReleaseDocument['metadata'] }> {
+    const { action, options } = createRelease(releaseOrOptions, maybeOptions)
+    const { releaseId, metadata } = action
 
     const actionResult = await lastValueFrom(
       _action(this.#client, this.#httpRequest, action, options),
     )
 
-    return {...actionResult, releaseId, metadata}
+    return { ...actionResult, releaseId, metadata }
   }
 
   /**
@@ -617,7 +491,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   edit(
-    {releaseId, patch}: {releaseId: string; patch: PatchOperations},
+    { releaseId, patch }: { releaseId: string; patch: PatchOperations },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const editAction: EditReleaseAction = {
@@ -648,7 +522,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   publish(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const publishAction: PublishReleaseAction = {
@@ -675,7 +549,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   archive(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const archiveAction: ArchiveReleaseAction = {
@@ -700,7 +574,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   unarchive(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const unarchiveAction: UnarchiveReleaseAction = {
@@ -728,7 +602,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   schedule(
-    {releaseId, publishAt}: {releaseId: string; publishAt: string},
+    { releaseId, publishAt }: { releaseId: string; publishAt: string },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const scheduleAction: ScheduleReleaseAction = {
@@ -756,7 +630,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   unschedule(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const unscheduleAction: UnscheduleReleaseAction = {
@@ -781,7 +655,7 @@ export class ReleasesClient {
    * @returns A promise that resolves to the `transactionId`.
    */
   delete(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult> {
     const deleteAction: DeleteReleaseAction = {
@@ -805,135 +679,9 @@ export class ReleasesClient {
    * @returns A promise that resolves to the documents in the release.
    */
   getDocuments(
-    {releaseId}: {releaseId: string},
+    { releaseId }: { releaseId: string },
     options?: BaseMutationOptions,
   ): Promise<RawQueryResponse<SanityDocument[]>> {
     return lastValueFrom(_getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options))
-  }
-
-  /**
-   * Edits an existing release, updating the metadata.
-   *
-   * @param releaseId - The id of the release to edit (with no prefix)
-   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
-   */
-  edit(
-    releaseId: string,
-    patch: PatchMutationOperation,
-    options?: BaseActionOptions,
-  ): Promise<SingleActionResult> {
-    const editAction: EditReleaseAction = {
-      actionType: 'sanity.action.release.edit',
-      releaseId,
-      patch,
-    }
-
-    return lastValueFrom(_action(this.#client, this.#httpRequest, editAction, options))
-  }
-
-  /**
-   * Publishes all documents in a release at once. For larger releases the effect of the publish
-   * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
-   * documents and creation of the corresponding published documents with the new content may
-   * take some time.
-   *
-   * During this period both the source and target documents are locked and cannot be
-   * modified through any other means.
-   *
-   * @param releaseId - The id of the release to publish (with no prefix)
-   */
-  publish(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
-    const publishAction: PublishReleaseAction = {
-      actionType: 'sanity.action.release.publish',
-      releaseId,
-    }
-
-    return lastValueFrom(_action(this.#client, this.#httpRequest, publishAction, options))
-  }
-
-  /**
-   * An archive action is used to remove an active release. The documents that comprise the release
-   * are deleted and therefore no longer queryable.
-   *
-   * While the documents remain in retention the last version can still be accessed using document history endpoint.
-   *
-   * @param releaseId - The id of the release to archive (with no prefix)
-   */
-  archive(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
-    const archiveAction: ArchiveReleaseAction = {
-      actionType: 'sanity.action.release.archive',
-      releaseId,
-    }
-
-    return lastValueFrom(_action(this.#client, this.#httpRequest, archiveAction, options))
-  }
-
-  /**
-   * An unarchive action is used to restore an archived release and all documents
-   * with the content they had just prior to archiving.
-   *
-   * @param releaseId - The id of the release to unarchive (with no prefix)
-   */
-  unarchive(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
-    const unarchiveAction: UnarchiveReleaseAction = {
-      actionType: 'sanity.action.release.unarchive',
-      releaseId,
-    }
-
-    return lastValueFrom(_action(this.#client, this.#httpRequest, unarchiveAction, options))
-  }
-
-  /**
-   * A schedule action queues a release for publishing at the given future time.
-   * The release is locked such that no documents in the release can be modified and
-   * no documents that it references can be deleted as this would make the publish fail.
-   * At the given time, the same logic as for the publish action is triggered.
-   *
-   * @param releaseId - The id of the release to schedle (with no prefix)
-   */
-  schedule(
-    releaseId: string,
-    publishAt: string,
-    options?: BaseActionOptions,
-  ): Promise<SingleActionResult> {
-    const scheduleAction: ScheduleReleaseAction = {
-      actionType: 'sanity.action.release.schedule',
-      releaseId,
-      publishAt,
-    }
-
-    return lastValueFrom(_action(this.#client, this.#httpRequest, scheduleAction, options))
-  }
-
-  /**
-   * An unschedule action is used to stop a release from being published.
-   * The documents in the release are considered unlocked and can be edited again.
-   * This may fail if another release is scheduled to be published after this one and
-   * has a reference to a document created by this one.
-   *
-   * @param releaseId - The id of the release to unschedule (with no prefix)
-   */
-  unschedule(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
-    const unscheduleAction: UnscheduleReleaseAction = {
-      actionType: 'sanity.action.release.unschedule',
-      releaseId,
-    }
-
-    return lastValueFrom(_action(this.#client, this.#httpRequest, unscheduleAction, options))
-  }
-
-  /**
-   * A delete action is used to delete a published or archived release.
-   * The backing system document will be removed from the dataset.
-   *
-   * @param releaseId - The id of the release to delete (with no prefix)
-   */
-  delete(releaseId: string, options?: BaseActionOptions): Promise<SingleActionResult> {
-    const deleteAction: DeleteReleaseAction = {
-      actionType: 'sanity.action.release.delete',
-      releaseId,
-    }
-
-    return lastValueFrom(_action(this.#client, this.#httpRequest, deleteAction, options))
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -594,7 +594,6 @@ export type VersionAction =
 /** @public */
 export type Action =
   | CreateAction
-  | CreateVersionAction
   | ReplaceDraftAction
   | EditAction
   | DeleteAction

--- a/src/types.ts
+++ b/src/types.ts
@@ -594,6 +594,7 @@ export type VersionAction =
 /** @public */
 export type Action =
   | CreateAction
+  | CreateVersionAction
   | ReplaceDraftAction
   | EditAction
   | DeleteAction


### PR DESCRIPTION
Errors:
Scenario: calling `client.getDocument`, but passing a draft ID in addition to a releaseId eg. `client.getDocument('drafts.foo', {releaseId: 'bar'})`
Message: 'The document ID (drafts.foo) is a draft, but `options.releaseId` is set bar'

Scenario:  calling `client.getDocument`, but passing a release version ID that does not match the provided option eg. `client.getDocument('versions.foo.bar', {releaseId: 'baz'})`
Message: 'The document ID (versions.foo.bar) is already a version of foo release, but this does not match the provided `options.releaseId` (baz)'

Scenario: calling `client.releases.createVersion` but without a `publishedId` and without a `document._id` eg.
```
client.releases.createVersion({
  document: {type: 'book', title: 'My book',}
})
```
Message: 'createVersion() requires either a publishedId or a document with an _id'

Scenario: calling `client.releases.replaceVersion` but without a `publishedId` and without a `document._id` eg.
```
client.releases.replaceVersion({
  document: {type: 'book', title: 'My book',}
})
```
Message: 'replaceVersion() requires either a publishedId or a document with an _id'

Scenario: calling `client.createVersion` or `client.replaceVersion` with a document._id that does not match the generated versionId eg.
eg. document is a published `foo` id
```
client.createVersion({
  document: {type: 'book', title: 'My book', _id: 'foo'},
  publishedId: 'foo'
})
```
Message: 'The provided document ID (foo) does not match the generated version ID (drafts.foo)'

eg. document is a draft but doesn't match the publishedId
```
client.createVersion({
  document: {type: 'book', title: 'My book', _id: 'drafts.foo'},
  publishedId: 'bar'
})
```
Message: 'The provided document ID (drafts.foo) does not match the generated version ID (drafts.bar)'

eg. document is a draft but provided a releaseId
```
client.createVersion({
  document: {type: 'book', title: 'My book', _id: 'drafts.foo'},
  publishedId: 'foo',
  releaseId: 'baz'
})
```
Message: 'The provided document ID (drafts.foo) does not match the generated version ID (versions.baz.foo)'

Scenario: calling `client.createVersion` or `client.replaceVersion` with a draft document and a releaseId eg.
```
client.createVersion({
  document: {type: 'book', title: 'My book', _id: 'drafts.foo'},
  releaseId: 'bar'
})
```
Message: 'createVersion() was called with a document ID (drafts.foo) that is a draft ID, but a release ID (bar) was also provided'

Scenario: calling `client.createVersion` or `client.replaceVersion` with only a document that is not a version or draft eg.
```
client.createVersion({
  document: {type: 'book', title: 'My book', _id: 'foo'},
})
```
Message: 'createVersion() requires a document with an _id that is a version or draft ID'

Scenario: calling `client.createVersion` or `client.replaceVersion` with a document that is a release version, but also providing a release ID that does not match eg.
```
client.createVersion({
  document: {type: 'book', title: 'My book', _id: 'versions.foo.bar'},
  releaseId: 'baz'
})
```
Message: 'createVersion() was called with a document ID (versions.foo.bar) that is a version ID, but the release ID (baz) does not match the document's version ID (foo).'