### PR TITLE
feat(views): implement dev mode

### DIFF
--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -318,7 +318,13 @@ export class ObservableSanityClient {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._create<R>(this.#clientConfig, this.#httpRequest, document, 'create', options)
+    return dataMethods._create<R>(
+      this.#clientConfig,
+      this.#httpRequest,
+      document,
+      'create',
+      options,
+    )
   }
 
   /**
@@ -387,7 +393,12 @@ export class ObservableSanityClient {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._createIfNotExists<R>(this.#clientConfig, this.#httpRequest, document, options)
+    return dataMethods._createIfNotExists<R>(
+      this.#clientConfig,
+      this.#httpRequest,
+      document,
+      options,
+    )
   }
 
   /**
@@ -726,7 +737,13 @@ export class ObservableSanityClient {
   ): Observable<SingleActionResult | MultipleActionResult> {
     const documentVersionId = getDocumentVersionId(publishedId, releaseId)
 
-    return dataMethods._discardVersion(this.config(), this.#httpRequest, documentVersionId, purge, options)
+    return dataMethods._discardVersion(
+      this.config(),
+      this.#httpRequest,
+      documentVersionId,
+      purge,
+      options,
+    )
   }
 
   /**
@@ -830,7 +847,12 @@ export class ObservableSanityClient {
 
     const documentVersion = {...document, _id: documentVersionId}
 
-    return dataMethods._replaceVersion<R>(this.config(), this.#httpRequest, documentVersion, options)
+    return dataMethods._replaceVersion<R>(
+      this.config(),
+      this.#httpRequest,
+      documentVersion,
+      options,
+    )
   }
 
   /**
@@ -860,7 +882,13 @@ export class ObservableSanityClient {
   ): Observable<SingleActionResult | MultipleActionResult> {
     const versionId = getVersionId(publishedId, releaseId)
 
-    return dataMethods._unpublishVersion(this.config(), this.#httpRequest, versionId, publishedId, options)
+    return dataMethods._unpublishVersion(
+      this.config(),
+      this.#httpRequest,
+      versionId,
+      publishedId,
+      options,
+    )
   }
 
   /**
@@ -1208,7 +1236,9 @@ export class SanityClient {
     id: string,
     options?: {signal?: AbortSignal; tag?: string; releaseId?: string},
   ): Promise<SanityDocument<R> | undefined> {
-    return lastValueFrom(dataMethods._getDocument<R>(this.#clientConfig, this.#httpRequest, id, options))
+    return lastValueFrom(
+      dataMethods._getDocument<R>(this.#clientConfig, this.#httpRequest, id, options),
+    )
   }
 
   /**
@@ -1224,7 +1254,9 @@ export class SanityClient {
     ids: string[],
     options?: {signal?: AbortSignal; tag?: string},
   ): Promise<(SanityDocument<R> | null)[]> {
-    return lastValueFrom(dataMethods._getDocuments<R>(this.#clientConfig, this.#httpRequest, ids, options))
+    return lastValueFrom(
+      dataMethods._getDocuments<R>(this.#clientConfig, this.#httpRequest, ids, options),
+    )
   }
 
   /**
@@ -1671,7 +1703,9 @@ export class SanityClient {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return lastValueFrom(dataMethods._delete<R>(this.#clientConfig, this.#httpRequest, selection, options))
+    return lastValueFrom(
+      dataMethods._delete<R>(this.#clientConfig, this.#httpRequest, selection, options),
+    )
   }
 
   /**
@@ -1710,7 +1744,13 @@ export class SanityClient {
     const documentVersionId = getDocumentVersionId(publishedId, releaseId)
 
     return lastValueFrom(
-      dataMethods._discardVersion(this.config(), this.#httpRequest, documentVersionId, purge, options),
+      dataMethods._discardVersion(
+        this.config(),
+        this.#httpRequest,
+        documentVersionId,
+        purge,
+        options,
+      ),
     )
   }
 
@@ -1849,7 +1889,13 @@ export class SanityClient {
     const versionId = getVersionId(publishedId, releaseId)
 
     return lastValueFrom(
-      dataMethods._unpublishVersion(this.config(), this.#httpRequest, versionId, publishedId, options),
+      dataMethods._unpublishVersion(
+        this.config(),
+        this.#httpRequest,
+        versionId,
+        publishedId,
+        options,
+      ),
     )
   }
 
@@ -1919,7 +1965,9 @@ export class SanityClient {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return lastValueFrom(dataMethods._mutate<R>(this.#clientConfig, this.#httpRequest, operations, options))
+    return lastValueFrom(
+      dataMethods._mutate<R>(this.#clientConfig, this.#httpRequest, operations, options),
+    )
   }
 
   /**
@@ -1982,7 +2030,9 @@ export class SanityClient {
     operations: Action | Action[],
     options?: BaseActionOptions,
   ): Promise<SingleActionResult | MultipleActionResult> {
-    return lastValueFrom(dataMethods._action(this.#clientConfig, this.#httpRequest, operations, options))
+    return lastValueFrom(
+      dataMethods._action(this.#clientConfig, this.#httpRequest, operations, options),
+    )
   }
 
   /**
@@ -2007,7 +2057,9 @@ export class SanityClient {
    * @internal
    */
   dataRequest(endpoint: string, body: unknown, options?: BaseMutationOptions): Promise<Any> {
-    return lastValueFrom(dataMethods._dataRequest(this.#clientConfig, this.#httpRequest, endpoint, body, options))
+    return lastValueFrom(
+      dataMethods._dataRequest(this.#clientConfig, this.#httpRequest, endpoint, body, options),
+    )
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,7 +154,9 @@ export const initConfig = (
   const protocol = hostParts[0]
   const host = hostParts[1]
 
-  const cdnURL = newConfig.isDefaultApi ? `https://${defaultCdnHost}` : newConfig.apiCdnHost || newConfig.apiHost
+  const cdnURL = newConfig.isDefaultApi
+    ? `https://${defaultCdnHost}`
+    : newConfig.apiCdnHost || newConfig.apiHost
   const cdnURLParts = cdnURL.split('://', 2)
   const cdnProtocol = cdnURLParts[0]
   const cdnHost = cdnURLParts[1]

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -458,7 +458,7 @@ export function _dataRequest(
     resultSourceMap: options.resultSourceMap,
     lastLiveEventId: Array.isArray(lastLiveEventId) ? lastLiveEventId[0] : lastLiveEventId,
     cacheMode: cacheMode,
-    canUseCdn: isQuery || isEmulate,
+    canUseCdn: isQuery,
     signal: options.signal,
     fetch: options.fetch,
     useAbortSignal: options.useAbortSignal,

--- a/src/datasets/DatasetsClient.ts
+++ b/src/datasets/DatasetsClient.ts
@@ -105,7 +105,10 @@ export class DatasetsClient {
   list(): Promise<DatasetsResponse> {
     validate.resourceGuard('dataset', this.#client.config())
     return lastValueFrom(
-      _request<DatasetsResponse>(this.#client.config(), this.#httpRequest, {uri: '/datasets', tag: null}),
+      _request<DatasetsResponse>(this.#client.config(), this.#httpRequest, {
+        uri: '/datasets',
+        tag: null,
+      }),
     )
   }
 }

--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -37,7 +37,9 @@ export class ObservableProjectsClient {
    */
   getById(projectId: string): Observable<SanityProject> {
     validate.resourceGuard('projects', this.#client.config())
-    return _request<SanityProject>(this.#client.config(), this.#httpRequest, {uri: `/projects/${projectId}`})
+    return _request<SanityProject>(this.#client.config(), this.#httpRequest, {
+      uri: `/projects/${projectId}`,
+    })
   }
 }
 
@@ -72,7 +74,9 @@ export class ProjectsClient {
   getById(projectId: string): Promise<SanityProject> {
     validate.resourceGuard('projects', this.#client.config())
     return lastValueFrom(
-      _request<SanityProject>(this.#client.config(), this.#httpRequest, {uri: `/projects/${projectId}`}),
+      _request<SanityProject>(this.#client.config(), this.#httpRequest, {
+        uri: `/projects/${projectId}`,
+      }),
     )
   }
 }

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -582,7 +582,9 @@ export class ReleasesClient {
       releaseId,
     }
 
-    return lastValueFrom(_action(this.#client.config(), this.#httpRequest, unarchiveAction, options))
+    return lastValueFrom(
+      _action(this.#client.config(), this.#httpRequest, unarchiveAction, options),
+    )
   }
 
   /**
@@ -638,7 +640,9 @@ export class ReleasesClient {
       releaseId,
     }
 
-    return lastValueFrom(_action(this.#client.config(), this.#httpRequest, unscheduleAction, options))
+    return lastValueFrom(
+      _action(this.#client.config(), this.#httpRequest, unscheduleAction, options),
+    )
   }
 
   /**
@@ -682,6 +686,8 @@ export class ReleasesClient {
     {releaseId}: {releaseId: string},
     options?: BaseMutationOptions,
   ): Promise<RawQueryResponse<SanityDocument[]>> {
-    return lastValueFrom(_getReleaseDocuments(this.#client.config(), this.#httpRequest, releaseId, options))
+    return lastValueFrom(
+      _getReleaseDocuments(this.#client.config(), this.#httpRequest, releaseId, options),
+    )
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ type ClientConfigResource =
   | {
       type: 'view'
       id: string
+      useEmulate?: boolean
     }
 
 /** @public */
@@ -1229,10 +1230,44 @@ export interface UnfilteredResponseWithoutQuery extends ResponseQueryOptions {
 }
 
 /** @public */
+export enum ViewResourceType {
+  Dataset = 'dataset',
+}
+
+/** @public */
+export type ViewOverride = {
+  id: string
+  connections: ViewConnectionOverride[]
+}
+
+/** @public */
+export type ViewConnectionOverride = {
+  query: string
+  resourceType: ViewResourceType
+  resourceId: string
+}
+
+/** @public */
+export interface EmulatedResponseQueryOptions extends ResponseQueryOptions {
+  useEmulate: boolean
+  connections?: ViewConnectionOverride[] | undefined
+
+  filterResponse?: false
+  returnQuery?: false
+}
+
+/** @public */
 export type QueryOptions =
   | FilteredResponseQueryOptions
   | UnfilteredResponseQueryOptions
   | UnfilteredResponseWithoutQuery
+  | EmulatedResponseQueryOptions
+
+/** @public */
+export type ViewQueryOptions = Pick<
+  EmulatedResponseQueryOptions,
+  'perspective' | 'resultSourceMap' | 'filterResponse'
+>
 
 /** @public */
 export interface RawQueryResponse<R> {

--- a/src/users/UsersClient.ts
+++ b/src/users/UsersClient.ts
@@ -47,9 +47,13 @@ export class UsersClient {
     id: T,
   ): Promise<T extends 'me' ? CurrentSanityUser : SanityUser> {
     return lastValueFrom(
-      _request<T extends 'me' ? CurrentSanityUser : SanityUser>(this.#client.config(), this.#httpRequest, {
-        uri: `/users/${id}`,
-      }),
+      _request<T extends 'me' ? CurrentSanityUser : SanityUser>(
+        this.#client.config(),
+        this.#httpRequest,
+        {
+          uri: `/users/${id}`,
+        },
+      ),
     )
   }
 }

--- a/test/dataMethods.test.ts
+++ b/test/dataMethods.test.ts
@@ -142,13 +142,15 @@ const testSignalOption = <T = unknown>(
 describe('dataMethods', async () => {
   describe('getUrl', () => {
     test('can use getUrl() to get API-relative paths', () => {
-      expect(dataMethods._getUrl(getClient().config(), '/bar/baz')).toEqual(`${projectHost()}/v1/bar/baz`)
+      expect(dataMethods._getUrl(getClient().config(), '/bar/baz')).toEqual(
+        `${projectHost()}/v1/bar/baz`,
+      )
     })
 
     test('can use getUrl() to get API-relative paths (custom api version)', () => {
-      expect(dataMethods._getUrl(getClient({apiVersion: '2019-01-29'}).config(), '/bar/baz')).toEqual(
-        `${projectHost()}/v2019-01-29/bar/baz`,
-      )
+      expect(
+        dataMethods._getUrl(getClient({apiVersion: '2019-01-29'}).config(), '/bar/baz'),
+      ).toEqual(`${projectHost()}/v2019-01-29/bar/baz`)
     })
   })
 
@@ -362,7 +364,11 @@ describe('dataMethods', async () => {
       mockHttpRequest.mockReturnValueOnce(createMockQueryResponse(mockDocs))
 
       const client = getClient()
-      const observable = dataMethods._getReleaseDocuments(client.config(), mockHttpRequest, releaseId)
+      const observable = dataMethods._getReleaseDocuments(
+        client.config(),
+        mockHttpRequest,
+        releaseId,
+      )
 
       return assertObservable<RawQueryResponse<SanityDocument[]>>(observable, (response) => {
         expect(response.result).toEqual(mockDocs)
@@ -383,7 +389,11 @@ describe('dataMethods', async () => {
       mockHttpRequest.mockReturnValueOnce(createMockQueryResponse([]))
 
       const client = getClient()
-      const observable = dataMethods._getReleaseDocuments(client.config(), mockHttpRequest, releaseId)
+      const observable = dataMethods._getReleaseDocuments(
+        client.config(),
+        mockHttpRequest,
+        releaseId,
+      )
 
       return assertObservable<RawQueryResponse<SanityDocument[]>>(observable, (response) => {
         expect(response.result).toEqual([])

--- a/test/views/client.test.ts
+++ b/test/views/client.test.ts
@@ -219,8 +219,8 @@ describe('view client', async () => {
       const client = createViewClient(configWithOverrides)
       const result = [{_id: 'dataset-doc', title: 'Dataset Document'}]
 
-      // Mock the emulate endpoint (POST request)
-      nock(`https://${apicdnHost}`)
+      // Mock the emulate endpoint (POST request) - uses API host, not CDN
+      nock(`https://${apiHost}`)
         .post('/v2025-01-01/views/vw-dataset-test/emulate?returnQuery=false', {
           query: '*[_type == "test"]',
           params: {},
@@ -484,8 +484,8 @@ describe('view client', async () => {
         const client = createViewClient(configWithOverrides)
         const result = [{_id: 'obs-dataset-doc', title: 'Observable Dataset Document'}]
 
-        // Mock the emulate endpoint (POST request)
-        nock(`https://${apicdnHost}`)
+        // Mock the emulate endpoint (POST request) - uses API host, not CDN
+        nock(`https://${apiHost}`)
           .post('/v2025-01-01/views/vw-obs-dataset/emulate?returnQuery=false', {
             query: '*[_type == "obs-test"]',
             params: {},


### PR DESCRIPTION
Add dev mode to views client:

Outbound requests need to look something like this:
```bash
POST /v2025-01-01/views/my-view-id/emulate?returnQuery=false HTTP/1.1
Host: apicdn.sanity.url
Content-Type: application/json
Accept: application/json

{
  "query": "*[_type == \"article\" && category == $cat]",
  "params": {
    "cat": "technology"
  },
  "connections": [
    {
      "query": "*[_type == \"document\"]",
      "resourceType": "dataset",
      "resourceId": "project123.dataset456"
    }
  ]
}
```

We make the request by calling the views client like this:

```js
import { createViewClient, ViewResourceType } from '@sanity/client/views'

const client = createViewClient({
  apiVersion: '2025-01-01',
  viewOverrides: [
    {
      id: 'my-view-id',
      connections: [
        {
          query: '*[_type == "document"]',
          resourceType: ViewResourceType.Dataset,
          resourceId: 'project123.dataset456'
        }
      ]
    }
  ]
})

// This automatically uses the emulate endpoint because dataset connections are detected
const result = await client.fetch(
  'my-view-id', 
  '*[_type == "article" && category == $cat]',
  { cat: 'technology' }
)
```