### PR TITLE
feat: add `isHttpError` method (and shared `HttpError` interface)

### DIFF
--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -21,6 +21,8 @@ export {
   ClientError,
   CorsOriginError,
   formatQueryParseError,
+  type HttpError,
+  isHttpError,
   isQueryParseError,
   ServerError,
 } from './http/errors'

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -6,6 +6,59 @@ import {isRecord} from '../util/isRecord'
 
 const MAX_ITEMS_IN_ERROR_MESSAGE = 5
 
+/**
+ * Shared properties for HTTP errors (eg both ClientError and ServerError)
+ * Use `isHttpError` for type narrowing and accessing response properties.
+ *
+ * @public
+ */
+export interface HttpError {
+  statusCode: number
+  message: string
+  response: {
+    body: unknown
+    url: string
+    method: string
+    headers: Record<string, string>
+    statusCode: number
+    statusMessage: string | null
+  }
+}
+
+/**
+ * Checks if the provided error is an HTTP error.
+ *
+ * @param error - The error to check.
+ * @returns `true` if the error is an HTTP error, `false` otherwise.
+ * @public
+ */
+export function isHttpError(error: unknown): error is HttpError {
+  if (!isRecord(error)) {
+    return false
+  }
+
+  const response = error.response
+  if (
+    typeof error.statusCode !== 'number' ||
+    typeof error.message !== 'string' ||
+    !isRecord(response)
+  ) {
+    return false
+  }
+
+  if (
+    typeof response.body === 'undefined' ||
+    typeof response.url !== 'string' ||
+    typeof response.method !== 'string' ||
+    typeof response.headers !== 'object' ||
+    typeof response.statusCode !== 'number'
+  ) {
+    return false
+  }
+
+  return true
+}
+
 /** @public */
 export class ClientError extends Error {
   response: ErrorProps['response']

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,6 +1,15 @@
+import {createClient} from '@sanity/client'
 import {describe, expect, test} from 'vitest'
 
-import {formatQueryParseError} from '../src/http/errors'
+import {
+  ClientError,
+  formatQueryParseError,
+  type HttpError,
+  isHttpError,
+  ServerError,
+} from '../src/http/errors'
+
+const apiHost = 'api.sanity.url'
 
 const singleLineQuery = `*[_type == "event]`
 const multiLineQuery = `*[
@@ -93,5 +102,174 @@ describe('groq errors', () => {
       > 1 | *[_type == "event]
           |     ^^^^^^^^^^^^^ unexpected token "\\"event]", expected expression"
     `)
