### PR TITLE
fix: allows perspective on instructionParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2047,6 +2047,7 @@ await client.agent.action.generate({
       type: 'groq',
       query: '*[_type==$type].title',
       params: {type: 'article'},
+      perspective: 'drafts' // optional
     },
   },
   target: {path: ['body']},

--- a/src/agent/actions/commonTypes.ts
+++ b/src/agent/actions/commonTypes.ts
@@ -1,3 +1,5 @@
+import type {ClientPerspective} from '@sanity/client'
+
 /**
  * Include a string in the instruction: do not have to escape $ signs in the string.
  *
@@ -128,6 +130,7 @@ export interface GroqAgentActionParam {
   type: 'groq'
   query: string
   params?: Record<string, string>
+  perspective?: ClientPerspective
 }
 
 /**  @beta */

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -4360,6 +4360,7 @@ describe('client', async () => {
             type: 'groq',
             query: '*[id=$id].title',
             params: {id: 'abc'},
+            perspective: 'drafts',
           },
           d: {
             type: 'document',
@@ -4515,6 +4516,7 @@ describe('client', async () => {
             type: 'groq',
             query: '*[id=$id].title',
             params: {id: 'abc'},
+            perspective: 'published',
           },
           d: {
             type: 'document',


### PR DESCRIPTION
### Description

Allows passing a `perspective` to instructionParam with `type: 'groq'`.

This is needed since recent versions of the api no longer has access to drafts data without a perspective, even when using drafts id in the query. Without this, actions running on drafts documents in the studio with AI Assist field actions, for instance, do not behave as expected, since it cannot see the drafts data in groq queries.

`@sanity/client@7.8.1-agent-action-perspective.0`