### PR TITLE
feat(projects): allow a project list to be filtered to a specific Organization ID

### DIFF
--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -78,7 +78,9 @@ export class ProjectsClient {
     if (options?.organizationId) {
       params.organizationId = options.organizationId
     }
-    return lastValueFrom(_request<SanityProject[]>(this.#client, this.#httpRequest, {uri}))
+    return lastValueFrom(
+      _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query: params}),
+    )
   }
 
   /**

--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -29,16 +29,16 @@ export class ObservableProjectsClient {
     includeMembers?: boolean
     organizationId?: string
   }): Observable<SanityProject[] | Omit<SanityProject, 'members'>[]> {
-    const params: Record<string, string> = {}
+    const query: Record<string, string> = {}
     const uri = '/projects'
     if (options?.includeMembers === false) {
-      params.includeMembers = 'false'
+      query.includeMembers = 'false'
     }
     if (options?.organizationId) {
-      params.organizationId = options.organizationId
+      query.organizationId = options.organizationId
     }
 
-    return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query: params})
+    return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query})
   }
 
   /**
@@ -76,17 +76,15 @@ export class ProjectsClient {
     includeMembers?: boolean
     organizationId?: string
   }): Promise<SanityProject[] | Omit<SanityProject, 'members'>[]> {
-    const params: Record<string, string> = {}
+    const query: Record<string, string> = {}
     const uri = '/projects'
     if (options?.includeMembers === false) {
-      params.includeMembers = 'false'
+      query.includeMembers = 'false'
     }
     if (options?.organizationId) {
-      params.organizationId = options.organizationId
+      query.organizationId = options.organizationId
     }
-    return lastValueFrom(
-      _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query: params}),
-    )
+    return lastValueFrom(_request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query}))
   }
 
   /**

--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -18,14 +18,27 @@ export class ObservableProjectsClient {
    *
    * @param options - Options for the list request
    *   - `includeMembers` - Whether to include members in the response (default: true)
+   *   - `organizationId` - ID of the organization to fetch projects for
    */
-  list(options?: {includeMembers?: true}): Observable<SanityProject[]>
-  list(options?: {includeMembers?: false}): Observable<Omit<SanityProject, 'members'>[]>
+  list(options?: {includeMembers?: true; organizationId?: string}): Observable<SanityProject[]>
+  list(options?: {
+    includeMembers?: false
+    organizationId?: string
+  }): Observable<Omit<SanityProject, 'members'>[]>
   list(options?: {
     includeMembers?: boolean
+    organizationId?: string
   }): Observable<SanityProject[] | Omit<SanityProject, 'members'>[]> {
-    const uri = options?.includeMembers === false ? '/projects?includeMembers=false' : '/projects'
-    return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri})
+    const params: Record<string, string> = {}
+    const uri = '/projects'
+    if (options?.includeMembers === false) {
+      params.includeMembers = 'false'
+    }
+    if (options?.organizationId) {
+      params.organizationId = options.organizationId
+    }
+
+    return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query: params})
   }
 
   /**
@@ -52,11 +65,19 @@ export class ProjectsClient {
    *
    * @param options - Options for the list request
    *   - `includeMembers` - Whether to include members in the response (default: true)
+   *   - `organizationId` - ID of the organization to fetch projects for
    */
   list(options?: {includeMembers?: true}): Promise<SanityProject[]>
   list(options?: {includeMembers?: false}): Promise<Omit<SanityProject, 'members'>[]>
-  list(options?: {includeMembers?: boolean}): Promise<SanityProject[]> {
-    const uri = options?.includeMembers === false ? '/projects?includeMembers=false' : '/projects'
+  list(options?: {includeMembers?: boolean; organizationId?: string}): Promise<SanityProject[]> {
+    const params: Record<string, string> = {}
+    const uri = '/projects'
+    if (options?.includeMembers === false) {
+      params.includeMembers = 'false'
+    }
+    if (options?.organizationId) {
+      params.organizationId = options.organizationId
+    }
     return lastValueFrom(_request<SanityProject[]>(this.#client, this.#httpRequest, {uri}))
   }
 

--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -67,9 +67,15 @@ export class ProjectsClient {
    *   - `includeMembers` - Whether to include members in the response (default: true)
    *   - `organizationId` - ID of the organization to fetch projects for
    */
-  list(options?: {includeMembers?: true}): Promise<SanityProject[]>
-  list(options?: {includeMembers?: false}): Promise<Omit<SanityProject, 'members'>[]>
-  list(options?: {includeMembers?: boolean; organizationId?: string}): Promise<SanityProject[]> {
+  list(options?: {includeMembers?: true; organizationId?: string}): Promise<SanityProject[]>
+  list(options?: {
+    includeMembers?: false
+    organizationId?: string
+  }): Promise<Omit<SanityProject, 'members'>[]>
+  list(options?: {
+    includeMembers?: boolean
+    organizationId?: string
+  }): Promise<SanityProject[] | Omit<SanityProject, 'members'>[]> {
     const params: Record<string, string> = {}
     const uri = '/projects'
     if (options?.includeMembers === false) {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -711,6 +711,17 @@ describe('client', async () => {
       expect(projects[0].members, 'should not have "members" prop').toBeUndefined()
     })
 
+    test('can request list of projects for an organization', async () => {
+      nock(`https://${apiHost}`)
+        .get('/v1/projects?organizationId=org_123')
+        .reply(200, [{id: 'foo'}, {id: 'bar'}])
+
+      const client = createClient({useProjectHostname: false, apiHost: `https://${apiHost}`})
+      const projects = await client.projects.list({organizationId: 'org_123'})
+      expect(projects.length, 'should have two projects').toBe(2)
+      expect(projects[0].id, 'should have project id').toBe('foo')
+    })
+
     test('can request list of projects, ignoring non-false `includeMembers` option', async () => {
       nock(`https://${apiHost}`)
         .get('/v1/projects')


### PR DESCRIPTION
### Description

Added support for filtering projects by organization ID in the `list` method of both `ObservableProjectsClient` and `ProjectsClient` classes. This allows clients to fetch projects belonging to a specific organization by passing an optional `organizationId` parameter.

### What to review

- The new `organizationId` parameter in the method signatures
- The query parameter handling in both client implementations
- Verify that the TypeScript types are correctly updated to reflect the new parameter

### Testing

The changes maintain type safety and follow the existing pattern for handling optional parameters. The implementation correctly adds the organization ID to the query parameters when provided.