### PR TITLE
fix: improve query parse errors

### DIFF
--- a/src/csm/walkMap.ts
+++ b/src/csm/walkMap.ts
@@ -1,5 +1,5 @@
+import {isRecord} from '../util/isRecord'
 import {isArray} from './isArray'
-import {isRecord} from './isRecord'
 import type {ContentSourceMapParsedPath, WalkMapFn} from './types'
 
 /**

--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -17,7 +17,13 @@ export {
 } from './data/eventsource'
 export * from './data/patch'
 export * from './data/transaction'
-export {ClientError, CorsOriginError, ServerError} from './http/errors'
+export {
+  ClientError,
+  CorsOriginError,
+  formatQueryParseError,
+  isQueryParseError,
+  ServerError,
+} from './http/errors'
 export * from './SanityClient'
 export * from './types'
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,4 +1,4 @@
-import {getIt, type Middlewares, type Requester} from 'get-it'
+import {getIt, type HttpContext, type Middlewares, type Requester} from 'get-it'
 import {jsonRequest, jsonResponse, observable, progress, retry} from 'get-it/middleware'
 import {Observable} from 'rxjs'
 
@@ -6,11 +6,11 @@ import type {Any} from '../types'
 import {ClientError, ServerError} from './errors'
 
 const httpError = {
-  onResponse: (res: Any) => {
+  onResponse: (res: Any, context: HttpContext) => {
     if (res.statusCode >= 500) {
       throw new ServerError(res)
     } else if (res.statusCode >= 400) {
-      throw new ClientError(res)
+      throw new ClientError(res, context)
     }
 
     return res

--- a/src/types.ts
+++ b/src/types.ts
@@ -1373,11 +1373,26 @@ export interface ApiError {
 
 /** @internal */
 export interface MutationError {
-  error: {
-    type: 'mutationError'
-    description: string
-    items?: MutationErrorItem[]
-  }
+  type: 'mutationError'
+  description: string
+  items?: MutationErrorItem[]
+}
+
+/**
+ * Returned from the Content Lake API when a query is malformed, usually with a start
+ * and end column to indicate where the error occurred, but not always. Can we used to
+ * provide a more structured error message to the user.
+ *
+ * This will be located under the response `error` property.
+ *
+ * @public
+ */
+export interface QueryParseError {
+  type: 'queryParseError'
+  description: string
+  start?: number
+  end?: number
+  query?: string
 }
 
 /** @internal */
