### PR TITLE
feat: agent.action.patch - a schema aware patch api

### DIFF
--- a/src/agent/actions/commonTypes.ts
+++ b/src/agent/actions/commonTypes.ts
@@ -230,7 +230,7 @@ export type AgentActionParams<
 > = Record<string, AgentActionParam<TParamConfig>>
 
 /** @beta */
-export interface AgentActionRequestBase {
+export interface AgentActionSchema {
   /** schemaId as reported by sanity deploy / sanity schema store */
   schemaId: string
 
@@ -264,7 +264,10 @@ export interface AgentActionRequestBase {
       hidden: boolean
     }[]
   }
+}
 
+/** @beta */
+export interface AgentActionRequestBase extends AgentActionSchema {
   /**
    * When localeSettings is provided on the request, instruct can write to date and datetime fields.
    * Otherwise, such fields will be ignored.

--- a/src/agent/actions/generate.ts
+++ b/src/agent/actions/generate.ts
@@ -25,7 +25,7 @@ export interface GenerateRequestBase extends AgentActionRequestBase {
    *
    * The LLM only has access to information in the instruction, plus the target schema.
    *
-   * string template using $variable
+   * String template with support for $variable from `instructionParams`.
    * */
   instruction: string
   /**
@@ -223,7 +223,7 @@ export type GenerateTargetDocument<T extends Record<string, Any> = Record<string
  */
 interface GenerateExistingDocumentRequest {
   documentId: string
-  createDocument?: never
+  targetDocument?: never
 }
 
 /**

--- a/src/agent/actions/patch.ts
+++ b/src/agent/actions/patch.ts
@@ -1,0 +1,130 @@
+import {type Observable} from 'rxjs'
+
+import {_request} from '../../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../../SanityClient'
+import type {
+  AgentActionPath,
+  AgentActionPathSegment,
+  Any,
+  GenerateTargetDocument,
+  HttpRequest,
+  IdentifiedSanityDocumentStub,
+} from '../../types'
+import {hasDataset} from '../../validators'
+import type {AgentActionAsync, AgentActionSchema, AgentActionSync} from './commonTypes'
+
+/**  @beta */
+export type PatchOperation = 'set' | 'append' | 'mixed' | 'unset'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyNonNullable = Exclude<any, null | undefined>
+
+/**  @beta */
+export interface PatchRequestBase extends AgentActionSchema {
+  /**
+   * Target defines which parts of the document will be affected by the instruction.
+   * It can be an array, so multiple parts of the document can be separately configured in detail.
+   *
+   * Omitting target implies that the document itself is the root.
+   *
+   * Notes:
+   * - instruction can only affect fields up to `maxPathDepth`
+   * - when multiple targets are provided, they will be coalesced into a single target sharing a common target root.
+   * It is therefore an error to provide conflicting include/exclude across targets (ie, include title in one, and exclude it in another)
+   *
+   * @see AgentActionRequestBase#conditionalPaths
+   */
+  target: PatchTarget | PatchTarget[]
+}
+
+/**  @beta */
+export type PatchTarget = {
+  /**
+   * Determines how the target path will be patched.
+   *
+   * ### Operation types
+   * - `'set'` – an *overwriting* operation: sets the full field value for primitive targets, and merges the provided value with existing values for objects
+   * - `'append'`:
+   *    – array fields: appends new items to the end of the array,
+   *    - string fields: '"existing content" "new content"'
+   *    - text fields: '"existing content"\\n"new content"'
+   *    - number fields: existing + new
+   *    - other field types not mentioned will set instead (dates, url)
+   * - `'mixed'` –  sets non-array fields, and appends to array fields
+   * - `'unset'` – removes whatever value is on the target path
+   *
+   * All operations except unset requires a `value`.
+   *
+   * #### Appending in the middle of arrays
+   * To append to an array, use the 'append' operation, and provide an array value with one or more array items.
+   *
+   * `target: {path: ['array'], operation: 'append', value: [{_type: 'item' _key: 'a'}]}` will append the items in the value to the existing array.
+   *
+   * To insert in the middle of the array, use `target: {path: ['array', {_key: 'appendAfterKey'}], operation: 'append', value: [{_type: 'item' _key: 'a'}]}`.
+   * Here, `{_type: 'item' _key: 'a'}` will be appended after the array item with key `'appendAfterKey'`
+   *
+   * It is optional to provide a _key for inserted array items; if one isn't provided, it will be generated.
+   */
+  operation: PatchOperation
+
+  path: AgentActionPathSegment | AgentActionPath
+} & (
+  | {operation: 'unset'; value?: never}
+  | {operation: Exclude<PatchOperation, 'unset'>; value: AnyNonNullable}
+)
+
+/**
+ * Patches an existing document
+ * @beta
+ */
+interface PatchExistingDocumentRequest {
+  documentId: string
+  targetDocument?: never
+}
+
+/**
+ * Create a new document, then patch it
+ * @beta
+ */
+interface PatchTargetDocumentRequest<T extends Record<string, Any> = Record<string, Any>> {
+  targetDocument: GenerateTargetDocument<T>
+  documentId?: never
+}
+
+/** @beta */
+export type PatchDocumentSync<T extends Record<string, Any> = Record<string, Any>> = (
+  | PatchExistingDocumentRequest
+  | PatchTargetDocumentRequest<T>
+) &
+  PatchRequestBase &
+  AgentActionSync
+
+/** @beta */
+export type PatchDocumentAsync<T extends Record<string, Any> = Record<string, Any>> = (
+  | PatchExistingDocumentRequest
+  | PatchTargetDocumentRequest<T>
+) &
+  PatchRequestBase &
+  AgentActionAsync
+
+/** @beta */
+export type PatchDocument<T extends Record<string, Any> = Record<string, Any>> =
+  | PatchDocumentSync<T>
+  | PatchDocumentAsync<T>
+
+export function _patch<DocumentShape extends Record<string, Any>>(
+  client: SanityClient | ObservableSanityClient,
+  httpRequest: HttpRequest,
+  request: PatchDocument<DocumentShape>,
+): Observable<
+  (typeof request)['async'] extends true
+    ? {_id: string}
+    : IdentifiedSanityDocumentStub & DocumentShape
+> {
+  const dataset = hasDataset(client.config())
+  return _request(client, httpRequest, {
+    method: 'POST',
+    uri: `/agent/action/patch/${dataset}`,
+    body: request,
+  })
+}

--- a/src/agent/actions/prompt.ts
+++ b/src/agent/actions/prompt.ts
@@ -12,7 +12,7 @@ export interface PromptRequestBase {
    *
    * The LLM only has access to information in the instruction, plus the target schema.
    *
-   * string template using $variable
+   * String template with support for $variable from `instructionParams`.
    * */
   instruction: string
   /**
@@ -24,9 +24,7 @@ export interface PromptRequestBase {
    *
    * ##### Shorthand
    * ```ts
-   * client.agent.action.generate({
-   *   schemaId,
-   *   documentId,
+   * client.agent.action.prompt({
    *   instruction: 'Give the following topic:\n $topic \n ---\nReturns some facts about it',
    *   instructionParams: {
    *     topic: 'Grapefruit'
@@ -94,10 +92,7 @@ export interface PromptRequestBase {
    *
    * Value must be in the range [0, 1] (inclusive).
    *
-   * Defaults:
-   * - generate: 0.3
-   * - translate: 0
-   * - transform: 0
+   * Default: 0.3
    */
   temperature?: number
 }
@@ -115,7 +110,7 @@ interface PromptJsonResponse<T extends Record<string, Any> = Record<string, Any>
    *
    * Note: In addition to setting this to true,  `instruction` MUST include the word 'JSON', or 'json' for this to work.
    */
-  json: true
+  format: 'json'
 }
 
 interface PromptTextResponse {
@@ -126,7 +121,7 @@ interface PromptTextResponse {
    *
    * Note: In addition to setting this to true,  `instruction` MUST include the word 'JSON', or 'json' for this to work.
    */
-  json?: false
+  format?: 'text'
 }
 
 /** @beta */
@@ -136,11 +131,11 @@ export type PromptRequest<T extends Record<string, Any> = Record<string, Any>> =
 ) &
   PromptRequestBase
 
