### PR TITLE
feat: releases client and document version actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
         "get-it": "^8.6.7",
+        "nanoid": "^5.1.5",
         "rxjs": "^7.0.0"
       },
       "devDependencies": {
@@ -9343,22 +9344,20 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.10.tgz",
-      "integrity": "sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==",
-      "dev": true,
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -10609,6 +10608,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -13399,6 +13416,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/vite/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   "dependencies": {
     "@sanity/eventsource": "^5.0.2",
     "get-it": "^8.6.7",
+    "nanoid": "^5.1.5",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -1,0 +1,423 @@
+import {lastValueFrom, map, Observable} from 'rxjs'
+
+import {_action, _getDocument, _getReleaseDocuments} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {
+  ArchiveReleaseAction,
+  BaseActionOptions,
+  BaseMutationOptions,
+  DeleteReleaseAction,
+  EditReleaseAction,
+  HttpRequest,
+  PatchOperations,
+  PublishReleaseAction,
+  RawQueryResponse,
+  ReleaseDocument,
+  SanityDocument,
+  ScheduleReleaseAction,
+  SingleActionResult,
+  UnarchiveReleaseAction,
+  UnscheduleReleaseAction,
+} from '../types'
+import {createRelease} from './createRelease'
+
+/** @public */
+export class ObservableReleasesClient {
+  #client: ObservableSanityClient
+  #httpRequest: HttpRequest
+  constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  get(
+    {releaseId}: {releaseId: string},
+    options?: {signal?: AbortSignal; tag?: string},
+  ): Observable<ReleaseDocument | undefined> {
+    return _getDocument<ReleaseDocument>(
+      this.#client,
+      this.#httpRequest,
+      `_.releases.${releaseId}`,
+      options,
+    )
+  }
+
+  /**
+   * Creates a new release under the given id, with metadata.
+   *
+   * @param releaseId - The id of the release to create (with no prefix)
+   * @param metadata - The metadata to associate with the release {@link ReleaseDocument}
+   * Must include a `releaseType` {@link ReleaseType}
+   */
+  create(
+    options: BaseActionOptions,
+  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  create(
+    release: {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  create(
+    releaseOrOptions?:
+      | {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>}
+      | BaseActionOptions,
+    maybeOptions?: BaseActionOptions,
+  ): Observable<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}> {
+    const {action, options} = createRelease(releaseOrOptions, maybeOptions)
+    const {releaseId, metadata} = action
+
+    return _action(this.#client, this.#httpRequest, action, options).pipe(
+      map((actionResult) => ({
+        ...actionResult,
+        releaseId,
+        metadata,
+      })),
+    )
+  }
+
+  /**
+   * Edits an existing release, updating the metadata.
+   *
+   * @param releaseId - The id of the release to edit (with no prefix)
+   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
+   */
+  edit(
+    {releaseId, patch}: {releaseId: string; patch: PatchOperations},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const editAction: EditReleaseAction = {
+      actionType: 'sanity.action.release.edit',
+      releaseId,
+      patch,
+    }
+
+    return _action(this.#client, this.#httpRequest, editAction, options)
+  }
+
+  /**
+   * Publishes all documents in a release at once. For larger releases the effect of the publish
+   * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
+   * documents and creation of the corresponding published documents with the new content may
+   * take some time.
+   *
+   * During this period both the source and target documents are locked and cannot be
+   * modified through any other means.
+   *
+   * @param releaseId - The id of the release to publish (with no prefix)
+   */
+  publish(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const publishAction: PublishReleaseAction = {
+      actionType: 'sanity.action.release.publish',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, publishAction, options)
+  }
+
+  /**
+   * An archive action is used to remove an active release. The documents that comprise the release
+   * are deleted and therefore no longer queryable.
+   *
+   * While the documents remain in retention the last version can still be accessed using document history endpoint.
+   *
+   * @param releaseId - The id of the release to archive (with no prefix)
+   */
+  archive(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const archiveAction: ArchiveReleaseAction = {
+      actionType: 'sanity.action.release.archive',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, archiveAction, options)
+  }
+
+  /**
+   * An unarchive action is used to restore an archived release and all documents
+   * with the content they had just prior to archiving.
+   *
+   * @param releaseId - The id of the release to unarchive (with no prefix)
+   */
+  unarchive(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const unarchiveAction: UnarchiveReleaseAction = {
+      actionType: 'sanity.action.release.unarchive',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, unarchiveAction, options)
+  }
+
+  /**
+   * A schedule action queues a release for publishing at the given future time.
+   * The release is locked such that no documents in the release can be modified and
+   * no documents that it references can be deleted as this would make the publish fail.
+   * At the given time, the same logic as for the publish action is triggered.
+   *
+   * @param releaseId - The id of the release to schedule (with no prefix)
+   */
+  schedule(
+    {releaseId, publishAt}: {releaseId: string; publishAt: string},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const scheduleAction: ScheduleReleaseAction = {
+      actionType: 'sanity.action.release.schedule',
+      releaseId,
+      publishAt,
+    }
+
+    return _action(this.#client, this.#httpRequest, scheduleAction, options)
+  }
+
+  /**
+   * An unschedule action is used to stop a release from being published.
+   * The documents in the release are considered unlocked and can be edited again.
+   * This may fail if another release is scheduled to be published after this one and
+   * has a reference to a document created by this one.
+   *
+   * @param releaseId - The id of the release to unschedule (with no prefix)
+   */
+  unschedule(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const unscheduleAction: UnscheduleReleaseAction = {
+      actionType: 'sanity.action.release.unschedule',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, unscheduleAction, options)
+  }
+
+  /**
+   * A delete action is used to delete a published or archived release.
+   * The backing system document will be removed from the dataset.
+   *
+   * @param releaseId - The id of the release to delete (with no prefix)
+   */
+  delete(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult> {
+    const deleteAction: DeleteReleaseAction = {
+      actionType: 'sanity.action.release.delete',
+      releaseId,
+    }
+
+    return _action(this.#client, this.#httpRequest, deleteAction, options)
+  }
+
+  fetchDocuments(
+    {releaseId}: {releaseId: string},
+    options?: BaseMutationOptions,
+  ): Observable<RawQueryResponse<SanityDocument[]>> {
+    return _getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options)
+  }
+}
+
+/** @public */
+export class ReleasesClient {
+  #client: SanityClient
+  #httpRequest: HttpRequest
+  constructor(client: SanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  get(
+    {releaseId}: {releaseId: string},
+    options?: {signal?: AbortSignal; tag?: string},
+  ): Promise<ReleaseDocument | undefined> {
+    return lastValueFrom(
+      _getDocument<ReleaseDocument>(
+        this.#client,
+        this.#httpRequest,
+        `_.releases.${releaseId}`,
+        options,
+      ),
+    )
+  }
+
+  /**
+   * Creates a new release under the given id, with metadata.
+   *
+   * @param releaseId - The id of the release to create
+   * @param metadata - The metadata to associate with the release {@link ReleaseDocument}.
+   * Must include a `releaseType` {@link ReleaseType}
+   */
+  async create(
+    options: BaseActionOptions,
+  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  async create(
+    release: {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}>
+  async create(
+    releaseOrOptions?:
+      | {releaseId?: string; metadata?: Partial<ReleaseDocument['metadata']>}
+      | BaseActionOptions,
+    maybeOptions?: BaseActionOptions,
+  ): Promise<SingleActionResult & {releaseId: string; metadata: ReleaseDocument['metadata']}> {
+    const {action, options} = createRelease(releaseOrOptions, maybeOptions)
+    const {releaseId, metadata} = action
+
+    const actionResult = await lastValueFrom(
+      _action(this.#client, this.#httpRequest, action, options),
+    )
+
+    return {...actionResult, releaseId, metadata}
+  }
+
+  /**
+   * Edits an existing release, updating the metadata.
+   *
+   * @param releaseId - The id of the release to edit
+   * @param patch - The patch operation to apply on the release metadata {@link PatchMutationOperation}
+   */
+  edit(
+    {releaseId, patch}: {releaseId: string; patch: PatchOperations},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const editAction: EditReleaseAction = {
+      actionType: 'sanity.action.release.edit',
+      releaseId,
+      patch,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, editAction, options))
+  }
+
+  /**
+   * Publishes all documents in a release at once. For larger releases the effect of the publish
+   * will be visible immediately when querying but the removal of the `versions.<releasesId>.*`
+   * documents and creation of the corresponding published documents with the new content may
+   * take some time.
+   *
+   * During this period both the source and target documents are locked and cannot be
+   * modified through any other means.
+   *
+   * @param releaseId - The id of the release to publish
+   */
+  publish(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const publishAction: PublishReleaseAction = {
+      actionType: 'sanity.action.release.publish',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, publishAction, options))
+  }
+
+  /**
+   * An archive action is used to remove an active release. The documents that comprise the release
+   * are deleted and therefore no longer queryable.
+   *
+   * While the documents remain in retention the last version can still be accessed using document history endpoint.
+   *
+   * @param releaseId - The id of the release to archive
+   */
+  archive(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const archiveAction: ArchiveReleaseAction = {
+      actionType: 'sanity.action.release.archive',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, archiveAction, options))
+  }
+
+  /**
+   * An unarchive action is used to restore an archived release and all documents
+   * with the content they had just prior to archiving.
+   *
+   * @param releaseId - The id of the release to unarchive
+   */
+  unarchive(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const unarchiveAction: UnarchiveReleaseAction = {
+      actionType: 'sanity.action.release.unarchive',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, unarchiveAction, options))
+  }
+
+  /**
+   * A schedule action queues a release for publishing at the given future time.
+   * The release is locked such that no documents in the release can be modified and
+   * no documents that it references can be deleted as this would make the publish fail.
+   * At the given time, the same logic as for the publish action is triggered.
+   *
+   * @param releaseId - The id of the release to schedule
+   */
+  schedule(
+    {releaseId, publishAt}: {releaseId: string; publishAt: string},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const scheduleAction: ScheduleReleaseAction = {
+      actionType: 'sanity.action.release.schedule',
+      releaseId,
+      publishAt,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, scheduleAction, options))
+  }
+
+  /**
+   * An unschedule action is used to stop a release from being published.
+   * The documents in the release are considered unlocked and can be edited again.
+   * This may fail if another release is scheduled to be published after this one and
+   * has a reference to a document created by this one.
+   *
+   * @param releaseId - The id of the release to unschedule
+   */
+  unschedule(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const unscheduleAction: UnscheduleReleaseAction = {
+      actionType: 'sanity.action.release.unschedule',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, unscheduleAction, options))
+  }
+
+  /**
+   * A delete action is used to delete a published or archived release.
+   * The backing system document will be removed from the dataset.
+   *
+   * @param params - Object containing:
+   * - `releaseId` - The id of the release to delete
+   */
+  delete(
+    {releaseId}: {releaseId: string},
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult> {
+    const deleteAction: DeleteReleaseAction = {
+      actionType: 'sanity.action.release.delete',
+      releaseId,
+    }
+
+    return lastValueFrom(_action(this.#client, this.#httpRequest, deleteAction, options))
+  }
+
+  fetchDocuments(
+    {releaseId}: {releaseId: string},
+    options?: BaseMutationOptions,
+  ): Promise<RawQueryResponse<SanityDocument[]>> {
+    return lastValueFrom(_getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options))
+  }
+}

--- a/src/releases/createRelease.ts
+++ b/src/releases/createRelease.ts
@@ -1,0 +1,53 @@
+import type {BaseActionOptions, CreateReleaseAction, ReleaseDocument} from '@sanity/client'
+
+import {generateReleaseId} from '../util/createVersionId'
+
+interface ReleaseOrOptions extends BaseActionOptions {
+  releaseId?: string
+  metadata?: Partial<ReleaseDocument['metadata']>
+}
+
+interface CompleteCreateReleaseAction extends CreateReleaseAction {
+  metadata: ReleaseDocument['metadata']
+}
+
+const getArgs = (
+  releaseOrOptions?: ReleaseOrOptions,
+  maybeOptions?: BaseActionOptions,
+): [string, Partial<ReleaseDocument['metadata']>, BaseActionOptions | undefined] => {
+  const isReleaseInput =
+    typeof releaseOrOptions === 'object' &&
+    releaseOrOptions !== null &&
+    ('releaseId' in releaseOrOptions || 'metadata' in releaseOrOptions)
+
+  if (isReleaseInput) {
+    const {releaseId = generateReleaseId(), metadata = {}} = releaseOrOptions
+    return [releaseId, metadata, maybeOptions]
+  }
+
+  return [generateReleaseId(), {}, releaseOrOptions as BaseActionOptions]
+}
+
+/** @internal */
+export const createRelease = (
+  releaseOrOptions?: ReleaseOrOptions,
+  maybeOptions?: BaseActionOptions,
+): {
+  action: CompleteCreateReleaseAction
+  options?: BaseActionOptions
+} => {
+  const [releaseId, metadata, options] = getArgs(releaseOrOptions, maybeOptions)
+
+  const finalMetadata: ReleaseDocument['metadata'] = {
+    ...metadata,
+    releaseType: metadata.releaseType || 'undecided',
+  }
+
+  const createAction: CompleteCreateReleaseAction = {
+    actionType: 'sanity.action.release.create',
+    releaseId,
+    metadata: finalMetadata,
+  }
+
+  return {action: createAction, options}
+}

--- a/src/util/createVersionId.ts
+++ b/src/util/createVersionId.ts
@@ -1,0 +1,79 @@
+import {
+  getDraftId,
+  getVersionFromId,
+  getVersionId,
+  isDraftId,
+  isVersionId,
+} from '@sanity/client/csm'
+import {customAlphabet} from 'nanoid'
+
+import type {IdentifiedSanityDocumentStub, SanityDocumentStub} from '../types'
+import {validateVersionIdMatch} from '../validators'
+
+/**
+ * @internal
+ *
+ * ~24 years (or 7.54e+8 seconds) needed, in order to have a 1% probability of at least one collision if 10 ID's are generated every hour.
+ */
+export const generateReleaseId = customAlphabet(
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+  8,
+)
+
+/** @internal */
+export const getDocumentVersionId = (publishedId: string, releaseId?: string) =>
+  releaseId ? getVersionId(publishedId, releaseId) : getDraftId(publishedId)
+
+/** @internal */
+export function deriveDocumentVersionId(
+  op: string,
+  {
+    releaseId,
+    publishedId,
+    document,
+  }: {
+    releaseId?: string
+    publishedId?: string
+    document: SanityDocumentStub | IdentifiedSanityDocumentStub
+  },
+): string {
+  if (publishedId && document._id) {
+    const versionId = getDocumentVersionId(publishedId, releaseId)
+    validateVersionIdMatch(versionId, document)
+    return versionId
+  }
+
+  if (document._id) {
+    const isDraft = isDraftId(document._id)
+    const isVersion = isVersionId(document._id)
+
+    if (!isDraft && !isVersion) {
+      throw new Error(
+        `\`${op}()\` requires a document with an \`_id\` that is a version or draft ID`,
+      )
+    }
+
+    if (releaseId) {
+      if (isDraft) {
+        throw new Error(
+          `\`${op}()\` was called with a document ID (\`${document._id}\`) that is a draft ID, but a release ID (\`${releaseId}\`) was also provided.`,
+        )
+      }
+
+      const builtVersionId = getVersionFromId(document._id)
+      if (builtVersionId !== releaseId) {
+        throw new Error(
+          `\`${op}()\` was called with a document ID (\`${document._id}\`) that is a version ID, but the release ID (\`${releaseId}\`) does not match the document's version ID (\`${builtVersionId}\`).`,
+        )
+      }
+    }
+
+    return document._id
+  }
+
+  if (publishedId) {
+    return getDocumentVersionId(publishedId, releaseId)
+  }
+
+  throw new Error(`\`${op}()\` requires either a publishedId or a document with an \`_id\``)
+}

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,4 +1,4 @@
-import type {Any, InitializedClientConfig} from './types'
+import type {Any, InitializedClientConfig, SanityDocumentStub} from './types'
 
 const VALID_ASSET_TYPES = ['image', 'file']
 const VALID_INSERT_LOCATIONS = ['before', 'after', 'replace']
@@ -41,6 +41,28 @@ export const requireDocumentId = (op: string, doc: Record<string, Any>) => {
   }
 
   validateDocumentId(op, doc._id)
+}
+
+export const validateDocumentType = (op: string, type: string) => {
+  if (typeof type !== 'string') {
+    throw new Error(`\`${op}()\`: \`${type}\` is not a valid document type`)
+  }
+}
+
+export const requireDocumentType = (op: string, doc: Record<string, Any>) => {
+  if (!doc._type) {
+    throw new Error(`\`${op}()\` requires that the document contains a type (\`_type\` property)`)
+  }
+
+  validateDocumentType(op, doc._type)
+}
+
+export const validateVersionIdMatch = (builtVersionId: string, document: SanityDocumentStub) => {
+  if (document._id && document._id !== builtVersionId) {
+    throw new Error(
+      `The provided document ID (\`${document._id}\`) does not match the generated version ID (\`${builtVersionId}\`)`,
+    )
+  }
 }
 
 export const validateInsert = (at: string, selector: string, items: Any[]) => {

--- a/test/dataMethods.test.ts
+++ b/test/dataMethods.test.ts
@@ -1,7 +1,14 @@
-import {describe, expect, test} from 'vitest'
+import {Observable, of, Subscription} from 'rxjs'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import * as dataMethods from '../src/data/dataMethods'
-import type {ClientConfig} from '../src/types'
+import type {
+  ClientConfig,
+  HttpRequest,
+  InitializedClientConfig,
+  RawQueryResponse,
+  SanityDocument,
+} from '../src/types'
 
 const apiHost = 'api.sanity.url'
 const defaultProjectId = 'bf1942'
@@ -14,13 +21,129 @@ const clientConfig = {
   useCdn: false,
 }
 
-describe('dataMethods', async () => {
-  const isEdge = typeof EdgeRuntime === 'string'
-  const {createClient}: typeof import('../src') = await import(
-    isEdge ? '../dist/index.browser.js' : '../src'
-  )
-  const getClient = (conf?: ClientConfig) => createClient({...clientConfig, ...(conf || {})})
+const isEdge = typeof EdgeRuntime === 'string'
+const {createClient}: typeof import('../src') = await import(
+  isEdge ? '../dist/index.browser.js' : '../src'
+)
 
+const getClient = (conf?: ClientConfig) => createClient({...clientConfig, ...(conf || {})})
+
+const createMockResponse = (documents: SanityDocument[]) =>
+  of({
+    type: 'response',
+    body: {documents},
+  })
+
+const createMockQueryResponse = <T>(result: T) =>
+  of({
+    type: 'response',
+    body: {result},
+  })
+
+type ClientLike = {
+  config(): InitializedClientConfig | ClientConfig
+}
+
+type MethodOptions = {
+  tag?: string
+  signal?: AbortSignal
+  releaseId?: string
+  perspective?: string | string[]
+  [key: string]: unknown
+}
+
+type DataMethodFn<T = unknown, Args extends readonly unknown[] = readonly unknown[]> = (
+  clientObj: ClientLike,
+  httpRequest: HttpRequest,
+  ...args: [...Args, MethodOptions?]
+) => Observable<T>
+
+const assertObservable = <T>(
+  observable: Observable<T>,
+  assertion: (value: T) => void,
+): Promise<void> => {
+  return new Promise<void>((resolve, reject) => {
+    let hasRun = false
+    let subscriptionObj: Subscription | null = null
+
+    const observer = {
+      next: (value: T) => {
+        if (hasRun) return
+        hasRun = true
+
+        try {
+          assertion(value)
+          if (subscriptionObj) subscriptionObj.unsubscribe()
+          resolve()
+        } catch (err) {
+          if (subscriptionObj) subscriptionObj.unsubscribe()
+          reject(err)
+        }
+      },
+      error: (err: Error) => {
+        if (hasRun) return
+        hasRun = true
+
+        if (subscriptionObj) subscriptionObj.unsubscribe()
+        reject(err)
+      },
+      complete: () => {
+        if (hasRun) return
+        if (subscriptionObj) subscriptionObj.unsubscribe()
+      },
+    }
+
+    subscriptionObj = observable.subscribe(observer)
+  })
+}
+
+const testTagOption = <T = unknown>(
+  methodName: string,
+  methodFn: (typeof dataMethods)[keyof typeof dataMethods],
+  args: readonly unknown[] = [],
+) => {
+  test('passes tag option to request', () => {
+    const mockHttpRequest = vi.fn()
+    mockHttpRequest.mockReturnValueOnce(
+      methodName.includes('Documents') ? createMockQueryResponse([]) : createMockResponse([]),
+    )
+
+    const client = getClient()
+    const options = {tag: 'test-tag'}
+    const typedMethodFn = methodFn as DataMethodFn<T>
+    const observable = typedMethodFn(client, mockHttpRequest, ...args, options)
+
+    return assertObservable(observable, () => {
+      expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+      expect(mockHttpRequest.mock.calls[0][0].tag).toEqual('test-tag')
+    })
+  })
+}
+
+const testSignalOption = <T = unknown>(
+  methodName: string,
+  methodFn: (typeof dataMethods)[keyof typeof dataMethods],
+  args: readonly unknown[] = [],
+) => {
+  test('passes signal option to request', () => {
+    const mockHttpRequest = vi.fn()
+    mockHttpRequest.mockReturnValueOnce(
+      methodName.includes('Documents') ? createMockQueryResponse([]) : createMockResponse([]),
+    )
+
+    const client = getClient()
+    const signal = new AbortController().signal
+    const typedMethodFn = methodFn as DataMethodFn<T>
+    const observable = typedMethodFn(client, mockHttpRequest, ...args, {signal})
+
+    return assertObservable(observable, () => {
+      expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+      expect(mockHttpRequest.mock.calls[0][0].signal).toBe(signal)
+    })
+  })
+}
+
+describe('dataMethods', async () => {
   describe('getUrl', () => {
     test('can use getUrl() to get API-relative paths', () => {
       expect(dataMethods._getUrl(getClient(), '/bar/baz')).toEqual(`${projectHost()}/v1/bar/baz`)
@@ -30,6 +153,251 @@ describe('dataMethods', async () => {
       expect(dataMethods._getUrl(getClient({apiVersion: '2019-01-29'}), '/bar/baz')).toEqual(
         `${projectHost()}/v2019-01-29/bar/baz`,
       )
+    })
+  })
+
+  describe('_getDocument', () => {
+    const mockHttpRequest = vi.fn()
+    const docId = 'someDocId'
+    const draftId = 'drafts.someDocId'
+    const releaseId = 'someReleaseId'
+    const versionId = `versions.${releaseId}.${docId}`
+    const mockDoc = {
+      _id: docId,
+      _type: 'test',
+      title: 'Test Document',
+      _rev: '1',
+      _createdAt: '2021-01-01',
+      _updatedAt: '2021-01-02',
+    }
+
+    beforeEach(() => {
+      mockHttpRequest.mockClear()
+    })
+
+    test('fetches a document by ID', () => {
+      mockHttpRequest.mockReturnValueOnce(createMockResponse([mockDoc]))
+
+      const client = getClient()
+      const observable = dataMethods._getDocument(client, mockHttpRequest, docId)
+
+      return assertObservable(observable, (document) => {
+        expect(document).toEqual(mockDoc)
+        expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+        expect(mockHttpRequest.mock.calls[0][0].uri).toEqual(`/data/doc/foo/${docId}`)
+      })
+    })
+
+    test('returns undefined when document is not found', () => {
+      mockHttpRequest.mockReturnValueOnce(createMockResponse([]))
+
+      const client = getClient()
+      const observable = dataMethods._getDocument(client, mockHttpRequest, docId)
+
+      return assertObservable(observable, (document) => {
+        expect(document).toBeUndefined()
+      })
+    })
+
+    testTagOption('_getDocument', dataMethods._getDocument, [docId])
+    testSignalOption('_getDocument', dataMethods._getDocument, [docId])
+
+    test('uses version ID when releaseId is provided', () => {
+      mockHttpRequest.mockReturnValueOnce(createMockResponse([{...mockDoc, _id: versionId}]))
+
+      const client = getClient()
+      const observable = dataMethods._getDocument(client, mockHttpRequest, docId, {
+        releaseId,
+      })
+
+      return assertObservable(observable, () => {
+        expect(mockHttpRequest.mock.calls[0][0].uri).toEqual(
+          `/data/doc/foo/versions.${releaseId}.${docId}`,
+        )
+      })
+    })
+
+    test('throws error when releaseId is provided with a draft ID', () => {
+      const client = getClient()
+
+      expect(() => {
+        dataMethods._getDocument(client, mockHttpRequest, draftId, {releaseId})
+      }).toThrow(
+        'The document ID (`drafts.someDocId`) is a draft, but `options.releaseId` is set as `someReleaseId`',
+      )
+    })
+
+    test('keeps existing version ID if it matches releaseId', () => {
+      mockHttpRequest.mockReturnValueOnce(createMockResponse([{...mockDoc, _id: versionId}]))
+
+      const client = getClient()
+      const observable = dataMethods._getDocument(client, mockHttpRequest, versionId, {
+        releaseId,
+      })
+
+      return assertObservable(observable, () => {
+        expect(mockHttpRequest.mock.calls[0][0].uri).toEqual(
+          `/data/doc/foo/versions.${releaseId}.${docId}`,
+        )
+      })
+    })
+
+    test('throws error when document version ID does not match provided releaseId', () => {
+      const client = getClient()
+      const differentReleaseId = 'differentReleaseId'
+      const differentVersionId = `versions.${differentReleaseId}.${docId}`
+
+      expect(() => {
+        dataMethods._getDocument(client, mockHttpRequest, differentVersionId, {
+          releaseId,
+        })
+      }).toThrow(/The document ID .* is already a version .* but this does not match the provided/)
+    })
+  })
+
+  describe('_getDocuments', () => {
+    const mockHttpRequest = vi.fn()
+    const docIds = ['doc1', 'doc2', 'doc3']
+    const mockDocs = [
+      {
+        _id: 'doc1',
+        _type: 'test',
+        title: 'Document 1',
+        _rev: '1',
+        _createdAt: '2021-01-01',
+        _updatedAt: '2021-01-02',
+      },
+      {
+        _id: 'doc2',
+        _type: 'test',
+        title: 'Document 2',
+        _rev: '1',
+        _createdAt: '2021-01-01',
+        _updatedAt: '2021-01-02',
+      },
+      {
+        _id: 'doc3',
+        _type: 'test',
+        title: 'Document 3',
+        _rev: '1',
+        _createdAt: '2021-01-01',
+        _updatedAt: '2021-01-02',
+      },
+    ]
+
+    beforeEach(() => {
+      mockHttpRequest.mockClear()
+    })
+
+    test('fetches multiple documents by ID', () => {
+      mockHttpRequest.mockReturnValueOnce(createMockResponse(mockDocs))
+
+      const client = getClient()
+      const observable = dataMethods._getDocuments(client, mockHttpRequest, docIds)
+
+      return assertObservable(observable, (documents) => {
+        expect(documents).toEqual(mockDocs)
+        expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+        expect(mockHttpRequest.mock.calls[0][0].uri).toEqual('/data/doc/foo/doc1,doc2,doc3')
+      })
+    })
+
+    test('handles missing documents with null values', () => {
+      const availableDocs = [mockDocs[0], mockDocs[2]]
+      mockHttpRequest.mockReturnValueOnce(createMockResponse(availableDocs))
+
+      const client = getClient()
+      const observable = dataMethods._getDocuments(client, mockHttpRequest, docIds)
+
+      return assertObservable(observable, (documents) => {
+        expect(documents).toEqual([mockDocs[0], null, mockDocs[2]])
+      })
+    })
+
+    testTagOption('_getDocuments', dataMethods._getDocuments, [docIds])
+    testSignalOption('_getDocuments', dataMethods._getDocuments, [docIds])
+
+    test('fetches versioned documents', () => {
+      const releaseId = 'someReleaseId'
+      const versionIds = docIds.map((id) => `versions.${releaseId}.${id}`)
+      const versionDocs = mockDocs.map((doc, i) => ({...doc, _id: versionIds[i]}))
+
+      mockHttpRequest.mockReturnValueOnce(createMockResponse(versionDocs))
+
+      const client = getClient()
+      const observable = dataMethods._getDocuments(client, mockHttpRequest, versionIds)
+
+      return assertObservable(observable, (documents) => {
+        expect(documents).toEqual(versionDocs)
+        expect(mockHttpRequest.mock.calls[0][0].uri).toEqual(
+          `/data/doc/foo/versions.${releaseId}.doc1,versions.${releaseId}.doc2,versions.${releaseId}.doc3`,
+        )
+      })
+    })
+  })
+
+  describe('_getReleaseDocuments', () => {
+    const mockHttpRequest = vi.fn()
+    const releaseId = 'summerRelease'
+    const mockDocs = [
+      {
+        _id: 'versions.summerRelease.doc1',
+        _type: 'test',
+        title: 'Document 1',
+        _rev: '1',
+        _createdAt: '2021-01-01',
+        _updatedAt: '2021-01-02',
+      },
+      {
+        _id: 'versions.summerRelease.doc2',
+        _type: 'test',
+        title: 'Document 2',
+        _rev: '1',
+        _createdAt: '2021-01-01',
+        _updatedAt: '2021-01-02',
+      },
+    ]
+
+    beforeEach(() => {
+      mockHttpRequest.mockClear()
+    })
+
+    test('fetches all documents in a release with correct query', () => {
+      mockHttpRequest.mockReturnValueOnce(createMockQueryResponse(mockDocs))
+
+      const client = getClient()
+      const observable = dataMethods._getReleaseDocuments(client, mockHttpRequest, releaseId)
+
+      return assertObservable<RawQueryResponse<SanityDocument[]>>(observable, (response) => {
+        expect(response.result).toEqual(mockDocs)
+        expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+
+        const request = mockHttpRequest.mock.calls[0][0]
+        const uri = decodeURIComponent(request.uri)
+
+        expect(uri).toContain('/data/query/foo')
+        expect(uri).toContain('query=*[sanity::partOfRelease($releaseId)]')
+        expect(uri).toContain(`$releaseId="${releaseId}"`)
+      })
+    })
+
+    testTagOption('_getReleaseDocuments', dataMethods._getReleaseDocuments, [releaseId])
+
+    test('handles empty response', () => {
+      mockHttpRequest.mockReturnValueOnce(createMockQueryResponse([]))
+
+      const client = getClient()
+      const observable = dataMethods._getReleaseDocuments(client, mockHttpRequest, releaseId)
+
+      return assertObservable<RawQueryResponse<SanityDocument[]>>(observable, (response) => {
+        expect(response.result).toEqual([])
+
+        const request = mockHttpRequest.mock.calls[0][0]
+        const uri = decodeURIComponent(request.uri)
+
+        expect(uri).toContain('query=*[sanity::partOfRelease($releaseId)]')
+        expect(uri).toContain(`$releaseId="${releaseId}"`)
+      })
     })
   })
 })

--- a/test/releasesClient.test.ts
+++ b/test/releasesClient.test.ts
@@ -1,0 +1,1049 @@
+import {createClient} from '@sanity/client'
+import nock from 'nock'
+import {firstValueFrom, Observable, Subscriber} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {ObservableReleasesClient, ReleasesClient} from '../src/releases/ReleasesClient'
+import type {ObservableSanityClient, SanityClient} from '../src/SanityClient'
+import type {
+  ApiError,
+  ArchiveReleaseAction,
+  BaseActionOptions,
+  CreateReleaseAction,
+  DeleteReleaseAction,
+  EditReleaseAction,
+  HttpRequest,
+  PatchOperations,
+  PublishReleaseAction,
+  ReleaseAction,
+  ReleaseDocument,
+  ReleaseType,
+  RequestOptions,
+  ResponseEvent,
+  ScheduleReleaseAction,
+  SingleActionResult,
+  UnarchiveReleaseAction,
+  UnscheduleReleaseAction,
+} from '../src/types'
+import * as createVersionIdModule from '../src/util/createVersionId'
+
+type MockResponseEvent = Partial<ResponseEvent>
+
+vi.mock('../src/util/createVersionId', () => ({
+  generateReleaseId: vi.fn().mockReturnValue('generatedReleaseId'),
+}))
+
+const TEST_PROJECT_ID = 'test123'
+const TEST_DATASET = 'test-dataset'
+const TEST_PROJECT_HOST = `https://${TEST_PROJECT_ID}.api.sanity.io`
+const TEST_RELEASE_ID = 'release123'
+const TEST_METADATA = {
+  releaseType: 'scheduled' as ReleaseType,
+  title: 'Test Release',
+}
+const TEST_PUBLISH_AT = '2023-12-31T12:00:00.000Z'
+
+const TEST_TXN_ID = 'txn123'
+
+const mockHttpSuccess = (httpRequest: ReturnType<typeof vi.fn>, transactionId: string) => {
+  httpRequest.mockImplementationOnce(() => ({
+    subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+      subscriber.next?.({
+        type: 'response',
+        body: {transactionId},
+      })
+      subscriber.complete?.()
+      return {unsubscribe: () => {}}
+    },
+  }))
+}
+
+const mockHttpError = (
+  httpRequest: ReturnType<typeof vi.fn>,
+  errorMessage: string,
+  details?: ApiError,
+) => {
+  httpRequest.mockImplementationOnce(() => ({
+    subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+      const error = new Error(errorMessage)
+      Object.defineProperty(error, 'details', {value: details})
+      subscriber.error?.(error)
+      return {unsubscribe: () => {}}
+    },
+  }))
+}
+
+const mockHttpDocumentResponse = (
+  httpRequest: ReturnType<typeof vi.fn>,
+  document: Partial<ReleaseDocument>,
+) => {
+  httpRequest.mockImplementationOnce(() => ({
+    subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+      subscriber.next?.({
+        type: 'response',
+        body: {documents: [document]},
+      })
+      subscriber.complete?.()
+      return {unsubscribe: () => {}}
+    },
+  }))
+}
+
+const createTestActionMethod = (httpRequest: ReturnType<typeof vi.fn>) => {
+  return <T extends ReleaseAction>(
+    methodName: string,
+    actionType: T['actionType'],
+    executeMethod: (options?: BaseActionOptions) => Promise<SingleActionResult>,
+    expectedAction: Omit<T, 'actionType'>,
+  ) => {
+    test(`${methodName} executes with correct action`, async () => {
+      mockHttpSuccess(httpRequest, TEST_TXN_ID)
+
+      const result = await executeMethod()
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.body.actions).toContainEqual({
+        actionType,
+        ...expectedAction,
+      })
+
+      expect(result).toEqual({
+        transactionId: TEST_TXN_ID,
+      })
+    })
+
+    test(`${methodName} forwards options to action method`, async () => {
+      const options = {
+        transactionId: 'custom-txn',
+        tag: `releases.${methodName}`,
+      }
+
+      mockHttpSuccess(httpRequest, 'custom-txn')
+
+      await executeMethod(options)
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.tag).toEqual(options.tag)
+      expect(requestArgs.body.transactionId).toEqual(options.transactionId)
+    })
+  }
+}
+
+const httpRequest = vi.fn().mockImplementation(() => ({
+  subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+    subscriber.next?.({type: 'response', body: {}})
+    subscriber.complete?.()
+    return {unsubscribe: () => {}}
+  },
+}))
+
+const testActionMethod = createTestActionMethod(httpRequest)
+
+describe('ReleasesClient', () => {
+  let client: SanityClient
+  let releasesClient: ReleasesClient
+
+  beforeEach(() => {
+    client = createClient({
+      projectId: TEST_PROJECT_ID,
+      dataset: TEST_DATASET,
+      apiVersion: '1',
+      useCdn: false,
+    })
+
+    httpRequest.mockClear()
+
+    releasesClient = new ReleasesClient(client, httpRequest)
+
+    nock.disableNetConnect()
+    vi.mocked(createVersionIdModule.generateReleaseId).mockReturnValue('generatedReleaseId')
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    vi.resetAllMocks()
+  })
+
+  describe('get()', () => {
+    test('fetches a release document by ID', async () => {
+      const releaseDocument: Partial<ReleaseDocument> = {
+        _id: `_.releases.${TEST_RELEASE_ID}`,
+        _type: 'system.release',
+        metadata: TEST_METADATA,
+        _rev: '123',
+        _createdAt: '2023-01-01T00:00:00.000Z',
+        _updatedAt: '2023-01-01T00:00:00.000Z',
+      }
+
+      nock(TEST_PROJECT_HOST)
+        .get(`/v1/data/doc/${TEST_DATASET}/_.releases.${TEST_RELEASE_ID}`)
+        .reply(200, {
+          documents: [releaseDocument],
+        })
+
+      mockHttpDocumentResponse(httpRequest, releaseDocument as Partial<ReleaseDocument>)
+
+      const result = await releasesClient.get({releaseId: TEST_RELEASE_ID})
+      expect(result).toEqual(releaseDocument)
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.uri).toEqual(`/data/doc/${TEST_DATASET}/_.releases.${TEST_RELEASE_ID}`)
+    })
+
+    test('returns undefined when release does not exist', async () => {
+      const releaseId = 'nonexistent'
+
+      nock(TEST_PROJECT_HOST)
+        .get(`/v1/data/doc/${TEST_DATASET}/_.releases.${releaseId}`)
+        .reply(200, {
+          documents: [],
+        })
+
+      httpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({type: 'response', body: {documents: []}})
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = await releasesClient.get({releaseId})
+      expect(result).toBeUndefined()
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.uri).toEqual(`/data/doc/${TEST_DATASET}/_.releases.${releaseId}`)
+    })
+
+    test('forwards signal and tag options', async () => {
+      const abortController = new AbortController()
+      const options = {
+        signal: abortController.signal,
+        tag: 'releases.get',
+      }
+
+      httpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({type: 'response', body: {documents: []}})
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      await releasesClient.get({releaseId: TEST_RELEASE_ID}, options)
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.signal).toEqual(options.signal)
+      expect(requestArgs.tag).toEqual(options.tag)
+    })
+  })
+
+  describe('create()', () => {
+    test('creates a release with provided ID and metadata', async () => {
+      const metadata = {
+        releaseType: 'scheduled' as ReleaseType,
+        title: 'Custom Release',
+      }
+
+      const expectedAction = {
+        actionType: 'sanity.action.release.create',
+        releaseId: TEST_RELEASE_ID,
+        metadata,
+      }
+
+      mockHttpSuccess(httpRequest, TEST_TXN_ID)
+
+      const result = await releasesClient.create({releaseId: TEST_RELEASE_ID, metadata})
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.body.actions).toContainEqual(expectedAction)
+
+      expect(result).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: TEST_RELEASE_ID,
+        metadata,
+      })
+    })
+
+    test('creates a release with undefined metadata', async () => {
+      const expectedMetadata = {
+        releaseType: 'undecided',
+      }
+
+      const expectedAction = {
+        actionType: 'sanity.action.release.create',
+        releaseId: TEST_RELEASE_ID,
+        metadata: expectedMetadata,
+      }
+
+      mockHttpSuccess(httpRequest, TEST_TXN_ID)
+
+      const result = await releasesClient.create({releaseId: TEST_RELEASE_ID})
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.body.actions).toContainEqual(expectedAction)
+
+      expect(result).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: TEST_RELEASE_ID,
+        metadata: expectedMetadata,
+      })
+    })
+
+    test('creates a release with metadata missing releaseType', async () => {
+      const metadata = {
+        title: 'Release without type',
+      }
+
+      const expectedMetadata = {
+        ...metadata,
+        releaseType: 'undecided',
+      }
+
+      const expectedAction = {
+        actionType: 'sanity.action.release.create',
+        releaseId: TEST_RELEASE_ID,
+        metadata: expectedMetadata,
+      }
+
+      mockHttpSuccess(httpRequest, TEST_TXN_ID)
+
+      const result = await releasesClient.create({releaseId: TEST_RELEASE_ID, metadata})
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.body.actions).toContainEqual(expectedAction)
+
+      expect(result).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: TEST_RELEASE_ID,
+        metadata: expectedMetadata,
+      })
+    })
+
+    test('generates release ID if not provided', async () => {
+      const metadata = {
+        releaseType: 'asap' as ReleaseType,
+        name: 'Generated ID Release',
+      }
+
+      mockHttpSuccess(httpRequest, TEST_TXN_ID)
+
+      const result = await releasesClient.create({metadata})
+
+      expect(vi.mocked(createVersionIdModule.generateReleaseId)).toHaveBeenCalled()
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+
+      expect(result).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: 'generatedReleaseId',
+        metadata,
+      })
+    })
+
+    test('forwards options to action method', async () => {
+      const metadata = {
+        releaseType: 'scheduled' as ReleaseType,
+        title: 'Test Release',
+      }
+
+      const options = {
+        transactionId: 'custom-txn',
+        tag: 'releases.create',
+      }
+
+      mockHttpSuccess(httpRequest, 'custom-txn')
+
+      await releasesClient.create({releaseId: TEST_RELEASE_ID, metadata}, options)
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.tag).toEqual(options.tag)
+      expect(requestArgs.body.transactionId).toEqual(options.transactionId)
+    })
+
+    test('auto-generates both releaseId and metadata.releaseType when neither is provided', async () => {
+      mockHttpSuccess(httpRequest, TEST_TXN_ID)
+
+      const result = await releasesClient.create({})
+
+      expect(vi.mocked(createVersionIdModule.generateReleaseId)).toHaveBeenCalled()
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+
+      const requestArgs = httpRequest.mock.calls[0][0]
+      const action = requestArgs.body.actions[0]
+
+      expect(action.releaseId).toEqual('generatedReleaseId')
+      expect(action.metadata.releaseType).toEqual('undecided')
+
+      expect(result).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: 'generatedReleaseId',
+        metadata: {
+          releaseType: 'undecided',
+        },
+      })
+    })
+
+    test('handles options as the first parameter and auto-generates release data', async () => {
+      const options = {
+        transactionId: 'options-txn',
+        tag: 'releases.create.options',
+      }
+
+      mockHttpSuccess(httpRequest, options.transactionId)
+
+      const result = await releasesClient.create(options)
+
+      expect(vi.mocked(createVersionIdModule.generateReleaseId)).toHaveBeenCalled()
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.tag).toEqual(options.tag)
+      expect(requestArgs.body.transactionId).toEqual(options.transactionId)
+
+      const action = requestArgs.body.actions[0]
+      expect(action.releaseId).toEqual('generatedReleaseId')
+      expect(action.metadata.releaseType).toEqual('undecided')
+
+      expect(result).toEqual({
+        transactionId: options.transactionId,
+        releaseId: 'generatedReleaseId',
+        metadata: {
+          releaseType: 'undecided',
+        },
+      })
+    })
+  })
+
+  describe('edit()', () => {
+    const patch: PatchOperations = {set: {title: 'New Title'}}
+
+    testActionMethod<EditReleaseAction>(
+      'edit',
+      'sanity.action.release.edit',
+      (options) => releasesClient.edit({releaseId: TEST_RELEASE_ID, patch}, options),
+      {releaseId: TEST_RELEASE_ID, patch},
+    )
+  })
+
+  describe('publish()', () => {
+    testActionMethod<PublishReleaseAction>(
+      'publish',
+      'sanity.action.release.publish',
+      (options) => releasesClient.publish({releaseId: TEST_RELEASE_ID}, options),
+      {releaseId: TEST_RELEASE_ID},
+    )
+  })
+
+  describe('archive()', () => {
+    testActionMethod<ArchiveReleaseAction>(
+      'archive',
+      'sanity.action.release.archive',
+      (options) => releasesClient.archive({releaseId: TEST_RELEASE_ID}, options),
+      {releaseId: TEST_RELEASE_ID},
+    )
+  })
+
+  describe('unarchive()', () => {
+    testActionMethod<UnarchiveReleaseAction>(
+      'unarchive',
+      'sanity.action.release.unarchive',
+      (options) => releasesClient.unarchive({releaseId: TEST_RELEASE_ID}, options),
+      {releaseId: TEST_RELEASE_ID},
+    )
+  })
+
+  describe('schedule()', () => {
+    testActionMethod<ScheduleReleaseAction>(
+      'schedule',
+      'sanity.action.release.schedule',
+      (options) =>
+        releasesClient.schedule({releaseId: TEST_RELEASE_ID, publishAt: TEST_PUBLISH_AT}, options),
+      {releaseId: TEST_RELEASE_ID, publishAt: TEST_PUBLISH_AT},
+    )
+  })
+
+  describe('unschedule()', () => {
+    testActionMethod<UnscheduleReleaseAction>(
+      'unschedule',
+      'sanity.action.release.unschedule',
+      (options) => releasesClient.unschedule({releaseId: TEST_RELEASE_ID}, options),
+      {releaseId: TEST_RELEASE_ID},
+    )
+  })
+
+  describe('delete()', () => {
+    testActionMethod<DeleteReleaseAction>(
+      'delete',
+      'sanity.action.release.delete',
+      (options) => releasesClient.delete({releaseId: TEST_RELEASE_ID}, options),
+      {releaseId: TEST_RELEASE_ID},
+    )
+  })
+
+  describe('fetchDocuments()', () => {
+    test('retrieves documents for a release by ID', async () => {
+      const documents = [
+        {_id: 'doc1', _type: 'post', title: 'Document 1'},
+        {_id: 'doc2', _type: 'post', title: 'Document 2'},
+      ]
+
+      httpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({type: 'response', body: {result: documents}})
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = await releasesClient.fetchDocuments({releaseId: TEST_RELEASE_ID})
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(decodeURIComponent(requestArgs.uri)).toEqual(
+        '/data/query/test-dataset?query=*[sanity::partOfRelease($releaseId)]&$releaseId="release123"',
+      )
+
+      expect(result).toEqual({result: documents})
+    })
+
+    test('forwards options to underlying method', async () => {
+      const options = {
+        tag: 'releases.documents',
+        signal: new AbortController().signal,
+      }
+
+      httpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({type: 'response', body: {result: []}})
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      await releasesClient.fetchDocuments({releaseId: TEST_RELEASE_ID}, options)
+
+      expect(httpRequest).toHaveBeenCalledTimes(1)
+      const requestArgs = httpRequest.mock.calls[0][0]
+      expect(requestArgs.tag).toEqual(options.tag)
+      expect(requestArgs.signal).toEqual(options.signal)
+    })
+  })
+
+  describe('error handling', () => {
+    test('propagates server errors when getting a release', async () => {
+      mockHttpError(httpRequest, 'Server error')
+      await expect(releasesClient.get({releaseId: TEST_RELEASE_ID})).rejects.toThrow('Server error')
+    })
+
+    test('propagates HTTP errors when creating a release', async () => {
+      const metadata = {
+        releaseType: 'scheduled' as ReleaseType,
+        title: 'Custom Release',
+      }
+      mockHttpError(httpRequest, 'Network error')
+      await expect(releasesClient.create({releaseId: TEST_RELEASE_ID, metadata})).rejects.toThrow(
+        'Network error',
+      )
+    })
+
+    test('propagates error responses with error details', async () => {
+      const patch = {
+        set: {
+          'metadata.title': 'Updated Release Name',
+        },
+      }
+      const errorResponse: ApiError = {
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Invalid patch operation',
+      }
+      mockHttpError(httpRequest, 'Invalid patch operation', errorResponse)
+      await expect(releasesClient.edit({releaseId: TEST_RELEASE_ID, patch})).rejects.toMatchObject({
+        message: expect.stringContaining('Invalid patch operation'),
+        details: expect.objectContaining(errorResponse),
+      })
+    })
+
+    test('propagates validation errors when publishing a release', async () => {
+      const validationError = new Error('Release not found')
+      validationError.name = 'ValidationError'
+
+      httpRequest
+        .mockImplementationOnce(() => ({
+          subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+            if (subscriber.error) subscriber.error(validationError)
+            return {unsubscribe: () => {}}
+          },
+        }))
+        .mockImplementationOnce(() => ({
+          subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+            if (subscriber.error) subscriber.error(validationError)
+            return {unsubscribe: () => {}}
+          },
+        }))
+
+      await expect(releasesClient.publish({releaseId: TEST_RELEASE_ID})).rejects.toThrow(
+        'Release not found',
+      )
+      await expect(releasesClient.publish({releaseId: TEST_RELEASE_ID})).rejects.toHaveProperty(
+        'name',
+        'ValidationError',
+      )
+    })
+
+    test('handles timeout errors', async () => {
+      const timeoutError = new Error('Request timed out')
+      timeoutError.name = 'TimeoutError'
+
+      httpRequest
+        .mockImplementationOnce(() => ({
+          subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+            if (subscriber.error) subscriber.error(timeoutError)
+            return {unsubscribe: () => {}}
+          },
+        }))
+        .mockImplementationOnce(() => ({
+          subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+            if (subscriber.error) subscriber.error(timeoutError)
+            return {unsubscribe: () => {}}
+          },
+        }))
+
+      await expect(releasesClient.archive({releaseId: TEST_RELEASE_ID})).rejects.toThrow(
+        'Request timed out',
+      )
+      await expect(releasesClient.archive({releaseId: TEST_RELEASE_ID})).rejects.toHaveProperty(
+        'name',
+        'TimeoutError',
+      )
+    })
+
+    test('handles aborted requests', async () => {
+      const abortError = new Error('Request aborted')
+      abortError.name = 'AbortError'
+
+      httpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          if (subscriber.error) subscriber.error(abortError)
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const abortController = new AbortController()
+      const promise = releasesClient.unarchive(
+        {releaseId: TEST_RELEASE_ID},
+        {signal: abortController.signal},
+      )
+
+      await expect(promise).rejects.toThrow('Request aborted')
+      await expect(promise).rejects.toHaveProperty('name', 'AbortError')
+    })
+  })
+})
+
+describe('ObservableReleasesClient', () => {
+  let client: SanityClient
+  let observableHttpRequest: ReturnType<typeof vi.fn>
+  let observableReleasesClient: ObservableReleasesClient
+
+  beforeEach(() => {
+    client = createClient({
+      projectId: TEST_PROJECT_ID,
+      dataset: TEST_DATASET,
+      apiVersion: '1',
+      useCdn: false,
+    })
+
+    observableHttpRequest = vi.fn().mockImplementation(() => ({
+      subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+        subscriber.next?.({type: 'response', body: {}})
+        subscriber.complete?.()
+        return {unsubscribe: () => {}}
+      },
+    }))
+
+    observableReleasesClient = new ObservableReleasesClient(
+      client.observable as ObservableSanityClient,
+      observableHttpRequest as HttpRequest,
+    )
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  const testObservableMethodForClient = (
+    methodName: keyof ObservableReleasesClient,
+    executeMethod: () => Observable<SingleActionResult>,
+  ) => {
+    test(`returns an observable for ${methodName} action`, async () => {
+      mockHttpSuccess(observableHttpRequest, TEST_TXN_ID)
+
+      const result = executeMethod()
+      expect(result).toBeDefined()
+      expect(await firstValueFrom(result)).toEqual({transactionId: TEST_TXN_ID})
+    })
+  }
+
+  describe('get()', () => {
+    test('returns an observable for a release document', async () => {
+      const releaseDocument: Partial<ReleaseDocument> = {
+        _id: `_.releases.${TEST_RELEASE_ID}`,
+        _type: 'system.release',
+        metadata: {
+          releaseType: 'scheduled' as ReleaseType,
+          title: 'Test Release',
+        },
+      }
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({
+            type: 'response',
+            body: {documents: [releaseDocument]},
+          })
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = observableReleasesClient.get({releaseId: TEST_RELEASE_ID})
+
+      expect(result).toBeDefined()
+      expect(await firstValueFrom(result)).toEqual(releaseDocument)
+    })
+  })
+
+  describe('create()', () => {
+    test('returns an observable for create action with provided ID', async () => {
+      const metadata = {
+        releaseType: 'scheduled' as ReleaseType,
+        title: 'Custom Release',
+      }
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({
+            type: 'response',
+            body: {transactionId: TEST_TXN_ID},
+          })
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = observableReleasesClient.create({releaseId: TEST_RELEASE_ID, metadata})
+
+      expect(result).toBeDefined()
+      expect(await firstValueFrom(result)).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: TEST_RELEASE_ID,
+        metadata,
+      })
+    })
+
+    test('returns an observable for create action with undefined metadata', async () => {
+      const expectedMetadata = {
+        releaseType: 'undecided',
+      }
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({
+            type: 'response',
+            body: {transactionId: TEST_TXN_ID},
+          })
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = observableReleasesClient.create({releaseId: TEST_RELEASE_ID})
+
+      expect(result).toBeDefined()
+      const response = await firstValueFrom(result)
+      expect(response).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: TEST_RELEASE_ID,
+        metadata: expectedMetadata,
+      })
+    })
+
+    test('returns an observable for create action with metadata missing releaseType', async () => {
+      const metadata = {
+        title: 'Release without type',
+      }
+
+      const expectedMetadata = {
+        ...metadata,
+        releaseType: 'undecided',
+      }
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({
+            type: 'response',
+            body: {transactionId: TEST_TXN_ID},
+          })
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = observableReleasesClient.create({releaseId: TEST_RELEASE_ID, metadata})
+
+      expect(result).toBeDefined()
+      const response = await firstValueFrom(result)
+      expect(response).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: TEST_RELEASE_ID,
+        metadata: expectedMetadata,
+      })
+    })
+
+    test('generates release ID if not provided', async () => {
+      const metadata = {
+        releaseType: 'asap' as ReleaseType,
+        name: 'Generated ID Release',
+      }
+
+      vi.mocked(createVersionIdModule.generateReleaseId).mockClear()
+      vi.mocked(createVersionIdModule.generateReleaseId).mockReturnValue('generatedReleaseId')
+
+      observableHttpRequest.mockImplementationOnce((options: RequestOptions) => {
+        const action = (options.body as {actions: CreateReleaseAction[]}).actions[0]
+        action.releaseId = 'generatedReleaseId'
+
+        return {
+          subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+            subscriber.next?.({
+              type: 'response',
+              body: {
+                transactionId: TEST_TXN_ID,
+                releaseId: 'generatedReleaseId',
+                metadata,
+              },
+            })
+            subscriber.complete?.()
+            return {unsubscribe: () => {}}
+          },
+        }
+      })
+
+      const result = observableReleasesClient.create({metadata})
+
+      expect(vi.mocked(createVersionIdModule.generateReleaseId)).toHaveBeenCalled()
+
+      const response = await firstValueFrom(result)
+      expect(response.transactionId).toEqual(TEST_TXN_ID)
+      expect(response.releaseId).toEqual('generatedReleaseId')
+      expect(response.metadata).toEqual(metadata)
+    })
+
+    test('auto-generates both releaseId and metadata.releaseType when neither is provided', async () => {
+      vi.mocked(createVersionIdModule.generateReleaseId).mockClear()
+      vi.mocked(createVersionIdModule.generateReleaseId).mockReturnValue('generatedReleaseId')
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({
+            type: 'response',
+            body: {transactionId: TEST_TXN_ID},
+          })
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = observableReleasesClient.create({})
+      const response = await firstValueFrom(result)
+
+      expect(vi.mocked(createVersionIdModule.generateReleaseId)).toHaveBeenCalled()
+      expect(observableHttpRequest).toHaveBeenCalledTimes(1)
+
+      const requestArgs = observableHttpRequest.mock.calls[0][0]
+      const action = requestArgs.body.actions[0]
+
+      expect(action.releaseId).toEqual('generatedReleaseId')
+      expect(action.metadata.releaseType).toEqual('undecided')
+
+      expect(response).toEqual({
+        transactionId: TEST_TXN_ID,
+        releaseId: 'generatedReleaseId',
+        metadata: {
+          releaseType: 'undecided',
+        },
+      })
+    })
+
+    test('handles options as the first parameter and auto-generates release data', async () => {
+      vi.mocked(createVersionIdModule.generateReleaseId).mockClear()
+      vi.mocked(createVersionIdModule.generateReleaseId).mockReturnValue('generatedReleaseId')
+
+      const options = {
+        transactionId: 'options-txn',
+        tag: 'releases.create.options',
+      }
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({
+            type: 'response',
+            body: {transactionId: options.transactionId},
+          })
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = observableReleasesClient.create(options)
+      const response = await firstValueFrom(result)
+
+      expect(vi.mocked(createVersionIdModule.generateReleaseId)).toHaveBeenCalled()
+      expect(observableHttpRequest).toHaveBeenCalledTimes(1)
+
+      const requestArgs = observableHttpRequest.mock.calls[0][0]
+      expect(requestArgs.tag).toEqual(options.tag)
+      expect(requestArgs.body.transactionId).toEqual(options.transactionId)
+
+      const action = requestArgs.body.actions[0]
+      expect(action.releaseId).toEqual('generatedReleaseId')
+      expect(action.metadata.releaseType).toEqual('undecided')
+
+      expect(response).toEqual({
+        transactionId: options.transactionId,
+        releaseId: 'generatedReleaseId',
+        metadata: {
+          releaseType: 'undecided',
+        },
+      })
+    })
+  })
+
+  describe('edit()', () => {
+    const patch: PatchOperations = {set: {title: 'New Title'}}
+
+    testObservableMethodForClient('edit', () =>
+      observableReleasesClient.edit({releaseId: TEST_RELEASE_ID, patch}),
+    )
+  })
+
+  describe('publish()', () => {
+    testObservableMethodForClient('publish', () =>
+      observableReleasesClient.publish({releaseId: TEST_RELEASE_ID}),
+    )
+  })
+
+  describe('archive()', () => {
+    testObservableMethodForClient('archive', () =>
+      observableReleasesClient.archive({releaseId: TEST_RELEASE_ID}),
+    )
+  })
+
+  describe('unarchive()', () => {
+    testObservableMethodForClient('unarchive', () =>
+      observableReleasesClient.unarchive({releaseId: TEST_RELEASE_ID}),
+    )
+  })
+
+  describe('schedule()', () => {
+    testObservableMethodForClient('schedule', () =>
+      observableReleasesClient.schedule({releaseId: TEST_RELEASE_ID, publishAt: TEST_PUBLISH_AT}),
+    )
+  })
+
+  describe('unschedule()', () => {
+    testObservableMethodForClient('unschedule', () =>
+      observableReleasesClient.unschedule({releaseId: TEST_RELEASE_ID}),
+    )
+  })
+
+  describe('delete()', () => {
+    testObservableMethodForClient('delete', () =>
+      observableReleasesClient.delete({releaseId: TEST_RELEASE_ID}),
+    )
+  })
+
+  describe('fetchDocuments()', () => {
+    test('returns an observable for fetchDocuments action', async () => {
+      const documents = [
+        {_id: 'doc1', _type: 'post', title: 'Document 1'},
+        {_id: 'doc2', _type: 'post', title: 'Document 2'},
+      ]
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          subscriber.next?.({type: 'response', body: {result: documents}})
+          subscriber.complete?.()
+          return {unsubscribe: () => {}}
+        },
+      }))
+
+      const result = observableReleasesClient.fetchDocuments({releaseId: TEST_RELEASE_ID})
+      expect(result).toBeDefined()
+      expect(await firstValueFrom(result)).toEqual({result: documents})
+    })
+  })
+
+  describe('error handling', () => {
+    test('emits errors when getting a release', async () => {
+      mockHttpError(observableHttpRequest, 'Server error')
+      const result = observableReleasesClient.get({releaseId: TEST_RELEASE_ID})
+      await expect(firstValueFrom(result)).rejects.toThrow('Server error')
+    })
+
+    test('emits errors when creating a release', async () => {
+      const metadata = {
+        releaseType: 'scheduled' as ReleaseType,
+        title: 'Custom Release',
+      }
+      mockHttpError(observableHttpRequest, 'Network error')
+      const result = observableReleasesClient.create({releaseId: TEST_RELEASE_ID, metadata})
+      await expect(firstValueFrom(result)).rejects.toThrow('Network error')
+    })
+
+    test('emits error responses with detailed error information', async () => {
+      const patch = {
+        set: {
+          'metadata.title': 'Updated Release Name',
+        },
+      }
+      const errorResponse: ApiError = {
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Invalid patch operation',
+      }
+      mockHttpError(observableHttpRequest, 'Invalid patch operation', errorResponse)
+      const result = observableReleasesClient.edit({releaseId: TEST_RELEASE_ID, patch})
+      await expect(firstValueFrom(result)).rejects.toMatchObject({
+        message: expect.stringContaining('Invalid patch operation'),
+        details: expect.objectContaining(errorResponse),
+      })
+    })
+
+    test('properly cleans up subscriptions when errors occur', async () => {
+      const unsubscribeSpy = vi.fn()
+
+      observableHttpRequest.mockImplementationOnce(() => ({
+        subscribe: (subscriber: Subscriber<MockResponseEvent>) => {
+          if (subscriber.error) subscriber.error(new Error('Server error'))
+          return {unsubscribe: unsubscribeSpy}
+        },
+      }))
+
+      const result = observableReleasesClient.get({releaseId: TEST_RELEASE_ID})
+      await expect(firstValueFrom(result)).rejects.toThrow('Server error')
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(unsubscribeSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/test/util/createVersionId.test.ts
+++ b/test/util/createVersionId.test.ts
@@ -1,0 +1,213 @@
+import {describe, expect, it} from 'vitest'
+
+import {type SanityDocumentStub} from '../../src/types'
+import {
+  deriveDocumentVersionId,
+  generateReleaseId,
+  getDocumentVersionId,
+} from '../../src/util/createVersionId'
+
+describe('createVersionId', () => {
+  describe('generateReleaseId', () => {
+    it('generates a string with 8 characters', () => {
+      const releaseId = generateReleaseId()
+      expect(typeof releaseId).toBe('string')
+      expect(releaseId.length).toBe(8)
+    })
+
+    it('generates unique values on multiple calls', () => {
+      const ids = new Set<string>()
+      for (let i = 0; i < 100; i++) {
+        ids.add(generateReleaseId())
+      }
+      expect(ids.size).toBe(100)
+    })
+
+    it('only uses characters from the defined alphabet', () => {
+      const releaseId = generateReleaseId()
+      const validChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+      releaseId.split('').forEach((char) => {
+        expect(validChars.includes(char)).toBe(true)
+      })
+    })
+  })
+
+  describe('getDocumentVersionId', () => {
+    it('returns a draft ID when no releaseId is provided', () => {
+      const publishedId = 'document123'
+      const versionId = getDocumentVersionId(publishedId)
+      expect(versionId).toBe('drafts.document123')
+    })
+
+    it('returns a version ID when releaseId is provided', () => {
+      const publishedId = 'document123'
+      const releaseId = 'release456'
+      const versionId = getDocumentVersionId(publishedId, releaseId)
+      expect(versionId).toBe('versions.release456.document123')
+    })
+
+    it('handles IDs with special characters correctly', () => {
+      const publishedId = 'complex-doc_with.chars'
+      const releaseId = 'release456'
+      const versionId = getDocumentVersionId(publishedId, releaseId)
+      expect(versionId).toBe('versions.release456.complex-doc_with.chars')
+    })
+  })
+
+  describe('deriveDocumentVersionId', () => {
+    it('returns document ID when only document with _id is provided', () => {
+      const document = {
+        _id: 'drafts.doc123',
+        _type: 'post',
+        title: 'Test document',
+      }
+
+      const result = deriveDocumentVersionId('test', {document})
+      expect(result).toBe('drafts.doc123')
+    })
+
+    it('returns draft ID when only publishedId is provided', () => {
+      const document = {title: 'Test without ID', _type: 'post'}
+      const publishedId = 'pub123'
+
+      const result = deriveDocumentVersionId('test', {publishedId, document})
+      expect(result).toBe('drafts.pub123')
+    })
+
+    it('returns version ID when publishedId and releaseId are provided', () => {
+      const document = {title: 'Test without ID', _type: 'post'}
+      const publishedId = 'pub123'
+      const releaseId = 'release456'
+      const result = deriveDocumentVersionId('test', {publishedId, releaseId, document})
+      expect(result).toBe('versions.release456.pub123')
+    })
+
+    it('throws error when document._id is provided but is not a version ID or draft ID', () => {
+      const document = {
+        _id: 'regularId123',
+        _type: 'post',
+        title: 'Test with regular ID',
+      }
+
+      expect(() => {
+        deriveDocumentVersionId('test', {document})
+      }).toThrow('`test()` requires a document with an `_id` that is a version or draft ID')
+    })
+
+    it('throws error when document._id is a draft ID and releaseId is provided', () => {
+      const publishedId = 'pub123'
+      const releaseId = 'release456'
+      const document = {
+        _id: `drafts.${publishedId}`,
+        _type: 'post',
+        title: 'Test with draft ID',
+      }
+
+      expect(() => {
+        deriveDocumentVersionId('test', {document, releaseId})
+      }).toThrow(
+        `\`test()\` was called with a document ID (\`${document._id}\`) that is a draft ID, but a release ID (\`${releaseId}\`) was also provided.`,
+      )
+    })
+
+    it('throws error when document._id is a version ID but version does not match provided releaseId', () => {
+      const publishedId = 'pub123'
+      const wrongReleaseId = 'oldRelease789'
+      const releaseId = 'newRelease456'
+      const versionId = `versions.${wrongReleaseId}.${publishedId}`
+      const document = {
+        _id: versionId,
+        _type: 'post',
+        title: 'Test with version ID',
+      }
+
+      expect(() => {
+        deriveDocumentVersionId('test', {document, releaseId})
+      }).toThrow(
+        `\`test()\` was called with a document ID (\`${versionId}\`) that is a version ID, but the release ID (\`${releaseId}\`) does not match the document's version ID (\`${wrongReleaseId}\`).`,
+      )
+    })
+
+    it('validates and returns version ID when both document._id and publishedId are provided', () => {
+      const publishedId = 'pub123'
+      const documentWithDraftId = {
+        _id: 'drafts.pub123',
+        title: 'Test with draft ID',
+        _type: 'post',
+      }
+
+      const result = deriveDocumentVersionId('test', {publishedId, document: documentWithDraftId})
+      expect(result).toBe('drafts.pub123')
+    })
+
+    it('validates and returns version ID when document._id, publishedId, and releaseId are provided', () => {
+      const publishedId = 'pub123'
+      const releaseId = 'release456'
+      const versionId = `versions.${releaseId}.${publishedId}`
+      const documentWithVersionId = {
+        _id: versionId,
+        title: 'Test with version ID',
+        _type: 'post',
+      }
+
+      const result = deriveDocumentVersionId('test', {
+        publishedId,
+        releaseId,
+        document: documentWithVersionId,
+      })
+      expect(result).toBe(versionId)
+    })
+
+    it('throws error when document ID does not match generated version ID', () => {
+      const publishedId = 'pub123'
+      const document = {
+        _id: 'drafts.different123',
+        title: 'Test with mismatched ID',
+        _type: 'post',
+      }
+
+      expect(() => {
+        deriveDocumentVersionId('test', {publishedId, document})
+      }).toThrow(
+        'The provided document ID (`drafts.different123`) does not match the generated version ID (`drafts.pub123`)',
+      )
+    })
+
+    it('throws error when neither publishedId nor document._id is provided', () => {
+      const document = {title: 'Test without ID', _type: 'post'} as SanityDocumentStub
+
+      expect(() => {
+        deriveDocumentVersionId('test', {document})
+      }).toThrow('`test()` requires either a publishedId or a document with an `_id`')
+    })
+
+    it('throws error when validating version ID with mismatched releaseId', () => {
+      const publishedId = 'pub123'
+      const releaseId = 'release456'
+      const wrongReleaseId = 'wrong789'
+      const document = {
+        _id: `versions.${wrongReleaseId}.${publishedId}`,
+        title: 'Test with wrong release ID',
+        _type: 'post',
+      }
+
+      expect(() => {
+        deriveDocumentVersionId('test', {publishedId, releaseId, document})
+      }).toThrow(
+        `The provided document ID (\`versions.${wrongReleaseId}.${publishedId}\`) does not match the generated version ID (\`versions.${releaseId}.${publishedId}\`)`,
+      )
+    })
+
+    it('handles correctly when document._id is a draft ID and publishedId matches', () => {
+      const publishedId = 'pub123'
+      const document = {
+        _id: 'drafts.pub123',
+        title: 'Test with draft ID',
+        _type: 'post',
+      }
+
+      const result = deriveDocumentVersionId('test', {publishedId, document})
+      expect(result).toBe('drafts.pub123')
+    })
+  })
+})


### PR DESCRIPTION
### Content Release and Document Version operations

The client now has complete abstractions and types for all Content Lake [release](https://www.sanity.io/docs/http-actions#a102448a3a7a) and [version](https://www.sanity.io/docs/http-actions#8c43ee58aa51) actions.

These are available to be used directly interfacing with the server action:
```ts
client.action(
  {
    actionType: 'sanity.action.document.version.create',
    publishedId: 'bike-123',
    document: {
      _id: 'versions.new-bike-release.bike-123'
      _type: 'bike'
    }
  }
)
```
Or additionally through method abstractions which provide more unified concepts such as releaseId and publishedId, in addition to client side guards on mismatching IDs:
```ts
client.createVersion(
  {
    publishedId: 'bike-123',
    releaseId: 'new-bike-release',
    document: {
      _type: 'bike'
    }
  }
)
```

> [!IMPORTANT]
> **Deprecation notice of some document server actions** 
> The `discard` and `replaceDraft` actions now have deprecation notices in the client, to reflect updates on the underlying Content Lake API.
> 
> `discard` is superseded by `discardVersion` and `replaceDraft` by `replaceVersion`