@@ -1391,11 +1406,9 @@ export interface MutationErrorItem {
 
 /** @internal */
 export interface ActionError {
-  error: {
-    type: 'actionError'
-    description: string
-    items?: ActionErrorItem[]
-  }
+  type: 'actionError'
+  description: string
+  items?: ActionErrorItem[]
 }
 
 /** @internal */

--- a/src/util/codeFrame.ts
+++ b/src/util/codeFrame.ts
@@ -1,0 +1,174 @@
+/**
+ * Inlined, modified version of the `codeFrameColumns` function from `@babel/code-frame`.
+ * MIT-licensed - https://github.com/babel/babel/blob/main/LICENSE
+ * Copyright (c) 2014-present Sebastian McKenzie and other contributors.
+ */
+type Location = {
+  column: number
+  line: number
+}
+
+type NodeLocation = {
+  start: Location
+  end?: Location
+}
+
+type GroqLocation = {
+  start: number
+  end?: number
+}
+
+/**
+ * RegExp to test for newlines.
+ */
+
+const NEWLINE = /\r\n|[\n\r\u2028\u2029]/
+
+/**
+ * Extract what lines should be marked and highlighted.
+ */
+
+type MarkerLines = Record<number, true | [number, number]>
+
+/**
+ * Highlight a code frame with the given location and message.
+ *
+ * @param query - The query to be highlighted.
+ * @param location - The location of the error in the code/query.
+ * @param message - Message to be displayed inline (if possible) next to the highlighted
+ * location in the code. If it can't be positioned inline, it will be placed above the
+ * code frame.
+ * @returns The highlighted code frame.
+ */
+export function codeFrame(query: string, location: GroqLocation, message?: string): string {
+  const lines = query.split(NEWLINE)
+  const loc = {
+    start: columnToLine(location.start, lines),
+    end: location.end ? columnToLine(location.end, lines) : undefined,
+  }
+
+  const {start, end, markerLines} = getMarkerLines(loc, lines)
+
+  const numberMaxWidth = `${end}`.length
+
+  return query
+    .split(NEWLINE, end)
+    .slice(start, end)
+    .map((line, index) => {
+      const number = start + 1 + index
+      const paddedNumber = ` ${number}`.slice(-numberMaxWidth)
+      const gutter = ` ${paddedNumber} |`
+      const hasMarker = markerLines[number]
+      const lastMarkerLine = !markerLines[number + 1]
+      if (!hasMarker) {
+        return ` ${gutter}${line.length > 0 ? ` ${line}` : ''}`
+      }
+
+      let markerLine = ''
+      if (Array.isArray(hasMarker)) {
+        const markerSpacing = line.slice(0, Math.max(hasMarker[0] - 1, 0)).replace(/[^\t]/g, ' ')
+        const numberOfMarkers = hasMarker[1] || 1
+
+        markerLine = [
+          '\n ',
+          gutter.replace(/\d/g, ' '),
+          ' ',
+          markerSpacing,
+          '^'.repeat(numberOfMarkers),
+        ].join('')
+
+        if (lastMarkerLine && message) {
+          markerLine += ' ' + message
+        }
+      }
+      return ['>', gutter, line.length > 0 ? ` ${line}` : '', markerLine].join('')
+    })
+    .join('\n')
+}
+
+function getMarkerLines(
+  loc: NodeLocation,
+  source: Array<string>,
+): {
+  start: number
+  end: number
+  markerLines: MarkerLines
+} {
+  const startLoc: Location = {...loc.start}
+  const endLoc: Location = {...startLoc, ...loc.end}
+  const linesAbove = 2
+  const linesBelow = 3
+  const startLine = startLoc.line ?? -1
+  const startColumn = startLoc.column ?? 0
+  const endLine = endLoc.line
+  const endColumn = endLoc.column
+
+  let start = Math.max(startLine - (linesAbove + 1), 0)
+  let end = Math.min(source.length, endLine + linesBelow)
+
+  if (startLine === -1) {
+    start = 0
+  }
+
+  if (endLine === -1) {
+    end = source.length
+  }
+
+  const lineDiff = endLine - startLine
+  const markerLines: MarkerLines = {}
+
+  if (lineDiff) {
+    for (let i = 0; i <= lineDiff; i++) {
+      const lineNumber = i + startLine
+
+      if (!startColumn) {
+        markerLines[lineNumber] = true
+      } else if (i === 0) {
+        const sourceLength = source[lineNumber - 1].length
+
+        markerLines[lineNumber] = [startColumn, sourceLength - startColumn + 1]
+      } else if (i === lineDiff) {
+        markerLines[lineNumber] = [0, endColumn]
+      } else {
+        const sourceLength = source[lineNumber - i].length
+
+        markerLines[lineNumber] = [0, sourceLength]
+      }
+    }
+  } else {
+    if (startColumn === endColumn) {
+      if (startColumn) {
+        markerLines[startLine] = [startColumn, 0]
+      } else {
+        markerLines[startLine] = true
+      }
+    } else {
+      markerLines[startLine] = [startColumn, endColumn - startColumn]
+    }
+  }
+
+  return {start, end, markerLines}
+}
+
+function columnToLine(column: number, lines: string[]): Location {
+  let offset = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineLength = lines[i].length + 1 // assume '\n' after each line
+
+    if (offset + lineLength > column) {
+      return {
+        line: i + 1, // 1-based line
+        column: column - offset, // 0-based column
+      }
+    }
+
+    offset += lineLength
+  }
+
+  // Fallback: beyond last line
+  return {
+    line: lines.length,
+    column: lines[lines.length - 1]?.length ?? 0,
+  }
+}

