### PR TITLE
feat: version.create action supports optional `baseId` and `versionId` instead of `document`

### DIFF
--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -546,7 +546,7 @@ export class ObservableSanityClient {
   createVersion(
     args: {
       baseId: string
-      versionId: string
+      releaseId: string
       publishedId: string
       ifBaseRevisionId?: string
     },
@@ -558,29 +558,23 @@ export class ObservableSanityClient {
       publishedId,
       releaseId,
       baseId,
-      versionId,
       ifBaseRevisionId,
     }: {
       document?: SanityDocumentStub<R> | IdentifiedSanityDocumentStub<R>
       publishedId?: string
       releaseId?: string
       baseId?: string
-      versionId?: string
       ifBaseRevisionId?: string
     },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult | MultipleActionResult> {
-    if ((!document && !baseId) || (document && baseId)) {
-      throw new Error('Either `document` or `baseId` must be provided to `createVersion()`')
-    }
-
     if (!document) {
       return dataMethods._createVersionFromBase(
         this,
         this.#httpRequest,
         publishedId,
         baseId,
-        versionId,
+        releaseId,
         ifBaseRevisionId,
         options,
       )

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -543,18 +543,49 @@ export class ObservableSanityClient {
     },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult | MultipleActionResult>
+  createVersion(
+    args: {
+      baseId: string
+      versionId: string
+      publishedId: string
+      ifBaseRevisionId?: string
+    },
+    options?: BaseActionOptions,
+  ): Observable<SingleActionResult | MultipleActionResult>
   createVersion<R extends Record<string, Any>>(
     {
       document,
       publishedId,
       releaseId,
+      baseId,
+      versionId,
+      ifBaseRevisionId,
     }: {
-      document: SanityDocumentStub<R> | IdentifiedSanityDocumentStub<R>
+      document?: SanityDocumentStub<R> | IdentifiedSanityDocumentStub<R>
       publishedId?: string
       releaseId?: string
+      baseId?: string
+      versionId?: string
+      ifBaseRevisionId?: string
     },
     options?: BaseActionOptions,
   ): Observable<SingleActionResult | MultipleActionResult> {
+    if ((!document && !baseId) || (document && baseId)) {
+      throw new Error('Either `document` or `baseId` must be provided to `createVersion()`')
+    }
+
+    if (!document) {
+      return dataMethods._createVersionFromBase(
+        this,
+        this.#httpRequest,
+        publishedId,
+        baseId,
+        versionId,
+        ifBaseRevisionId,
+        options,
+      )
+    }
+
     const documentVersionId = deriveDocumentVersionId('createVersion', {
       document,
       publishedId,
@@ -1524,18 +1555,51 @@ export class SanityClient {
     },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult | MultipleActionResult>
+  createVersion(
+    args: {
+      publishedId: string
+      baseId: string
+      versionId: string
+      ifBaseRevisionId?: string
+    },
+    options?: BaseActionOptions,
+  ): Promise<SingleActionResult | MultipleActionResult>
   createVersion<R extends Record<string, Any>>(
     {
       document,
       publishedId,
       releaseId,
+      baseId,
+      versionId,
+      ifBaseRevisionId,
     }: {
-      document: SanityDocumentStub<R> | IdentifiedSanityDocumentStub<R>
+      document?: SanityDocumentStub<R> | IdentifiedSanityDocumentStub<R>
       publishedId?: string
       releaseId?: string
+      baseId?: string
+      versionId?: string
+      ifBaseRevisionId?: string
     },
     options?: BaseActionOptions,
   ): Promise<SingleActionResult | MultipleActionResult> {
+    if ((!document && !baseId) || (document && baseId)) {
+      throw new Error('Either `document` or `baseId` must be provided to `createVersion()`')
+    }
+
+    if (!document) {
+      return firstValueFrom(
+        dataMethods._createVersionFromBase(
+          this,
+          this.#httpRequest,
+          publishedId,
+          baseId,
+          versionId,
+          ifBaseRevisionId,
+          options,
+        ),
+      )
+    }
+
     const documentVersionId = deriveDocumentVersionId('createVersion', {
       document,
       publishedId,

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -1,4 +1,4 @@
-import {getVersionFromId, getVersionId, isDraftId} from '@sanity/client/csm'
+import {getDraftId, getVersionFromId, getVersionId, isDraftId} from '@sanity/client/csm'
 import {from, type MonoTypeOperatorFunction, Observable} from 'rxjs'
 import {combineLatestWith, filter, map} from 'rxjs/operators'
 
@@ -285,9 +285,9 @@ export function _createVersion<R extends Record<string, Any>>(
 export function _createVersionFromBase(
   client: ObservableSanityClient | SanityClient,
   httpRequest: HttpRequest,
-  publishedId: string | undefined,
-  baseId: string | undefined,
-  versionId: string | undefined,
+  publishedId?: string,
+  baseId?: string,
+  releaseId?: string,
   ifBaseRevisionId?: string,
   options?: BaseActionOptions,
 ): Observable<SingleActionResult> {
@@ -295,23 +295,18 @@ export function _createVersionFromBase(
     throw new Error('`createVersion()` requires `baseId` when no `document` is provided')
   }
 
-  if (!versionId) {
-    throw new Error('`createVersion()` requires `versionId` when `baseId` is provided')
-  }
-
   if (!publishedId) {
     throw new Error('`createVersion()` requires `publishedId` when `baseId` is provided')
   }
 
   validators.validateDocumentId('createVersion', baseId)
-  validators.validateDocumentId('createVersion', versionId)
   validators.validateDocumentId('createVersion', publishedId)
 
   const createVersionAction: CreateVersionAction = {
     actionType: 'sanity.action.document.version.create',
     publishedId,
     baseId,
-    versionId,
+    versionId: releaseId ? getVersionId(publishedId, releaseId) : getDraftId(publishedId),
     ifBaseRevisionId,
   }
 

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -39,7 +39,11 @@ import type {
 import {getSelection} from '../util/getSelection'
 import * as validate from '../validators'
 import * as validators from '../validators'
-import {printCdnPreviewDraftsWarning, printPreviewDraftsDeprecationWarning} from '../warnings'
+import {
+  printCdnPreviewDraftsWarning,
+  printCreateVersionWithBaseIdWarning,
+  printPreviewDraftsDeprecationWarning,
+} from '../warnings'
 import {encodeQueryString} from './encodeQueryString'
 import {ObservablePatch, Patch} from './patch'
 import {ObservableTransaction, Transaction} from './transaction'
@@ -266,11 +270,49 @@ export function _createVersion<R extends Record<string, Any>>(
 ): Observable<SingleActionResult> {
   validators.requireDocumentId('createVersion', doc)
   validators.requireDocumentType('createVersion', doc)
+  printCreateVersionWithBaseIdWarning()
 
   const createVersionAction: CreateVersionAction = {
     actionType: 'sanity.action.document.version.create',
     publishedId,
     document: doc,
+  }
+
+  return _action(client, httpRequest, createVersionAction, options)
+}
+
+/** @internal */
+export function _createVersionFromBase(
+  client: ObservableSanityClient | SanityClient,
+  httpRequest: HttpRequest,
+  publishedId: string | undefined,
+  baseId: string | undefined,
+  versionId: string | undefined,
+  ifBaseRevisionId?: string,
+  options?: BaseActionOptions,
+): Observable<SingleActionResult> {
+  if (!baseId) {
+    throw new Error('`createVersion()` requires `baseId` when no `document` is provided')
+  }
+
+  if (!versionId) {
+    throw new Error('`createVersion()` requires `versionId` when `baseId` is provided')
+  }
+
+  if (!publishedId) {
+    throw new Error('`createVersion()` requires `publishedId` when `baseId` is provided')
+  }
+
+  validators.validateDocumentId('createVersion', baseId)
+  validators.validateDocumentId('createVersion', versionId)
+  validators.validateDocumentId('createVersion', publishedId)
+
+  const createVersionAction: CreateVersionAction = {
+    actionType: 'sanity.action.document.version.create',
+    publishedId,
+    baseId,
+    versionId,
+    ifBaseRevisionId,
   }
 
   return _action(client, httpRequest, createVersionAction, options)

--- a/src/types.ts
+++ b/src/types.ts
@@ -701,16 +701,29 @@ export interface DeleteReleaseAction {
 }
 
 /**
- * Creates a new version of an existing document, attached to the release as given
- * by `document._id`
+ * Creates a new version of an existing document.
+ *
+ * If the `document` is provided, the version is created from the document
+ * attached to the release as given by `document._id`
+ *
+ * If the `baseId` and `versionId` are provided, the version is created from the base document
+ * and the version is attached to the release as given by `baseId` and `versionId`
  *
  * @public
  */
-export interface CreateVersionAction {
+export type CreateVersionAction = {
   actionType: 'sanity.action.document.version.create'
   publishedId: string
-  document: IdentifiedSanityDocumentStub
-}
+} & (
+  | {
+      document: IdentifiedSanityDocumentStub
+    }
+  | {
+      baseId: string
+      versionId: string
+      ifBaseRevisionId?: string
+    }
+)
 
 /**
  * Delete a version of a document.

--- a/src/types.ts
+++ b/src/types.ts
@@ -707,7 +707,7 @@ export interface DeleteReleaseAction {
  * attached to the release as given by `document._id`
  *
  * If the `baseId` and `versionId` are provided, the version is created from the base document
- * and the version is attached to the release as given by `baseId` and `versionId`
+ * and the version is attached to the release as given by `publishedId` and `versionId`
  *
  * @public
  */

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -46,3 +46,7 @@ export const printNoApiVersionSpecifiedWarning = createWarningPrinter([
 export const printNoDefaultExport = createWarningPrinter([
   'The default export of @sanity/client has been deprecated. Use the named export `createClient` instead.',
 ])
+
+export const printCreateVersionWithBaseIdWarning = createWarningPrinter([
+  'You have called `createVersion()` with a defined `document`. The recommended approach is to provide a `baseId` and `versionId` instead.',
+])

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -48,5 +48,5 @@ export const printNoDefaultExport = createWarningPrinter([
 ])
 
 export const printCreateVersionWithBaseIdWarning = createWarningPrinter([
-  'You have called `createVersion()` with a defined `document`. The recommended approach is to provide a `baseId` and `versionId` instead.',
+  'You have called `createVersion()` with a defined `document`. The recommended approach is to provide a `baseId` and `releaseId` instead.',
 ])

--- a/test/dataMethods.test.ts
+++ b/test/dataMethods.test.ts
@@ -400,4 +400,191 @@ describe('dataMethods', async () => {
       })
     })
   })
+
+  describe('_createVersionFromBase', () => {
+    const mockHttpRequest = vi.fn()
+    const publishedId = 'pub123'
+    const baseId = 'base456'
+    const versionId = 'versions.release789.target123'
+
+    beforeEach(() => {
+      mockHttpRequest.mockClear()
+    })
+
+    test('creates version from base with correct action structure', () => {
+      const expectedAction = {
+        actionType: 'sanity.action.document.version.create',
+        publishedId,
+        baseId,
+        versionId,
+      }
+
+      mockHttpRequest.mockReturnValueOnce(
+        of({
+          type: 'response',
+          body: {transactionId: 'abc123'},
+        }),
+      )
+
+      const client = getClient()
+      const observable = dataMethods._createVersionFromBase(
+        client,
+        mockHttpRequest,
+        publishedId,
+        baseId,
+        versionId,
+      )
+
+      return assertObservable(observable, (result) => {
+        expect(result.transactionId).toEqual('abc123')
+        expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+
+        const request = mockHttpRequest.mock.calls[0][0]
+        expect(request.uri).toEqual('/data/actions/foo')
+        expect(request.body).toEqual({
+          actions: [expectedAction],
+        })
+      })
+    })
+
+    test('creates version from base with ifBaseRevisionId', () => {
+      const ifBaseRevisionId = 'rev456'
+      const expectedAction = {
+        actionType: 'sanity.action.document.version.create',
+        publishedId,
+        baseId,
+        versionId,
+        ifBaseRevisionId,
+      }
+
+      mockHttpRequest.mockReturnValueOnce(
+        of({
+          type: 'response',
+          body: {transactionId: 'abc123'},
+        }),
+      )
+
+      const client = getClient()
+      const observable = dataMethods._createVersionFromBase(
+        client,
+        mockHttpRequest,
+        publishedId,
+        baseId,
+        versionId,
+        ifBaseRevisionId,
+      )
+
+      return assertObservable(observable, (result) => {
+        expect(result.transactionId).toEqual('abc123')
+        expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+
+        const request = mockHttpRequest.mock.calls[0][0]
+        expect(request.body).toEqual({
+          actions: [expectedAction],
+        })
+      })
+    })
+
+    test('creates version from base with options', () => {
+      const options = {
+        skipCrossDatasetReferenceValidation: true,
+        dryRun: true,
+      }
+
+      mockHttpRequest.mockReturnValueOnce(
+        of({
+          type: 'response',
+          body: {transactionId: 'abc123'},
+        }),
+      )
+
+      const client = getClient()
+      const observable = dataMethods._createVersionFromBase(
+        client,
+        mockHttpRequest,
+        publishedId,
+        baseId,
+        versionId,
+        undefined,
+        options,
+      )
+
+      return assertObservable(observable, (result) => {
+        expect(result.transactionId).toEqual('abc123')
+        expect(mockHttpRequest).toHaveBeenCalledTimes(1)
+
+        const request = mockHttpRequest.mock.calls[0][0]
+        expect(request.body).toEqual({
+          actions: [
+            {
+              actionType: 'sanity.action.document.version.create',
+              publishedId,
+              baseId,
+              versionId,
+            },
+          ],
+          skipCrossDatasetReferenceValidation: true,
+          dryRun: true,
+        })
+      })
+    })
+
+    test('throws when baseId is missing', () => {
+      const client = getClient()
+
+      expect(() => {
+        dataMethods._createVersionFromBase(
+          client,
+          mockHttpRequest,
+          publishedId,
+          undefined,
+          versionId,
+        )
+      }).toThrow('`createVersion()` requires `baseId` when no `document` is provided')
+    })
+
+    test('throws when versionId is missing', () => {
+      const client = getClient()
+
+      expect(() => {
+        dataMethods._createVersionFromBase(client, mockHttpRequest, publishedId, baseId, undefined)
+      }).toThrow('`createVersion()` requires `versionId` when `baseId` is provided')
+    })
+
+    test('throws when publishedId is missing', () => {
+      const client = getClient()
+
+      expect(() => {
+        dataMethods._createVersionFromBase(client, mockHttpRequest, undefined, baseId, versionId)
+      }).toThrow('`createVersion()` requires `publishedId` when `baseId` is provided')
+    })
+
+    test('validates document IDs', () => {
+      const client = getClient()
+
+      expect(() => {
+        dataMethods._createVersionFromBase(client, mockHttpRequest, 'invalid*id', baseId, versionId)
+      }).toThrow(/is not a valid document ID/)
+
+      expect(() => {
+        dataMethods._createVersionFromBase(
+          client,
+          mockHttpRequest,
+          publishedId,
+          'invalid*id',
+          versionId,
+        )
+      }).toThrow(/is not a valid document ID/)
+
+      expect(() => {
+        dataMethods._createVersionFromBase(
+          client,
+          mockHttpRequest,
+          publishedId,
+          baseId,
+          'invalid*id',
+        )
+      }).toThrow(/is not a valid document ID/)
+    })
+  })
 })


### PR DESCRIPTION
As of the latest content lake API, `version.create` server action now supports an optional `baseId` and `versionId` instead of a `document`. eg

```
client.createVersion({
  publishedId: 'my-document',
  baseId: 'versions.summer-sale.my-document',
  releaseId: 'winter-sale'
})
```
will create the document:
```
{
  _id: 'versions.winter-sale.my-document',
  <fields copied from versions.summer-sale.my-document>,
  _system: {
    base: {
      id: 'versions.summer-sale.my-document'
    }
  }
}
```

When `baseId` is provided, then the API will copy from the document at that Id path, creating a new document under the `versionId`.

This is a recommended approach over defining `document` as when using `baseId`, the resultant document will contain a `_system.base.id` property, which will allow for inheritance and head tracing.