### PR TITLE
fix!: drop support for node < v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "vitest": "3.1.1"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,6 @@
   },
   "packageManager": "npm@11.3.0",
   "engines": {
-    "node": ">=14.18"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Dropping support for Node.js < v20 as Node.js v18 is EOL as of 2025-04-30