### PR TITLE
feat: new agent action parameter forcePublishedWrite – agent actions never write to published doc by default

### DIFF
--- a/src/agent/actions/commonTypes.ts
+++ b/src/agent/actions/commonTypes.ts
@@ -235,6 +235,30 @@ export interface AgentActionSchema {
   schemaId: string
 
   /**
+   * ### forcePublishedWrite: false (default)
+   * By default, agent actions will never write to a published document.
+   *
+   * Instead, they will force the use of a draft ID ("drafts.some-id") instead of the published ID ("some-id"),
+   * even when a published ID is provided.
+   *
+   * Actions will use state from an existing draft if it exists,
+   * or use the published document to create a draft, if no draft exists.
+   *
+   * On successful responses contains the _id that was actually mutated by the action.
+   *
+   * ### forcePublishedWrite: true
+   *
+   * When forcePublishedWrite: true an agent action will write to the exact id provided.
+   * The action will also not fallback to published state for draft ids.
+   *
+   * ### Versioned ids (releases)
+   * When an ID on the form "versions.<release>.some-id" behave is provided, agent actions will
+   * always behave as if forcePublishedWrite: true. That is, only the exact document state of the id provided
+   * is considered.
+   * */
+  forcePublishedWrite?: boolean
+
+  /**
    * When a type or field in the schema has a function set for `hidden` or `readOnly`, it is conditional.
    *
    * By default, Generate will not output to conditional `readOnly` and `hidden` fields,

--- a/src/agent/actions/commonTypes.ts
+++ b/src/agent/actions/commonTypes.ts
@@ -244,17 +244,20 @@ export interface AgentActionSchema {
    * Actions will use state from an existing draft if it exists,
    * or use the published document to create a draft, if no draft exists.
    *
-   * On successful responses contains the _id that was actually mutated by the action.
+   * Successful responses contains the _id that was mutated by the action.
+   *
    *
    * ### forcePublishedWrite: true
    *
    * When forcePublishedWrite: true an agent action will write to the exact id provided.
    * The action will also not fallback to published state for draft ids.
    *
+   *
    * ### Versioned ids (releases)
-   * When an ID on the form "versions.<release>.some-id" behave is provided, agent actions will
-   * always behave as if forcePublishedWrite: true. That is, only the exact document state of the id provided
-   * is considered.
+   *
+   * When an ID on the form "versions.<release>.some-id" is provided, agent actions will
+   * always behave as if `forcePublishedWrite: true`.
+   * That is, only the exact document state of the id provided is considered and mutated.
    * */
   forcePublishedWrite?: boolean
 

--- a/src/agent/actions/generate.ts
+++ b/src/agent/actions/generate.ts
@@ -179,6 +179,7 @@ export interface GenerateTarget extends AgentActionTarget {
    * @see #AgentActionTargetInclude.operation
    * @see #include
    * @see #AgentActionTargetInclude.include
+   * @see #AgentActionSchema.forcePublishedWrite
    */
   operation?: GenerateOperation
 
@@ -196,22 +197,34 @@ export interface GenerateTarget extends AgentActionTarget {
 export type GenerateTargetDocument<T extends Record<string, Any> = Record<string, Any>> =
   | {
       operation: 'edit'
+      /**
+       * @see #AgentActionSchema.forcePublishedWrite
+       */
       _id: string
     }
   | {
       operation: 'create'
+      /**
+       * @see #AgentActionSchema.forcePublishedWrite
+       */
       _id?: string
       _type: string
       initialValues?: T
     }
   | {
       operation: 'createIfNotExists'
+      /**
+       * @see #AgentActionSchema.forcePublishedWrite
+       */
       _id: string
       _type: string
       initialValues?: T
     }
   | {
       operation: 'createOrReplace'
+      /**
+       * @see #AgentActionSchema.forcePublishedWrite
+       */
       _id: string
       _type: string
       initialValues?: T
@@ -222,6 +235,9 @@ export type GenerateTargetDocument<T extends Record<string, Any> = Record<string
  * @beta
  */
 interface GenerateExistingDocumentRequest {
+  /**
+   * @see #AgentActionSchema.forcePublishedWrite
+   */
   documentId: string
   targetDocument?: never
 }
@@ -231,6 +247,9 @@ interface GenerateExistingDocumentRequest {
  * @beta
  */
 interface GenerateTargetDocumentRequest<T extends Record<string, Any> = Record<string, Any>> {
+  /**
+   * @see #AgentActionSchema.forcePublishedWrite
+   */
   targetDocument: GenerateTargetDocument<T>
   documentId?: never
 }

--- a/src/agent/actions/patch.ts
+++ b/src/agent/actions/patch.ts
@@ -78,6 +78,9 @@ export type PatchTarget = {
  * @beta
  */
 interface PatchExistingDocumentRequest {
+  /**
+   * @see #AgentActionSchema.forcePublishedWrite
+   */
   documentId: string
   targetDocument?: never
 }
@@ -87,6 +90,9 @@ interface PatchExistingDocumentRequest {
  * @beta
  */
 interface PatchTargetDocumentRequest<T extends Record<string, Any> = Record<string, Any>> {
+  /**
+   * @see #AgentActionSchema.forcePublishedWrite
+   */
   targetDocument: GenerateTargetDocument<T>
   documentId?: never
 }

--- a/src/agent/actions/transform.ts
+++ b/src/agent/actions/transform.ts
@@ -20,6 +20,8 @@ export interface TransformRequestBase extends AgentActionRequestBase {
 
   /**
    * The source document the transformation will use as input.
+   *
+   * @see #AgentActionSchema.forcePublishedWrite
    */
   documentId: string
 
@@ -28,6 +30,8 @@ export interface TransformRequestBase extends AgentActionRequestBase {
    * then it is transformed according to the instruction.
    *
    * When omitted, the source document (documentId) is also the target document.
+   *
+   *  @see #AgentActionSchema.forcePublishedWrite
    */
   targetDocument?: TransformTargetDocument
 
@@ -139,7 +143,11 @@ export interface TransformRequestBase extends AgentActionRequestBase {
   target?: TransformTarget | TransformTarget[]
 }
 
-/**  @beta */
+/**
+ * @see #AgentActionSchema.forcePublishedWrite
+ *
+ * @beta
+ * */
 export type TransformTargetDocument =
   | {operation: 'edit'; _id: string}
   | {operation: 'create'; _id?: string}

--- a/src/agent/actions/translate.ts
+++ b/src/agent/actions/translate.ts
@@ -27,6 +27,7 @@ export interface TranslateRequestBase extends AgentActionRequestBase {
 
   /**
    * The source document the transformation will use as input.
+   * @see #AgentActionSchema.forcePublishedWrite
    */
   documentId: string
 
@@ -35,6 +36,8 @@ export interface TranslateRequestBase extends AgentActionRequestBase {
    * then it is translated according to the instruction.
    *
    * When omitted, the source document (documentId) is also the target document.
+   *
+   * @see #AgentActionSchema.forcePublishedWrite
    */
   targetDocument?: TransformTargetDocument
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4012,6 +4012,7 @@ describe('client', async () => {
       const body = await getClient().agent.action.patch<{title?: string}>({
         targetDocument: {_id: 'some-id', operation: 'edit'},
         async: false,
+        forcePublishedWrite: true,
         target: [
           {path: ['title'], operation: 'append', value: 'title'},
           {path: 'description', operation: 'set', value: 'desc'},
@@ -4176,6 +4177,7 @@ describe('client', async () => {
       const body = await getClient().agent.action.generate<{title?: string}>({
         targetDocument: {_id: 'some-id', operation: 'edit'},
         instruction: '$a $b $d',
+        forcePublishedWrite: true,
         instructionParams: {
           a: 'constant',
           b: {
@@ -4330,6 +4332,7 @@ describe('client', async () => {
       const body = await getClient().agent.action.transform<{title?: string}>({
         documentId: 'some-id',
         instruction: '$a $b $d',
+        forcePublishedWrite: true,
         instructionParams: {
           a: 'constant',
           b: {
@@ -4500,6 +4503,7 @@ describe('client', async () => {
       const body = await getClient().agent.action.translate<{title?: string}>({
         documentId: 'some-id',
         styleGuide: '$a $b $d',
+        forcePublishedWrite: true,
         targetDocument: {
           operation: 'createIfNotExists',
           _id: 'target',


### PR DESCRIPTION
**API BREAKING CHANGE**: The changes in this PR are not breaking for the _client api_, but the backend will start behaving differently once this has been released. Since agent actions require `/vX , this is new behavior will be forced upon all users of agent actions, regardless of client version. Using this release (or later) will be required to opt out of the new behavior.

## Agent actions never write to published documents by default

As of this going out, by default:
- agent.actions will NEVER mutate a published doc – it will use a drafts id if a published id is provided
- operations on drafts will get initial state from published doc, if no draft exists
- Callers should check the _id in the response as needed; when a `publishedId` is provided a `drafts.publishedId` will be returned
- To opt out of the default behavior, pass `forcePublishedWrite: true`
- Documents with `liveEdit: true` schema definition will behave as if `forcePublishedWrite: true`, and also accept drafts IDs in requests

 ### forcePublishedWrite: false (default)
 By default, agent actions will never write to a published document.

 Instead, they will force the use of a draft ID ("drafts.some-id") instead of the published ID ("some-id"),
 even when a published ID is provided.

 Actions will use state from an existing draft if it exists,
 or use the published document to create a draft, if no draft exists.

 Successful responses contain the _id that was mutated by the action.

 ### forcePublishedWrite: true

 When forcePublishedWrite: true an agent action will write to the exact id provided.
 The action will also not fallback to published state for draft ids.

 ### Versioned ids (releases)

 When an ID on the form "versions.<release>.some-id" is provided, agent actions will
 always behave as if `forcePublishedWrite: true`.
 That is, only the exact document state of the id provided is considered and mutated.


