### PR TITLE
feat(transform): adds support for optional imageUrl param in for target.operation image-description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2138,6 +2138,13 @@ For example:
 - `target: {path: ['wrapper', 'title'], operation: {type: 'image-description', sourcePath: ['array', {_key: 'abc'}, 'image'] }`
 - `target: {path: ['wrapper'], include: ['portableTextField'], operation: {type: 'image-description', sourcePath: ['image', 'asset'] }, instruction: 'Use formatting and headings to describe the image in great detail' }`
 
+
+###### Targeting images outside the document (URL)
+If the source image is available on a https URL outside the target document, it is possible to get a description for it using `imageUrl`.
+
+Example:
+- `target: {path: ['description'], operation: operation: {type: 'image-description', imageUrL: 'https://www.sanity.io/static/images/favicons/android-icon-192x192.png?v=2' }`
+
 ##### Example: Field-based transformation
 
 ```ts

--- a/src/agent/actions/transform.ts
+++ b/src/agent/actions/transform.ts
@@ -180,7 +180,7 @@ export type TransformTargetDocument =
  * @see #TransformOperation
  * @beta
  */
-export interface ImageDescriptionOperation {
+export type ImageDescriptionOperation = {
   type: 'image-description'
   /**
    * When omitted, parent image value will be inferred from the arget path.
@@ -191,7 +191,32 @@ export interface ImageDescriptionOperation {
    * - `['heroImage', 'asset'] // the asset segment is optional, but supported`
    */
   sourcePath?: AgentActionPath
-}
+} & (
+  | {
+      /**
+       * When omitted, parent image value will be inferred from the target path.
+       *
+       * When specified, the `sourcePath` should be a path to an image (or image asset) field:
+       * - `['image']`
+       * - `['wrapper', 'mainImage']`
+       * - `['heroImage', 'asset'] // the asset segment is optional, but supported`
+       *
+       * Incompatible with `imageUrl`
+       *
+       */
+      sourcePath?: AgentActionPath
+      imageUrl?: never
+    }
+  | {
+      /**
+       * When specified, the image source to be described will be fetched from the URL.
+       *
+       * Incompatible with `sourcePath`
+       */
+      imageUrl?: `https://${string}`
+      sourcePath?: never
+    }
+)
 
 /**
  *
@@ -222,6 +247,11 @@ export interface ImageDescriptionOperation {
  * - `target: {path: ['wrapper', 'title'], operation: {type: 'image-description', sourcePath: ['array', {_key: 'abc'}, 'image'] }`
  * - `target: {path: ['wrapper'], include: ['portableTextField'], operation: {type: 'image-description', sourcePath: ['image', 'asset'] }, instruction: 'Use formatting and headings to describe the image in great detail' }`
  *
+ * ### Targeting images outside the document (URL)
+ * If the source image is available on a https URL outside the target document, it is possible to get a description for it using `imageUrl`.
+ *
+ * Example:
+ * - `target: {path: ['description'], operation: operation: {type: 'image-description', imageUrL: 'https://www.sanity.io/static/images/favicons/android-icon-192x192.png?v=2' }`
  * @beta
  */
 export type TransformOperation = 'set' | ImageDescriptionOperation

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4355,6 +4355,19 @@ describe('client', async () => {
           {path: ['title'], operation: 'set'},
           {path: ['description'], operation: {type: 'image-description', sourcePath: ['image']}},
           {
+            path: ['remoteImageDescription'],
+            operation: {type: 'image-description', imageUrl: 'https://www.santiy.io/logo.png'},
+          },
+          {
+            path: ['errorDesc'],
+            operation: {
+              type: 'image-description',
+              imageUrl: 'https://www.santiy.io/logo.png',
+              //@ts-expect-error imageUrl and sourcePath are mutually exclusive
+              sourcePath: ['image'],
+            },
+          },
+          {
             instruction: 'based on $c – replace this field',
             include: [
               'object',


### PR DESCRIPTION
## Agent Action: Transform – Image descriptions

### Targeting images outside the document (URL)
If the source image is available on a https URL outside the target document, it is possible to get a description for it using `imageUrl`.

Example:
```ts
client.agent.action.transform({
  schemaId,
  documentId,
  instruction: 'describe the image in great detail',
  target: [
    {
      path: ['imageDescription'],
      operation: {
        type: 'image-description',
        imageUrl: 'https://www.sanity.io/static/images/favicons/android-icon-192x192.png?v=2',
      },
    },
  ],
})
```
