### PR TITLE
docs(views): add initial reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2316,7 +2316,6 @@ const client = createViewClient({
 })
 
 client.fetch('viewId', 'count(*)')
-        .fetch('viewId', 'count(*)')
         .then((data) => console.log(`Number of documents: ${data}`))
         .catch(console.error);
 ```

--- a/README.md
+++ b/README.md
@@ -2380,7 +2380,8 @@ const config: ViewClientConfig = {
   token: process.env.SANITY_API_TOKEN, // this is required to use the override functionality
   viewOverrides: [
     {
-      id: 'vw2x09caysNaZdjksWEsToG43meSg', // the view id you are developing
+      resourceType: ViewResourceType.View,
+      resourceId: 'vw2x09caysNaZdjksWEsToG43meSg', // the view id you are developing
       connections: [
         {
           query: '*[_type == "location"]', // the query to use for this connection - this is what you would deploy later

--- a/src/types.ts
+++ b/src/types.ts
@@ -1232,11 +1232,13 @@ export interface UnfilteredResponseWithoutQuery extends ResponseQueryOptions {
 /** @public */
 export enum ViewResourceType {
   Dataset = 'dataset',
+  View = 'view',
 }
 
 /** @public */
 export type ViewOverride = {
-  id: string
+  resourceType: ViewResourceType.View
+  resourceId: string
   connections: ViewConnectionOverride[]
 }
 

--- a/test/views/client.test.ts
+++ b/test/views/client.test.ts
@@ -46,6 +46,22 @@ describe('view client', async () => {
       expect(client).toBeDefined()
       expect(client.observable).toBeInstanceOf(ObservableViewClient)
     })
+
+    test('throws if viewOverrides contains a non-view resource type', () => {
+      expect(() =>
+        createViewClient({
+          ...defaultConfig,
+          viewOverrides: [
+            {
+              // @ts-expect-error - we want to test that it throws an error
+              resourceType: ViewResourceType.Dataset,
+              resourceId: 'vw-dataset-test',
+              connections: [],
+            },
+          ],
+        }),
+      ).toThrow(/View overrides only support resource type "view"/)
+    })
   })
 
   describe('promise client', () => {
@@ -205,7 +221,8 @@ describe('view client', async () => {
         ...defaultConfig,
         viewOverrides: [
           {
-            id: 'vw-dataset-test',
+            resourceType: ViewResourceType.View,
+            resourceId: 'vw-dataset-test',
             connections: [
               {
                 query: '*[_type == "document"]',
@@ -243,7 +260,8 @@ describe('view client', async () => {
         ...defaultConfig,
         viewOverrides: [
           {
-            id: 'vw-other',
+            resourceType: ViewResourceType.View,
+            resourceId: 'vw-other',
             connections: [
               {
                 query: '*[_type == "document"]',
@@ -470,7 +488,8 @@ describe('view client', async () => {
           ...defaultConfig,
           viewOverrides: [
             {
-              id: 'vw-obs-dataset',
+              resourceType: ViewResourceType.View,
+              resourceId: 'vw-obs-dataset',
               connections: [
                 {
                   query: '*[_type == "document"]',


### PR DESCRIPTION
Docs for the views client. I've tried to keep this as light as possible while communicating the functionality so maintainance isn't too bad given this overlaps with the sanityClient in places. Conventions and patterns are copied form elsewhere in the docs. 