### PR TITLE
fix: add support for custom headers in listen and live clients

### DIFF
--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -70,7 +70,7 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
   params?: ListenParams,
   opts: ListenOptions = {},
 ): Observable<MutationEvent<R> | ListenEvent<R>> {
-  const {url, token, withCredentials, requestTagPrefix} = this.config()
+  const {url, token, withCredentials, requestTagPrefix, headers: configHeaders} = this.config()
   const tag = opts.tag && requestTagPrefix ? [requestTagPrefix, opts.tag].join('.') : opts.tag
   const options = {...defaults(opts, defaultOptions), tag}
   const listenOpts = pick(options, possibleOptions)
@@ -88,9 +88,15 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
     esOptions.withCredentials = true
   }
 
-  if (token) {
-    esOptions.headers = {
-      Authorization: `Bearer ${token}`,
+  if (token || configHeaders) {
+    esOptions.headers = {}
+
+    if (token) {
+      esOptions.headers.Authorization = `Bearer ${token}`
+    }
+
+    if (configHeaders) {
+      Object.assign(esOptions.headers, configHeaders)
     }
   }
 

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -52,6 +52,7 @@ export class LiveClient {
       token,
       withCredentials,
       requestTagPrefix,
+      headers: configHeaders,
     } = this.#client.config()
     const apiVersion = _apiVersion.replace(/^v/, '')
     if (apiVersion !== 'X' && apiVersion < requiredApiVersion) {
@@ -76,13 +77,20 @@ export class LiveClient {
       url.searchParams.set('includeDrafts', 'true')
     }
     const esOptions: EventSourceInit & {headers?: Record<string, string>} = {}
-    if (includeDrafts && token) {
-      esOptions.headers = {
-        Authorization: `Bearer ${token}`,
-      }
-    }
     if (includeDrafts && withCredentials) {
       esOptions.withCredentials = true
+    }
+
+    if ((includeDrafts && token) || configHeaders) {
+      esOptions.headers = {}
+
+      if (includeDrafts && token) {
+        esOptions.headers.Authorization = `Bearer ${token}`
+      }
+
+      if (configHeaders) {
+        Object.assign(esOptions.headers, configHeaders)
+      }
     }
 
     const key = `${url.href}::${JSON.stringify(esOptions)}`

--- a/test/listen.test.ts
+++ b/test/listen.test.ts
@@ -235,5 +235,20 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect(onRequest).not.toHaveBeenCalled()
       server.close()
     })
+
+    test('passes custom headers from client configuration', async () => {
+      expect.assertions(1)
+
+      const {server, client} = await testSse(
+        ({request, channel}) => {
+          expect(request.headers['x-custom-header']).toBe('custom-value')
+          channel!.send({event: 'welcome'})
+        },
+        {headers: {'X-Custom-Header': 'custom-value'}},
+      )
+
+      await firstValueFrom(client.listen('*', {}, {events: ['welcome']}), {defaultValue: null})
+      server.close()
+    })
   },
 )

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -284,6 +284,27 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       server.close()
     })
 
+    test('passes custom headers from client configuration', async () => {
+      expect.assertions(1)
+
+      const {server, client} = await testSse(
+        ({request, channel}) => {
+          if (request.method === 'OPTIONS') {
+            expect(request.headers['x-custom-header']).toBe('custom-value')
+          }
+
+          if (channel) {
+            channel.send({id: '123', data: {tags: ['tag1']}})
+            process.nextTick(() => channel.close())
+          }
+        },
+        {headers: {'X-Custom-Header': 'custom-value'}},
+      )
+
+      await firstValueFrom(client.live.events(), {defaultValue: null})
+      server.close()
+    })
+
     test('deduplicates EventSource instances for same URL and options', async () => {
       expect.assertions(5)
       let instanceCount = 0


### PR DESCRIPTION
[This previous PR that added default headers](https://github.com/sanity-io/client/pull/1079) forgot to support listen and live endpoints too.

This PR extends the support to them
