### PR TITLE
fix: correctly uses format: 'string' typing for prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2215,13 +2215,13 @@ const result = await client.agent.action.prompt({
     name: 'Mark',
   },
   temperature: 0.5,
-  format: 'text',
+  format: 'string',
 })
 ```
 
 - **instruction**: A string template describing what the LLM should do. Use `$variable` for dynamic values.
 - **instructionParams**: Values for variables in the instruction. Supports constants, fields, documents, or GROQ queries.
-- **format**: (Optional) 'text' or 'json'. Defaults to 'text'. Note that when specifying 'json', the instruction MUST include the word "json" (ignoring case) in some form.
+- **format**: (Optional) 'string' or 'json'. Defaults to 'string'. Note that when specifying 'json', the instruction MUST include the word "json" (ignoring case) in some form.
 - **temperature**: (Optional) Controls variance, 0-1 – defaults to 0
 
 #### Patch with a schema-aware API

--- a/src/agent/actions/prompt.ts
+++ b/src/agent/actions/prompt.ts
@@ -113,7 +113,7 @@ interface PromptJsonResponse<T extends Record<string, Any> = Record<string, Any>
 
 interface PromptTextResponse {
   /**
-   * When format is 'string', the response will be a string
+   * When format is 'string', the response will be a raw text response to the instruction.
    */
   format?: 'string'
 }

--- a/src/agent/actions/prompt.ts
+++ b/src/agent/actions/prompt.ts
@@ -105,23 +105,17 @@ export interface PromptRequestBase {
 interface PromptJsonResponse<T extends Record<string, Any> = Record<string, Any>> {
   /**
    *
-   * When true, the response body will be json according to the instruction.
-   * When false, the response is the raw text response to the instruction.
-   *
-   * Note: In addition to setting this to true,  `instruction` MUST include the word 'JSON', or 'json' for this to work.
+   * When format is 'json', the response will be json according to the instruction.
+   * Note: In addition to setting this to 'json',  `instruction` MUST include the word 'JSON', or 'json' for this to work.
    */
   format: 'json'
 }
 
 interface PromptTextResponse {
   /**
-   *
-   * When true, the response body will be json according to the instruction.
-   * When false, the response is the raw text response to the instruction.
-   *
-   * Note: In addition to setting this to true,  `instruction` MUST include the word 'JSON', or 'json' for this to work.
+   * When format is 'string', the response will be a string
    */
-  format?: 'text'
+  format?: 'string'
 }
 
 /** @beta */

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4032,7 +4032,7 @@ describe('client', async () => {
           },
         },
         temperature: 0.6,
-        format: 'text',
+        format: 'string',
       })
       expect(body).toEqual('whatever')
     })


### PR DESCRIPTION
The prompt type was incorrectly using 'text' for format param in prompt action. The backend requires 'string'.