+  })
+})
+
+describe('http errors', async () => {
+  const isEdge = typeof EdgeRuntime === 'string'
+  let nock: typeof import('nock') = (() => {
+    throw new Error('Not supported in EdgeRuntime')
+  }) as any
+  if (!isEdge) {
+    const _nock = await import('nock')
+    nock = _nock.default
+  }
+
+  test.skipIf(isEdge)('yields ServerError on 503 (non-sanity api response)', async () => {
+    nock(`https://${apiHost}`).get('/v1/projects/n1f7y').reply(503, 'Service Unavailable')
+    const client = createClient({
+      useCdn: true,
+      apiVersion: '1',
+      useProjectHostname: false,
+      apiHost: `https://${apiHost}`,
+      maxRetries: 0,
+    })
+
+    const err = await client.projects.getById('n1f7y').catch((error) => error)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(ServerError)
+    expect(err.constructor.name).toBe('ServerError')
+    expect(err.message).toContain('503 (Service Unavailable)')
+    expect(err).toHaveProperty('statusCode', 503)
+
+    expect(isHttpError(err)).toBe(true)
+  })
+
+  test.skipIf(isEdge)('yields ServerError on 503 (sanity api response)', async () => {
+    nock(`https://${apiHost}`).get('/v1/projects/n1f7y').reply(503, {
+      statusCode: 503,
+      error: 'Service Unavailable',
+      message: 'Some internal error occurred',
+    })
+    const client = createClient({
+      useCdn: true,
+      apiVersion: '1',
+      useProjectHostname: false,
+      apiHost: `https://${apiHost}`,
+      maxRetries: 0,
+    })
+
+    const err = await client.projects.getById('n1f7y').catch((error) => error)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(ServerError)
+    expect(err.constructor.name).toBe('ServerError')
+    expect(err.message).toContain('Service Unavailable - Some internal error occurred')
+    expect(err).toHaveProperty('statusCode', 503)
+
+    expect(isHttpError(err)).toBe(true)
+  })
+
+  test.skipIf(isEdge)('yields ClientError on 400 (non-sanity api response)', async () => {
+    nock(`https://${apiHost}`).get('/v1/projects/n1f7y').reply(400, 'Bad Request')
+
+    const client = createClient({
+      useCdn: true,
+      apiVersion: '1',
+      useProjectHostname: false,
+      apiHost: `https://${apiHost}`,
+      maxRetries: 0,
+    })
+
+    const err = await client.projects.getById('n1f7y').catch((error) => error)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(ClientError)
+    expect(err.constructor.name).toBe('ClientError')
+    expect(err.message).toContain('400 (Bad Request)')
+    expect(err).toHaveProperty('statusCode', 400)
+
+    expect(isHttpError(err)).toBe(true)
+  })
+
+  test.skipIf(isEdge)('yields ClientError on 400 (sanity api response)', async () => {
+    nock(`https://${apiHost}`).get('/v1/projects/n1f7y').reply(400, {
+      statusCode: 400,
+      error: 'Bad Request',
+      message: 'Invalid request parameters',
+    })
+
+    const client = createClient({
+      useCdn: true,
+      apiVersion: '1',
+      useProjectHostname: false,
+      apiHost: `https://${apiHost}`,
+      maxRetries: 0,
+    })
+
+    const err = await client.projects.getById('n1f7y').catch((error) => error)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(ClientError)
+    expect(err.constructor.name).toBe('ClientError')
+    expect(err.message).toContain('Bad Request - Invalid request parameters')
+    expect(err).toHaveProperty('statusCode', 400)
+
+    expect(isHttpError(err)).toBe(true)
+  })
+})
+
+describe('isHttpError', () => {
+  const res = {headers: {}, body: '', url: 'https://api.sanity.io/v1/data/query', method: 'GET'}
+  const clientErr = new ClientError({statusCode: 400, ...res}) satisfies HttpError
+  const serverErr = new ServerError({statusCode: 500, ...res}) satisfies HttpError
+
+  test('returns true for ClientError instance', () => {
+    expect(isHttpError(clientErr)).toBe(true)
+  })
+
+  test('returns true for ServerError instance', () => {
+    expect(isHttpError(serverErr)).toBe(true)
+  })
+
+  test('returns false for non-object errors', () => {
+    expect(isHttpError('not an object')).toBe(false)
+    expect(isHttpError(123)).toBe(false)
+    expect(isHttpError(null)).toBe(false)
+    expect(isHttpError(undefined)).toBe(false)
+  })
+
+  test('returns false for objects without response', () => {
+    expect(isHttpError({statusCode: 400, message: 'Bad Request'})).toBe(false)
+  })
+
+  test('returns true for valid HttpError objects', () => {
+    const error = {
+      statusCode: 400,
+      message: 'Bad Request',
+      response: {
+        body: {},
+        url: 'https://api.sanity.io/v1/data/query',
+        method: 'GET',
+        headers: {},
+        statusCode: 400,
+      },
+    }
+    expect(isHttpError(error)).toBe(true)
+  })
+
+  test('returns false for HttpError objects with missing properties', () => {
+    const error = {
+      statusCode: 400,
+      message: 'Bad Request',
+      response: {
+        body: {},
+        url: 'https://api.sanity.io/v1/data/query',
+        method: 'GET',
+        headers: {},
+      },
+    }
+    expect(isHttpError(error)).toBe(false)
+  })
+  test('returns false for HttpError objects with invalid response structure', () => {
+    const error = {
+      statusCode: 400,
+      message: 'Bad Request',
+      response: {
+        body: {},
+        url: 'https://api.sanity.io/v1/data/query',
+        method: 'GET',
+        headers: {},
+        statusCode: '400', // Invalid type
+      },
+    }
+    expect(isHttpError(error)).toBe(false)
   })
 })


### PR DESCRIPTION
### Description

Kept re-implementing this in a bunch of different places - when a client request throws and your TS settings are strict, error is always `unknown`. Quite often you're just interested in knowing that the error was actually an HTTP error and what HTTP error code it had. 

This introduces a `isHttpError` utility function to determine this - it does the type narrowing for you. Both the `ClientError` and `ServerError` adhere to the now defined `HttpError` interface.

### What to review

Changes make sense? Sufficient testing?

### Testing

New tests added for the utility function.
