### PR TITLE
chore: add unused-imports plugin and update rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import typescriptEslint from '@typescript-eslint/eslint-plugin'
 import tsParser from '@typescript-eslint/parser'
 import prettier from 'eslint-plugin-prettier'
 import simpleImportSort from 'eslint-plugin-simple-import-sort'
+import unusedImports from 'eslint-plugin-unused-imports'
 import globals from 'globals'
 
 // eslint-disable-next-line no-redeclare
@@ -33,6 +34,7 @@ export default [
     plugins: {
       '@typescript-eslint': typescriptEslint,
       'simple-import-sort': simpleImportSort,
+      'unused-imports': unusedImports,
       prettier,
     },
 
@@ -63,6 +65,10 @@ export default [
           terms: ['todo', '@todo', 'fixme'],
         },
       ],
+
+      '@typescript-eslint/no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': ['warn'],
 
       'prettier/prettier': 'warn',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-formatter-compact": "^8.40.0",
         "eslint-plugin-prettier": "^5.2.6",
         "eslint-plugin-simple-import-sort": "^12.1.1",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "faucet": "^0.0.4",
         "globals": "^16.0.0",
         "happy-dom": "^12.10.3",
@@ -6183,6 +6184,21 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "eslint-formatter-compact": "^8.40.0",
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "faucet": "^0.0.4",
     "globals": "^16.0.0",
     "happy-dom": "^12.10.3",

--- a/src/csm/draftUtils.ts
+++ b/src/csm/draftUtils.ts
@@ -60,7 +60,7 @@ export function getVersionId(id: string, version: string): string {
  */
 export function getVersionFromId(id: string): string | undefined {
   if (!isVersionId(id)) return undefined
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line unused-imports/no-unused-vars
   const [_versionPrefix, versionId, ..._publishedId] = id.split(PATH_SEPARATOR)
 
   return versionId

--- a/src/util/shareReplayLatest.ts
+++ b/src/util/shareReplayLatest.ts
@@ -44,7 +44,7 @@ function _shareReplayLatest<T>(config: ShareReplayLatestConfig<T>): MonoTypeOper
     let latest: T | undefined
     let emitted = false
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line unused-imports/no-unused-vars
     const {predicate, ...shareConfig} = config
 
     const wrapped = source.pipe(


### PR DESCRIPTION
`eslint-plugin-unused-imports` is a very small (4kb) dev dependency only.
It is used in SDK and in sanity studio.

The principle difference for it's inclusion is that it auto-fixes issues with unusued imports. This creates a consistent development experience across our largest of projects and repos