### PR TITLE
fix: add missing `provider` property to `CurrentSanityUser` type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -508,6 +508,7 @@ export interface CurrentSanityUser {
   email: string
   profileImage: string | null
   role: string
+  provider: string
 }
 
 /** @public */


### PR DESCRIPTION
### Description

`/v1/users/me` (and other API versions) all seems to return `provider`. Added to the type definition.

### What to review

Hit https://api.sanity.io/v1/users/me as authed user, see `provider` option. 
See `CurrentSanityUser` is used for `.users.getById('me')` typing.

### Testing

None needed.
