### PR TITLE
chore: improvements to CI with PR title validation and esm compatibility check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           path: |
             dist/
             umd/
-  
+
   coverage:
     permissions:
       # Required to checkout the code
@@ -94,6 +94,22 @@ jobs:
       - run: npm install
       - run: npx ls-engines
       - run: npm test
+
+  esm-compatibility:
+    name: Check ESM compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [lts/*, '21', 'latest']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - name: Test dependencies for ESM compatibility
+        run: npm run check-esm-compatibility
 
   prod-deps:
     name: Cache production dependencies

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,21 @@
+name: 'Validate PR title'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,7 +1,7 @@
 name: 'Validate PR title'
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
         "get-it": "^8.6.7",
-        "nanoid": "5.1.5",
+        "nanoid": "^3.3.11",
         "rxjs": "^7.0.0"
       },
       "devDependencies": {
@@ -9344,20 +9344,21 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
-      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -10608,24 +10609,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -13416,24 +13399,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/vite/node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
         "get-it": "^8.6.7",
-        "nanoid": "^3.3.11",
+        "nanoid": "5.1.5",
         "rxjs": "^7.0.0"
       },
       "devDependencies": {
@@ -9344,21 +9344,20 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -10609,6 +10608,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -13399,6 +13416,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/vite/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "prebuild": "npm run clean",
     "build": "pkg build --strict && pkg --strict && npm run rollup && npm run minify",
     "clean": "npx rimraf dist coverage umd/*.js",
+    "check-esm-compatibility": "node scripts/check-esm-compatibility.mjs",
     "coverage": "vitest run --coverage",
     "lint": "eslint . --max-warnings 0",
     "minify": "terser -c -m -- umd/sanityClient.js > umd/sanityClient.min.js",
@@ -121,7 +122,7 @@
   "dependencies": {
     "@sanity/eventsource": "^5.0.2",
     "get-it": "^8.6.7",
-    "nanoid": "^3.3.11",
+    "nanoid": "5.1.5",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "prebuild": "npm run clean",
     "build": "pkg build --strict && pkg --strict && npm run rollup && npm run minify",
     "clean": "npx rimraf dist coverage umd/*.js",
-    "check-esm-compatibility": "node scripts/check-esm-compatibility.mjs",
     "coverage": "vitest run --coverage",
     "lint": "eslint . --max-warnings 0",
     "minify": "terser -c -m -- umd/sanityClient.js > umd/sanityClient.min.js",
@@ -122,7 +121,7 @@
   "dependencies": {
     "@sanity/eventsource": "^5.0.2",
     "get-it": "^8.6.7",
-    "nanoid": "5.1.5",
+    "nanoid": "^3.3.11",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "benchmark": "npm test -- bench",
     "prebuild": "npm run clean",
     "build": "pkg build --strict && pkg --strict && npm run rollup && npm run minify",
+    "check-esm-compatibility": "node scripts/check-esm-compatibility.mjs",
     "clean": "npx rimraf dist coverage umd/*.js",
     "coverage": "vitest run --coverage",
     "lint": "eslint . --max-warnings 0",

--- a/scripts/check-esm-compatibility.mjs
+++ b/scripts/check-esm-compatibility.mjs
@@ -1,0 +1,39 @@
+/**
+ * This detects dependencies that are ESM-only and cannot be imported using CommonJS require().
+ * In Node.js environments (especially v12+), some packages are distributed exclusively as ES Modules,
+ * which breaks compatibility with CommonJS code that tries to require them directly.
+ */
+
+/* eslint-disable no-console */
+
+import fs from 'fs'
+import {createRequire} from 'module'
+import path from 'path'
+import {fileURLToPath} from 'url'
+
+const currentFilename = fileURLToPath(import.meta.url)
+const currentDirname = path.dirname(currentFilename)
+const dynamicRequire = createRequire(import.meta.url)
+
+const pkgJsonPath = path.join(currentDirname, '../package.json')
+
+const deps = Object.keys(JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).dependencies || {})
+
+const esmOnlyDeps = []
+
+for (const dep of deps) {
+  try {
+    dynamicRequire(dep)
+  } catch (err) {
+    if (err.code === 'ERR_REQUIRE_ESM') {
+      esmOnlyDeps.push(dep)
+    } else {
+      console.log(`${dep} encountered an unexpected error: ${err.message}`)
+    }
+  }
+}
+
+if (esmOnlyDeps.length > 0) {
+  console.log(`Found ${esmOnlyDeps.length} ESM-only dependencies: ${esmOnlyDeps.join(', ')}`)
+  process.exit(1)
+}


### PR DESCRIPTION
This introduces 2 improvements to the CI build steps to address 2 recent issues:
1. Adds in a validation that PR titles are conventional commit messages - this was found by a previous issue of a merged PR that did not trigger a new release-please version release
2. Adding a check that all production dependencies support CJS imports - recently a version of nanoid was added that does not support CJS, only ESM. This could have been spotted and prevented had this check already existed

Testing:
1. Since validate workflow uses the PR target as the source of the file, this cannot be fully tested until this PR is merged, however manual testing of using only `pull_request` as the trigger showed that the title does correctly fail the build
2. When using the version of nanoid that only supports ESM the follow was seen:
<img width="789" alt="Screenshot 2025-05-10 at 00 57 48" src="https://github.com/user-attachments/assets/d06b339a-92fc-4e20-88c9-9a65126d6408" />

