### PR TITLE
feat: pass default headers to createClient for all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,8 +489,7 @@ Request tags are values assigned to API and CDN requests that can be used to fil
 Sanity Client has out-of-the-box support for tagging every API and CDN request on two levels:
 
 - Globally: Using the `requestTagPrefix` client configuration parameter
-- Per Request: Pass the tag option to the SDK's Request method.
-
+- Per Request: Pass the tag option to the SDK’s Request method.
 The following example will result in a query with `tag=website.landing-page`:
 
 ```ts
@@ -1964,18 +1963,6 @@ client.config({dataset: 'newDataset'})
 `client.config(options)`
 
 Set client configuration. Required options are `projectId` and `dataset`.
-
-You can also set default headers to be included with all requests:
-
-```js
-client.config({
-  headers: {
-    'X-Custom-Header': 'custom-value',
-  },
-})
-```
-
-Note that request-specific headers will override any default headers with the same name.
 
 ### Agent Actions API
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ export const client = createClient({
   projectId: 'your-project-id',
   dataset: 'your-dataset-name',
   useCdn: true, // set to `false` to bypass the edge cache
+  // Set default headers to be included with all requests
+  headers: {
+    'X-Custom-Header': 'custom-value'
+  },
   apiVersion: '2025-02-06', // use current date (YYYY-MM-DD) to target the latest API version. Note: this should always be hard coded. Setting API version based on a dynamic value (e.g. new Date()) may break your application at a random point in the future.
   // token: process.env.SANITY_SECRET_TOKEN // Needed for certain operations like updating content, accessing drafts or using draft perspectives
 })
@@ -485,7 +489,7 @@ Request tags are values assigned to API and CDN requests that can be used to fil
 Sanity Client has out-of-the-box support for tagging every API and CDN request on two levels:
 
 - Globally: Using the `requestTagPrefix` client configuration parameter
-- Per Request: Pass the tag option to the SDK’s Request method.
+- Per Request: Pass the tag option to the SDK's Request method.
 
 The following example will result in a query with `tag=website.landing-page`:
 
@@ -1960,6 +1964,18 @@ client.config({dataset: 'newDataset'})
 `client.config(options)`
 
 Set client configuration. Required options are `projectId` and `dataset`.
+
+You can also set default headers to be included with all requests:
+
+```js
+client.config({
+  headers: {
+    'X-Custom-Header': 'custom-value',
+  },
+})
+```
+
+Note that request-specific headers will override any default headers with the same name.
 
 ### Agent Actions API
 

--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Sanity Client has out-of-the-box support for tagging every API and CDN request o
 
 - Globally: Using the `requestTagPrefix` client configuration parameter
 - Per Request: Pass the tag option to the SDK’s Request method.
+
 The following example will result in a query with `tag=website.landing-page`:
 
 ```ts

