### PR TITLE
fix: update types and readme for actions api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1488,7 +1488,7 @@ client
   })
 ```
 
-`sanity.action.document.delete` cannot be used to delete documents that have not yet been published. Use `.delete()` from the Mutation API instead.
+`sanity.action.document.delete` cannot be used to delete documents that have not yet been published. Use `sanity.action.version.discard` or `.delete()` from the Mutation API instead.
 
 #### Edit Action
 
@@ -1500,9 +1500,9 @@ client
     {
       actionType: 'sanity.action.document.edit',
       publishedId: 'bike-123',
-      draftId: 'drafts.bike-123',
+      versionId: 'drafts.bike-123',
       patch: {
-        set: { seats: 1 },
+        set: {seats: 1},
       },
     },
     actionOptions,
@@ -1525,7 +1525,7 @@ client
     {
       actionType: 'sanity.action.document.publish',
       versionId: 'drafts.bike-123',
-      ifDraftRevisionId: '<previously-known-revision>',
+      ifVersionRevisionId: '<previously-known-revision>',
       publishedId: 'bike-123',
       ifPublishedRevisionId: '<previously-known-revision>',
     },

--- a/README.md
+++ b/README.md
@@ -1424,7 +1424,7 @@ if (runRelease.state === 'published' && !runRelease.error) {
 
 ### Actions
 
-The Actions API provides a new interface for creating, updating and publishing documents. It is a wrapper around the [Actions API](https://www.sanity.io/docs/http-actions).
+The Actions API provides a new interface for creating, updating and publishing documents with a greater focus on handling document versions such as drafts and releases. It is a wrapper around the [Actions API](https://www.sanity.io/docs/http-actions).
 
 This API is only available from API version `v2024-05-23`.
 
@@ -1438,7 +1438,7 @@ The following options are available for actions, and can be applied as the secon
 
 #### Create Action
 
-A document draft can be created by specifying a create action type:
+A document version can be created by specifying a `sanity.action.document.create` action type.
 
 ```js
 client
@@ -1446,7 +1446,12 @@ client
     {
       actionType: 'sanity.action.document.create',
       publishedId: 'bike-123',
-      attributes: {name: 'Sanity Tandem Extraordinaire', _type: 'bike', seats: 1},
+      attributes: {
+        _id: 'drafts.bike-123',
+        _type: 'bike',
+        name: 'Sanity Tandem Extraordinaire',
+        seats: 1,
+      },
       ifExists: 'fail',
     },
     actionOptions,
@@ -1459,9 +1464,11 @@ client
   })
 ```
 
+`sanity.action.document.create` cannot be used to create documents with published IDs. Use `.create()` from the Mutation API instead.
+
 #### Delete Action
 
-A published document can be deleted by specifying a delete action type, optionally including some drafts:
+A published document can be deleted by specifying a `sanity.action.document.delete` action type, optionally including some draft or version IDs of the published document:
 
 ```js
 client
@@ -1469,7 +1476,7 @@ client
     {
       actionType: 'sanity.action.document.delete',
       publishedId: 'bike-123',
-      includeDrafts: ['draft.bike-123'],
+      includeVersions: ['drafts.bike-123'],
     },
     actionOptions,
   )
@@ -1481,9 +1488,11 @@ client
   })
 ```
 
+`sanity.action.document.delete` cannot be used to delete documents that have not yet been published. Use `.delete()` from the Mutation API instead.
+
 #### Edit Action
 
-A patch can be applied to an existing document draft or create a new one by specifying an edit action type:
+The `sanity.action.document.edit` action will update an existing draft document if it exists, or create a new draft document from the published version and then apply the edit:
 
 ```js
 client
@@ -1491,7 +1500,10 @@ client
     {
       actionType: 'sanity.action.document.edit',
       publishedId: 'bike-123',
-      attributes: {name: 'Sanity Tandem Extraordinaire', _type: 'bike', seats: 2},
+      draftId: 'drafts.bike-123',
+      patch: {
+        set: { seats: 1 },
+      },
     },
     actionOptions,
   )
