### PR TITLE
feat: agent.action.prompt – for when you dont want to bring an LLM key and just use Sanity

### DIFF
--- a/src/agent/actions/AgentActionsClient.ts
+++ b/src/agent/actions/AgentActionsClient.ts
@@ -3,6 +3,7 @@ import {lastValueFrom, type Observable} from 'rxjs'
 import type {ObservableSanityClient, SanityClient} from '../../SanityClient'
 import type {Any, HttpRequest, IdentifiedSanityDocumentStub, TranslateDocument} from '../../types'
 import {_generate, type GenerateInstruction} from './generate'
+import {_prompt, type PromptRequest} from './prompt'
 import {_transform, type TransformDocument} from './transform'
 import {_translate} from './translate'
 
@@ -107,5 +108,15 @@ export class AgentActionsClient {
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
     return lastValueFrom(_translate(this.#client, this.#httpRequest, request))
+  }
+
+  /**
+   * Run a raw instruction and return the result either as text or json
+   * @param request - prompt request
+   */
+  prompt<DocumentShape extends Record<string, Any>>(
+    request: PromptRequest<DocumentShape>,
+  ): Promise<(typeof request)['json'] extends true ? DocumentShape : string> {
+    return lastValueFrom(_prompt(this.#client, this.#httpRequest, request))
   }
 }

--- a/src/agent/actions/commonTypes.ts
+++ b/src/agent/actions/commonTypes.ts
@@ -35,6 +35,16 @@ export interface ConstantAgentActionParam {
   value: string
 }
 
+type DocIdParam<TParamConfig extends {docIdRequired: boolean} = {docIdRequired: false}> =
+  TParamConfig['docIdRequired'] extends true
+    ? {documentId: string}
+    : {
+        /**
+         * If omitted, implicitly uses the documentId of the instruction target
+         */
+        documentId?: string
+      }
+
 /**
  *
  *
@@ -58,17 +68,15 @@ export interface ConstantAgentActionParam {
  *
  * @beta
  * */
-export interface FieldAgentActionParam {
+export type FieldAgentActionParam<
+  TParamConfig extends {docIdRequired: boolean} = {docIdRequired: false},
+> = {
   type: 'field'
   /**
    * Examples: 'title', ['array', \{_key: 'arrayItemKey'\}, 'field']
    */
   path: AgentActionPathSegment | AgentActionPath
-  /**
-   * If omitted, implicitly uses the documentId of the instruction target
-   */
-  documentId?: string
-}
+} & DocIdParam<TParamConfig>
 
 /**
  *
@@ -90,13 +98,11 @@ export interface FieldAgentActionParam {
  *
  * @beta
  * */
-export interface DocumentAgentActionParam {
+export type DocumentAgentActionParam<
+  TParamConfig extends {docIdRequired: boolean} = {docIdRequired: false},
+> = {
   type: 'document'
-  /**
-   * If omitted, implicitly uses the documentId of the instruction target
-   */
-  documentId?: string
-}
+} & DocIdParam<TParamConfig>
 
 /**
  * Includes a LLM-friendly version of GROQ query result in the instruction
@@ -209,15 +215,19 @@ export interface AgentActionTarget {
 }
 
 /** @beta */
-export type AgentActionParam =
+export type AgentActionParam<
+  TParamConfig extends {docIdRequired: boolean} = {docIdRequired: false},
+> =
   | string
   | ConstantAgentActionParam
-  | FieldAgentActionParam
-  | DocumentAgentActionParam
+  | FieldAgentActionParam<TParamConfig>
+  | DocumentAgentActionParam<TParamConfig>
   | GroqAgentActionParam
 
 /** @beta */
-export type AgentActionParams = Record<string, AgentActionParam>
+export type AgentActionParams<
+  TParamConfig extends {docIdRequired: boolean} = {docIdRequired: false},
+> = Record<string, AgentActionParam<TParamConfig>>
 
 /** @beta */
 export interface AgentActionRequestBase {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1632,6 +1632,7 @@ export type {
   GenerateTargetDocument,
   GenerateTargetInclude,
 } from './agent/actions/generate'
+export type {PromptRequest} from './agent/actions/prompt'
 export type {
   TransformDocument,
   TransformTarget,


### PR DESCRIPTION
#### Prompt the LLM

Useful if you dont want to bring your own API key.

```ts
const result = await client.agent.action.prompt({
  instruction: 'Say: Oh, hi $name!',
  instructionParams: {
    name: 'Mark',
  },
  temperature: 0.5,
  format: 'text'
})
```

- **instruction**: A string template describing what the LLM should do. Use `$variable` for dynamic values.
- **instructionParams**: Values for variables in the instruction. Supports constants, fields, documents, or GROQ queries.
- **format**: (Optional) 'text' or 'json'. Defaults to 'text'. Note that when specifying 'json', the instruction MUST include the word "json" (ignoring case) in some form.
- **temperature**: (Optional) Controls variance, 0-1 – defaults to 0