-export function _prompt<DocumentShape extends Record<string, Any>>(
+export function _prompt<const DocumentShape extends Record<string, Any>>(
   client: SanityClient | ObservableSanityClient,
   httpRequest: HttpRequest,
   request: PromptRequest<DocumentShape>,
-): Observable<(typeof request)['json'] extends true ? DocumentShape : string> {
+): Observable<(typeof request)['format'] extends 'json' ? DocumentShape : string> {
   const dataset = hasDataset(client.config())
   return _request(client, httpRequest, {
     method: 'POST',

--- a/src/agent/actions/transform.ts
+++ b/src/agent/actions/transform.ts
@@ -34,7 +34,7 @@ export interface TransformRequestBase extends AgentActionRequestBase {
   /**
    * Instruct the LLM how to transform the input to th output.
    *
-   * String template using $variable from instructionParams.
+   * String template with support for $variable from `instructionParams`.
    *
    * Capped to 2000 characters, after variables has been injected.
    * */
@@ -151,7 +151,7 @@ export interface TransformTargetInclude extends AgentActionTargetInclude {
   /**
    * Specifies a tailored instruction of this target.
    *
-   * string template using $variable from instructionParams  */
+   * String template with support for $variable from `instructionParams`.  */
   instruction?: string
 
   /**
@@ -169,7 +169,7 @@ export interface TransformTarget extends AgentActionTarget {
   /**
    * Specifies a tailored instruction of this target.
    *
-   * string template using $variable from instructionParams.
+   * String template with support for $variable from `instructionParams`.
    * */
   instruction?: string
 

--- a/src/agent/actions/translate.ts
+++ b/src/agent/actions/translate.ts
@@ -105,7 +105,7 @@ export interface TranslateLanguage {
 
 /**  @beta */
 export interface TranslateTargetInclude extends AgentActionTargetInclude {
-  /** string template using $variable from instructionParams  */
+  /** String template using $variable from styleGuideParams.  */
   styleGuide?: string
 
   /**
@@ -120,7 +120,7 @@ export interface TranslateTargetInclude extends AgentActionTargetInclude {
 
 /**  @beta */
 export interface TranslateTarget extends AgentActionTarget {
-  /** string template using $variable from instructionParams  */
+  /** String template using $variable from styleGuideParams.  */
   styleGuide?: string
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1632,6 +1632,7 @@ export type {
   GenerateTargetDocument,
   GenerateTargetInclude,
 } from './agent/actions/generate'
+export type {PatchDocument, PatchOperation, PatchTarget} from './agent/actions/patch'
 export type {PromptRequest} from './agent/actions/prompt'
 export type {
   TransformDocument,

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -3804,7 +3804,7 @@ describe('client', async () => {
 
       const body = await getClient().agent.action.prompt<{json: true}>({
         instruction: 'return the exact json: {json: true}',
-        json: true,
+        format: 'json',
       })
       expect(body).toEqual(response)
     })
@@ -3860,9 +3860,173 @@ describe('client', async () => {
           },
         },
         temperature: 0.6,
-        json: false,
+        format: 'text',
       })
       expect(body).toEqual('whatever')
+    })
+  })
+
+  describe.skipIf(isEdge)('AGENT ACTION: PATCH', () => {
+    test('can create new document', async () => {
+      const response = {
+        _id: 'generated',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      const body = await getClient().agent.action.patch({
+        schemaId: 'some-schema-id',
+        targetDocument: {
+          operation: 'create',
+          _type: 'some-type',
+        },
+        target: {path: 'title', operation: 'unset'},
+      })
+      expect(body).toEqual(response)
+    })
+
+    test('can create new document with id', async () => {
+      const response = {
+        _id: 'generated',
+        title: 'new title',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      const body = await getClient().agent.action.patch({
+        schemaId: 'some-schema-id',
+        targetDocument: {operation: 'createIfNotExists', _id: 'new', _type: 'some-type'},
+        target: {path: 'title', operation: 'set', value: 'new title'},
+      })
+      expect(body).toEqual(response)
+    })
+
+    test('can patch existing document', async () => {
+      const response = {
+        _id: 'generated',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      const body = await getClient().agent.action.patch({
+        documentId: 'some-id',
+        target: {path: 'title', operation: 'unset'},
+        schemaId: 'some-schema-id',
+      })
+      expect(body).toEqual(response)
+    })
+
+    test('can apply generics to type returned document value', async () => {
+      const response = {
+        _id: 'generated',
+        title: 'override',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      const body = await getClient().agent.action.patch<{title?: string}>({
+        documentId: 'some-id',
+        target: {path: 'title', operation: 'set', value: 'override'},
+        schemaId: 'some-schema-id',
+      })
+      expect(body.title).toEqual(response.title)
+    })
+
+    test('providing both documentId & targetDocument should not compile', async () => {
+      const response = {
+        _id: 'generated',
+        title: 'override',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      await getClient().agent.action.patch<{title?: string}>({
+        documentId: 'some-id',
+        //@ts-expect-error not allowed
+        targetDocument: {operation: 'create', _type: 'yolo'},
+        target: {path: 'title', operation: 'set', value: 'override'},
+        schemaId: 'some-schema-id',
+      })
+    })
+
+    test('can cannot apply generics to async request since it returns _id only', async () => {
+      const response = {
+        _id: 'generated',
+        title: 'override',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      const body = await getClient().agent.action.patch({
+        documentId: 'some-id',
+        target: {path: 'title', operation: 'set', value: 'override'},
+        schemaId: 'some-schema-id',
+        async: true,
+      })
+      expect(body._id).toEqual(response._id)
+    })
+
+    test('async cannot noWrite', async () => {
+      const response = {
+        _id: 'generated',
+        title: 'override',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      const body = await getClient().agent.action.patch({
+        documentId: 'some-id',
+        target: {path: 'title', operation: 'set', value: 'override'},
+        schemaId: 'some-schema-id',
+        async: true,
+        //@ts-expect-error not allowed
+        noWrite: true,
+      })
+      expect(body._id).toEqual(response._id)
+    })
+
+    test('all the params', async () => {
+      const response = {
+        _id: 'generated',
+        title: 'override',
+      }
+
+      nock(projectHost())
+        .post(`/v1/agent/action/patch/${clientConfig.dataset}`)
+        .reply(200, response)
+
+      const body = await getClient().agent.action.patch<{title?: string}>({
+        targetDocument: {_id: 'some-id', operation: 'edit'},
+        async: false,
+        target: [
+          {path: ['title'], operation: 'append', value: 'title'},
+          {path: 'description', operation: 'set', value: 'desc'},
+          {path: 'body', operation: 'mixed', value: 'mixed'},
+          {path: 'body', operation: 'unset'},
+        ],
+        noWrite: true,
+        conditionalPaths: {
+          defaultHidden: true,
+          defaultReadOnly: false,
+          paths: [{path: ['title'], readOnly: false, hidden: false}],
+        },
+        schemaId: 'some-schema-id',
+      })
+      expect(body.title).toEqual(response.title)
     })
   })
 
@@ -3940,7 +4104,7 @@ describe('client', async () => {
       expect(body.title).toEqual(response.title)
     })
 
-    test('providing both documentId & createDocument should not compile', async () => {
+    test('providing both documentId & targetDocument should not compile', async () => {
       const response = {
         _id: 'generated',
         title: 'override',


### PR DESCRIPTION
#### Patch with a schema-aware API

The `client.patch` and `client.transaction` API are not schema aware. This allows patching documents any way you want, but the operations will not fail if they deviate from the document schema.

To ensure schema-compliant operation, `client.agent.action.patch` is available. It will ensure that provided paths and values adhere to the document schema, 
ensure no duplicate keys are inserted, and merge object values so `set` operations dont accidentally remove existing values.

See README changes and added TSDocs for details.