--- a/src/http/requestOptions.ts
+++ b/src/http/requestOptions.ts
@@ -7,6 +7,10 @@ const projectHeader = 'X-Sanity-Project-ID'
 export function requestOptions(config: Any, overrides: Any = {}): Omit<RequestOptions, 'url'> {
   const headers: Any = {}
 
+  if (config.headers) {
+    Object.assign(headers, config.headers)
+  }
+
   const token = overrides.token || config.token
   if (token) {
     headers.Authorization = `Bearer ${token}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,12 @@ export interface ClientConfig {
    * Optional request tag prefix for all request tags
    */
   requestTagPrefix?: string
+
+  /**
+   * Optional default headers to include with all requests
+   */
+  headers?: Record<string, string>
+
   ignoreBrowserTokenWarning?: boolean
   withCredentials?: boolean
   allowReconfigure?: boolean
@@ -173,6 +179,10 @@ export interface InitializedClientConfig extends ClientConfig {
    * The fully initialized stega config, can be used to check if stega is enabled
    */
   stega: InitializedStegaConfig
+  /**
+   * Default headers to include with all requests
+   */
+  headers?: Record<string, string>
 }
 
 /** @public */

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,8 @@ export interface ClientConfig {
 
   /**
    * Optional default headers to include with all requests
+   *
+   * @remarks request-specific headers will override any default headers with the same name.
    */
   headers?: Record<string, string>
 
@@ -181,6 +183,8 @@ export interface InitializedClientConfig extends ClientConfig {
   stega: InitializedStegaConfig
   /**
    * Default headers to include with all requests
+   *
+   * @remarks request-specific headers will override any default headers with the same name.
    */
   headers?: Record<string, string>
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4253,7 +4253,7 @@ describe('client', async () => {
       await expect(client.fetch('*')).resolves.not.toThrow()
     })
 
-    test.skipIf(isEdge)('allows overriding headers', async () => {
+    test('allows overriding headers', async () => {
       const client = createClient({
         projectId: 'abc123',
         dataset: 'foo',

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -5057,7 +5057,7 @@ describe('client', async () => {
     await expect(client.fetch('*')).resolves.not.toThrow()
   })
 
-  test('respects header priority: request-specific > critical > config', async () => {
+  test('critical headers are not overridden by config headers', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
@@ -5069,19 +5069,19 @@ describe('client', async () => {
       },
     })
 
-    const authHeaders = {
+    const reqheaders = {
       Authorization: 'Bearer auth-token',
       'X-Custom-Header': 'config-value',
     }
-    nock('https://abc123.api.sanity.io', {reqheaders: authHeaders})
+    nock('https://abc123.api.sanity.io', {reqheaders})
       .get('/v1/data/query/foo?query=auth-test&returnQuery=false')
       .reply(200, {result: []})
 
-    const requestHeaders = {
+    const reqheaders2 = {
       Authorization: 'Bearer request-token',
       'X-Custom-Header': 'request-value',
     }
-    nock('https://abc123.api.sanity.io', {reqheaders: requestHeaders})
+    nock('https://abc123.api.sanity.io', {reqheaders: reqheaders2})
       .get('/v1/data/query/foo?query=request-test&returnQuery=false')
       .reply(200, {result: []})
 
@@ -5100,7 +5100,7 @@ describe('client', async () => {
     ).resolves.not.toThrow()
   })
 
-  test('headers work with mutations and can be reconfigured', async () => {
+  test('headers can be reconfigured', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
@@ -5110,8 +5110,8 @@ describe('client', async () => {
       },
     })
 
-    const mutationHeaders = {'X-Custom-Header': 'mutation-test'}
-    nock('https://abc123.api.sanity.io', {reqheaders: mutationHeaders})
+    const reqheaders = {'X-Custom-Header': 'mutation-test'}
+    nock('https://abc123.api.sanity.io', {reqheaders})
       .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync')
       .reply(200, {transactionId: 'abc123', results: [{id: 'doc123', operation: 'create'}]})
 
@@ -5123,8 +5123,8 @@ describe('client', async () => {
       },
     })
 
-    const reconfiguredHeaders = {'X-Custom-Header': 'new-value'}
-    nock('https://abc123.api.sanity.io', {reqheaders: reconfiguredHeaders})
+    const reqheaders2 = {'X-Custom-Header': 'new-value'}
+    nock('https://abc123.api.sanity.io', {reqheaders: reqheaders2})
       .get('/v1/data/query/foo?query=*&returnQuery=false')
       .reply(200, {result: []})
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4253,7 +4253,7 @@ describe('client', async () => {
       await expect(client.fetch('*')).resolves.not.toThrow()
     })
 
-    test('allows overriding headers', async () => {
+    test.skipIf(isEdge)('allows overriding headers', async () => {
       const client = createClient({
         projectId: 'abc123',
         dataset: 'foo',
@@ -5019,7 +5019,7 @@ describe('client', async () => {
     })
   })
 
-  test('allows overriding headers', async () => {
+  test.skipIf(isEdge)('allows overriding headers', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
@@ -5035,7 +5035,7 @@ describe('client', async () => {
     await expect(client.fetch('*', {}, {headers: {foo: 'bar'}})).resolves.not.toThrow()
   })
 
-  test('applies headers from client configuration', async () => {
+  test.skipIf(isEdge)('applies headers from client configuration', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
@@ -5057,7 +5057,7 @@ describe('client', async () => {
     await expect(client.fetch('*')).resolves.not.toThrow()
   })
 
-  test('critical headers are not overridden by config headers', async () => {
+  test.skipIf(isEdge)('critical headers are not overridden by config headers', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
@@ -5100,7 +5100,7 @@ describe('client', async () => {
     ).resolves.not.toThrow()
   })
 
-  test('headers can be reconfigured', async () => {
+  test.skipIf(isEdge)('headers can be reconfigured', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
@@ -5141,7 +5141,7 @@ describe('client', async () => {
     await expect(client.fetch('empty-test')).resolves.not.toThrow()
   })
 
-  test('will use live API if withCredentials is set to true', async () => {
+  test.skipIf(isEdge)('will use live API if withCredentials is set to true', async () => {
     const client = createClient({
       withCredentials: true,
       projectId: 'abc123',

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -5042,10 +5042,14 @@ describe('client', async () => {
       useCdn: false,
       headers: {
         'X-Custom-Header': 'custom-value',
+        'X-Another-Header': 'another-value',
       },
     })
 
-    const reqheaders = {'X-Custom-Header': 'custom-value'}
+    const reqheaders = {
+      'X-Custom-Header': 'custom-value',
+      'X-Another-Header': 'another-value',
+    }
     nock('https://abc123.api.sanity.io', {reqheaders})
       .get('/v1/data/query/foo?query=*&returnQuery=false')
       .reply(200, {result: []})
@@ -5053,113 +5057,50 @@ describe('client', async () => {
     await expect(client.fetch('*')).resolves.not.toThrow()
   })
 
-  test('request-specific headers override client configuration headers', async () => {
+  test('respects header priority: request-specific > critical > config', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
+      token: 'auth-token',
       useCdn: false,
       headers: {
-        'X-Custom-Header': 'client-value',
+        'X-Custom-Header': 'config-value',
+        Authorization: 'Bearer fake-token',
       },
     })
 
-    const reqheaders = {'X-Custom-Header': 'request-value'}
-    nock('https://abc123.api.sanity.io', {reqheaders})
-      .get('/v1/data/query/foo?query=*&returnQuery=false')
+    const authHeaders = {
+      Authorization: 'Bearer auth-token',
+      'X-Custom-Header': 'config-value',
+    }
+    nock('https://abc123.api.sanity.io', {reqheaders: authHeaders})
+      .get('/v1/data/query/foo?query=auth-test&returnQuery=false')
       .reply(200, {result: []})
 
+    const requestHeaders = {
+      Authorization: 'Bearer request-token',
+      'X-Custom-Header': 'request-value',
+    }
+    nock('https://abc123.api.sanity.io', {reqheaders: requestHeaders})
+      .get('/v1/data/query/foo?query=request-test&returnQuery=false')
+      .reply(200, {result: []})
+
+    await expect(client.fetch('auth-test')).resolves.not.toThrow()
     await expect(
-      client.fetch('*', {}, {headers: {'X-Custom-Header': 'request-value'}}),
+      client.fetch(
+        'request-test',
+        {},
+        {
+          headers: {
+            Authorization: 'Bearer request-token',
+            'X-Custom-Header': 'request-value',
+          },
+        },
+      ),
     ).resolves.not.toThrow()
   })
 
-  test('critical headers like Authorization are not overridden by client config headers', async () => {
-    const client = createClient({
-      projectId: 'abc123',
-      dataset: 'foo',
-      token: 'real-token',
-      useCdn: false,
-      headers: {
-        Authorization: 'Bearer fake-token',
-      },
-    })
-
-    const reqheaders = {
-      Authorization: 'Bearer real-token',
-    }
-    nock('https://abc123.api.sanity.io', {reqheaders})
-      .get('/v1/data/query/foo?query=*&returnQuery=false')
-      .reply(200, {result: []})
-
-    await expect(client.fetch('*')).resolves.not.toThrow()
-  })
-
-  test('critical headers like X-Sanity-Project-ID are not overridden by client config headers', async () => {
-    // Let's completely change the test approach to avoid issues with useProjectHostname
-    // Instead of testing X-Sanity-Project-ID directly, we'll use a test that verifies
-    // the Authorization header can't be overridden when a token is provided
-    const client = createClient({
-      projectId: 'abc123',
-      dataset: 'foo',
-      token: 'real-token',
-      useCdn: false,
-      headers: {
-        Authorization: 'Bearer fake-token',
-      },
-    })
-
-    // This verifies that the token from the config is used, not the one from headers
-    const reqheaders = {
-      Authorization: 'Bearer real-token',
-    }
-    nock('https://abc123.api.sanity.io', {reqheaders})
-      .get('/v1/data/query/foo?query=*&returnQuery=false')
-      .reply(200, {result: []})
-
-    await expect(client.fetch('*')).resolves.not.toThrow()
-  })
-
-  test('applies multiple headers from client configuration', async () => {
-    const client = createClient({
-      projectId: 'abc123',
-      dataset: 'foo',
-      useCdn: false,
-      headers: {
-        'X-Custom-Header-1': 'value1',
-        'X-Custom-Header-2': 'value2',
-        'X-Custom-Header-3': 'value3',
-      },
-    })
-
-    const reqheaders = {
-      'X-Custom-Header-1': 'value1',
-      'X-Custom-Header-2': 'value2',
-      'X-Custom-Header-3': 'value3',
-    }
-    nock('https://abc123.api.sanity.io', {reqheaders})
-      .get('/v1/data/query/foo?query=*&returnQuery=false')
-      .reply(200, {result: []})
-
-    await expect(client.fetch('*')).resolves.not.toThrow()
-  })
-
-  test('handles empty headers object in client configuration', async () => {
-    const client = createClient({
-      projectId: 'abc123',
-      dataset: 'foo',
-      useCdn: false,
-      headers: {},
-    })
-
-    nock('https://abc123.api.sanity.io')
-      .get('/v1/data/query/foo?query=*&returnQuery=false')
-      .reply(200, {result: []})
-
-    await expect(client.fetch('*')).resolves.not.toThrow()
-  })
-
-  test('headers from client config are applied to all request types', async () => {
-    // Test for mutations to ensure headers are applied to all request types
+  test('headers work with mutations and can be reconfigured', async () => {
     const client = createClient({
       projectId: 'abc123',
       dataset: 'foo',
@@ -5169,37 +5110,35 @@ describe('client', async () => {
       },
     })
 
-    const reqheaders = {'X-Custom-Header': 'mutation-test'}
-    nock('https://abc123.api.sanity.io', {reqheaders})
+    const mutationHeaders = {'X-Custom-Header': 'mutation-test'}
+    nock('https://abc123.api.sanity.io', {reqheaders: mutationHeaders})
       .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync')
       .reply(200, {transactionId: 'abc123', results: [{id: 'doc123', operation: 'create'}]})
 
     await expect(client.create({_type: 'test', title: 'Test Document'})).resolves.not.toThrow()
-  })
 
-  test('headers can be reconfigured using client.config()', async () => {
-    const client = createClient({
-      projectId: 'abc123',
-      dataset: 'foo',
-      useCdn: false,
-      headers: {
-        'X-Custom-Header': 'original-value',
-      },
-    })
-
-    // Reconfigure with new headers
     client.config({
       headers: {
         'X-Custom-Header': 'new-value',
       },
     })
 
-    const reqheaders = {'X-Custom-Header': 'new-value'}
-    nock('https://abc123.api.sanity.io', {reqheaders})
+    const reconfiguredHeaders = {'X-Custom-Header': 'new-value'}
+    nock('https://abc123.api.sanity.io', {reqheaders: reconfiguredHeaders})
       .get('/v1/data/query/foo?query=*&returnQuery=false')
       .reply(200, {result: []})
 
     await expect(client.fetch('*')).resolves.not.toThrow()
+
+    client.config({
+      headers: {},
+    })
+
+    nock('https://abc123.api.sanity.io')
+      .get('/v1/data/query/foo?query=empty-test&returnQuery=false')
+      .reply(200, {result: []})
+
+    await expect(client.fetch('empty-test')).resolves.not.toThrow()
   })
 
   test('will use live API if withCredentials is set to true', async () => {


### PR DESCRIPTION
Exposes the ability to define default headers when using client configs. These will be present on all requests sent with that client definition, but can still be overrideen with request specific headers