--- a/src/util/isRecord.ts
+++ b/src/util/isRecord.ts
@@ -1,4 +1,4 @@
 /** @internal */
 export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,97 @@
+import {describe, expect, test} from 'vitest'
+
+import {formatQueryParseError} from '../src/http/errors'
+
+const singleLineQuery = `*[_type == "event]`
+const multiLineQuery = `*[
+  _type == "event" &&
+  defined(startDate) &&
+  eventDate > now())
+] {
+  "title": eventTitle,
+  "coverPhoto": photo.asset->url
+}`
+
+describe('groq errors', () => {
+  test('formats single-line errors correctly', () => {
+    expect(
+      formatQueryParseError({
+        type: 'queryParseError',
+        query: singleLineQuery,
+        description: 'unexpected token "\\"event]", expected expression',
+        start: 11,
+        end: 18,
+      }),
+    ).toMatchInlineSnapshot(`
+      "GROQ query parse error:
+      > 1 | *[_type == "event]
+          |           ^^^^^^^ unexpected token "\\"event]", expected expression"
+    `)
+  })
+
+  test('formats unknown function errors correctly', () => {
+    expect(
+      formatQueryParseError({
+        description: 'unknown function "eventDate"',
+        type: 'queryParseError',
+      }),
+    ).toMatchInlineSnapshot(`"GROQ query parse error: unknown function "eventDate""`)
+  })
+
+  test('formats multi-line errors correctly', () => {
+    expect(
+      formatQueryParseError({
+        type: 'queryParseError',
+        query: multiLineQuery,
+        description: "expected ']' following expression",
+        start: 1,
+        end: 69,
+      }),
+    ).toMatchInlineSnapshot(`
+      "GROQ query parse error:
+      > 1 | *[
+          | ^^
+      > 2 |   _type == "event" &&
+          | ^^^^^^^^^^^^^^^^^^^^^
+      > 3 |   defined(startDate) &&
+          | ^^^^^^^^^^^^^^^^^^^^^
+      > 4 |   eventDate > now())
+          | ^^^^^^^^^^^^^^^^^^^^ expected ']' following expression
+        5 | ] {
+        6 |   "title": eventTitle,
+        7 |   "coverPhoto": photo.asset->url"
+    `)
+  })
+
+  test('out of bounds column error (start)', () => {
+    expect(
+      formatQueryParseError({
+        type: 'queryParseError',
+        query: singleLineQuery,
+        description: 'unexpected token "\\"event]", expected expression',
+        start: 3000,
+        end: 3000 + singleLineQuery.length,
+      }),
+    ).toMatchInlineSnapshot(`
+      "GROQ query parse error:
+      > 1 | *[_type == "event]
+          |                  ^ unexpected token "\\"event]", expected expression"
+    `)
+  })
+
+  test('out of bounds column error (end)', () => {
+    expect(
+      formatQueryParseError({
+        type: 'queryParseError',
+        query: singleLineQuery,
+        description: 'unexpected token "\\"event]", expected expression',
+        start: 5,
+        end: 3000,
+      }),
+    ).toMatchInlineSnapshot(`
+      "GROQ query parse error:
+      > 1 | *[_type == "event]
+          |     ^^^^^^^^^^^^^ unexpected token "\\"event]", expected expression"
+    `)
+  })
+})


### PR DESCRIPTION
If you have an invalid GROQ query, it can be hard to actually understand what went wrong - and even that it is caused by a GROQ syntax error. As an example, the query `*[_type == "event]` leaves out a missing `"` and produces the following error:

```
Error: unexpected token "\"event]", expected expression
```

Where is this coming from? What was the query?

With this change, we produce more context on GROQ query parse errors:
```
GROQ query parse error: unexpected token "\\"event]", expected expression.

*[_type == "event
-----------^^^^^^^

Line: 1
Column: 11
Tag: some-tag
```

The tag is only included if there is one, obviously.