@@ -1512,7 +1524,7 @@ client
   .action(
     {
       actionType: 'sanity.action.document.publish',
-      draftId: 'draft.bike-123',
+      versionId: 'drafts.bike-123',
       ifDraftRevisionId: '<previously-known-revision>',
       publishedId: 'bike-123',
       ifPublishedRevisionId: '<previously-known-revision>',
@@ -1536,7 +1548,7 @@ client
   .action(
     {
       actionType: 'sanity.action.document.unpublish',
-      draftId: 'draft.bike-123',
+      versionId: 'drafts.bike-123',
       publishedId: 'bike-123',
     },
     actionOptions,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/client",
-  "version": "7.8.1",
+  "version": "7.8.1-beta.0",
   "description": "Client for retrieving, creating and patching data from Sanity.io",
   "keywords": [
     "sanity",

--- a/src/types.ts
+++ b/src/types.ts
@@ -870,11 +870,16 @@ export type DeleteAction = {
    * Published document ID to delete
    */
   publishedId: string
+  
+  /**
+   * Draft or version IDs of the published document to delete
+   */
+  includeVersions: [string, ...string[]]
 
   /**
-   * Draft document ID to delete
+   * @deprecated Use `includeVersions` instead
    */
-  includeDrafts: string[]
+  includeDrafts?: string[]
 
   /**
    * Delete document history
@@ -916,12 +921,22 @@ export type PublishAction = {
   actionType: 'sanity.action.document.publish'
 
   /**
-   * Draft document ID to publish
+   * Draft or version document ID to publish
    */
-  draftId: string
+  versionId: string
 
   /**
-   * Draft revision ID to match
+   * @deprecated Use `versionId` instead
+   */
+  draftId?: string
+
+  /**
+   * Draft or version revision ID to match
+   */
+  ifVersionRevisionId?: string
+
+  /**
+   * @deprecated Use `ifVersionRevisionId` instead
    */
   ifDraftRevisionId?: string
 
@@ -947,9 +962,14 @@ export type UnpublishAction = {
   actionType: 'sanity.action.document.unpublish'
 
   /**
-   * Draft document ID to replace the published document with
+   * Draft or version document ID to replace the published document with
    */
-  draftId: string
+  versionId: string
+
+  /**
+   * @deprecated Use `versionId` instead
+   */
+  draftId?: string
 
   /**
    * Published document ID to delete

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2248,7 +2248,7 @@ describe('client', async () => {
       const action6: PublishAction = {
         actionType: 'sanity.action.document.publish',
         versionId: 'drafts.post6',
-        ifDraftRevisionId: 'rev7',
+        ifVersionRevisionId: 'rev7',
         publishedId: 'post6',
         ifPublishedRevisionId: 'rev6',
       }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2235,7 +2235,7 @@ describe('client', async () => {
       const action4: DeleteAction = {
         actionType: 'sanity.action.document.delete',
         publishedId: 'post4',
-        includeDrafts: ['drafts.post4'],
+        includeVersions: ['drafts.post4'],
         purge: true,
       }
 
@@ -2247,7 +2247,7 @@ describe('client', async () => {
 
       const action6: PublishAction = {
         actionType: 'sanity.action.document.publish',
-        draftId: 'drafts.post6',
+        versionId: 'drafts.post6',
         ifDraftRevisionId: 'rev7',
         publishedId: 'post6',
         ifPublishedRevisionId: 'rev6',
@@ -2255,7 +2255,7 @@ describe('client', async () => {
 
       const action7: UnpublishAction = {
         actionType: 'sanity.action.document.unpublish',
-        draftId: 'drafts.post7',
+        versionId: 'drafts.post7',
         publishedId: 'post7',
       }
 


### PR DESCRIPTION
### Description

Updated README guidance + examples for the actions:
* `sanity.action.document.create`
* `sanity.action.document.edit`
* `sanity.action.document.delete`
* `sanity.action.document.publish`

Some of the code examples were just wrong.

Also updated some of the type signatures and parameters for invoking these actions to reference `versions` instead of `drafts`. 

### What to review

As far as I know, these drafts -> versions options **work** but I have only crudely confirmed it by running some scripts locally.

### Testing

I updated the tests to match the new Types changing drafts -> versions