### PR TITLE
feat: add media library video client

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ export async function updateDocumentTitle(_id, title) {
       - [Example: Storing language in a field](#example-storing-language-in-a-field)
     - [Prompt the LLM](#prompt-the-llm)
     - [Patch with a schema-aware API](#patch-with-a-schema-aware-api)
+  - [Media Library API](#media-library-api)
+    - [Getting video playback information](#getting-video-playback-information)
+    - [Working with signed playback information](#working-with-signed-playback-information)
 - [License](#license)
 - [From `v5`](#from-v5)
   - [The default `useCdn` is changed to `true`](#the-default-usecdn-is-changed-to-true)
@@ -2271,6 +2274,101 @@ const result = await client.agent.action.patch({
     value: [{_type: 'item', title: 'Item title', _key: 'isOptionalAndWillBeGeneratedIfMissing'}],
   },
 })
+```
+
+### Media Library API
+
+The Media Library provides centralized asset management for your organization. Store, organize, and manage digital assets across multiple applications and datasets with programmatic access through the `client.mediaLibrary` interface.
+
+👉 Read more about [Media Library in Sanity](https://www.sanity.io/docs/media-library)
+
+#### Getting video playback information
+
+```js
+const client = createClient({
+  token: 'valid-token',
+  useCdn: false,
+  '~experimental_resource': {
+    type: 'media-library',
+    id: 'mediaLibraryId',
+  },
+})
+
+// Basic usage with video asset ID
+const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo('video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4')
+
+// With transformations
+const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo('video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4', {
+  transformations: {
+    thumbnail: { width: 300, format: 'webp', fit: 'smartcrop' },
+    animated: { width: 200, fps: 15, format: 'webp' }
+  },
+  expiration: 3600  // seconds
+})
+
+// Using Global Dataset Reference (GDR)
+const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo({
+  _ref: 'media-library:mlZxz9rvqf76:30rh9U3GDEK3ToiId1Zje4uvalC'
+})
+```
+
+The response contains playback URLs and metadata:
+
+```js
+// Public playback response
+{
+  id: "30rh9U3GDEK3ToiId1Zje4uvalC",
+  stream: { url: "https://stream.m.sanity-cdn.com/..." },
+  thumbnail: { url: "https://image.m.sanity-cdn.com/..." },
+  animated: { url: "https://image.m.sanity-cdn.com/..." },
+  storyboard: { url: "https://storyboard.m.sanity-cdn.com/..." },
+  duration: 120.5,
+  aspectRatio: 1.77
+}
+
+// Signed playback response (when video requires authentication)
+{
+  id: "30rh9U3GDEK3ToiId1Zje4uvalC",
+  stream: { 
+    url: "https://stream.m.sanity-cdn.com/...",
+    token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+  },
+  thumbnail: { 
+    url: "https://image.m.sanity-cdn.com/...",
+    token: "eyJ0a2VuIjoiVGh1bWJuYWlsVG9rZW4tMTIz..."
+  },
+  animated: { 
+    url: "https://image.m.sanity-cdn.com/...",
+    token: "eyJ0a2VuIjoiQW5pbWF0ZWRUb2tlbi1kZWY..."
+  },
+  storyboard: { 
+    url: "https://storyboard.m.sanity-cdn.com/...",
+    token: "eyJ0a2VuIjoiU3Rvcnlib2FyZFRva2VuLTc4..."
+  },
+  duration: 120.5,
+  aspectRatio: 1.77
+}
+```
+
+#### Working with signed playback information
+
+```js
+const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo('video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4')
+
+// Extract tokens for use with video players (returns undefined if not signed)
+const tokens = client.mediaLibrary.video.getPlaybackTokens(playbackInfo)
+if (tokens) {
+  console.log(tokens)
+  // {
+  //   playback: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  //   animated: "eyJ0a2VuIjoiQW5pbWF0ZWRUb2tlbi1kZWY...",
+  //   thumbnail: "eyJ0a2VuIjoiVGh1bWJuYWlsVG9rZW4tMTIz...",
+  //   storyboard: "eyJ0a2VuIjoiU3Rvcnlib2FyZFRva2VuLTc4..."
+  // }
+  
+  // Use with Mux Player or other compatible players
+  // The tokens authenticate access to the video resources
+}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2353,16 +2353,19 @@ The response contains playback URLs and metadata:
 #### Working with signed playback information
 
 ```js
+import {getPlaybackTokens, isSignedPlaybackInfo} from '@sanity/client/media-library'
+
 const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo('video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4')
 
-// Extract tokens for use with video players (returns undefined if not signed)
-const tokens = client.mediaLibrary.video.getPlaybackTokens(playbackInfo)
-if (tokens) {
+// Check if the response requires signed URLs
+if (isSignedPlaybackInfo(playbackInfo)) {
+  // Extract tokens for use with video players
+  const tokens = getPlaybackTokens(playbackInfo)
   console.log(tokens)
   // {
-  //   playback: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
-  //   animated: "eyJ0a2VuIjoiQW5pbWF0ZWRUb2tlbi1kZWY...",
+  //   stream: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
   //   thumbnail: "eyJ0a2VuIjoiVGh1bWJuYWlsVG9rZW4tMTIz...",
+  //   animated: "eyJ0a2VuIjoiQW5pbWF0ZWRUb2tlbi1kZWY...",
   //   storyboard: "eyJ0a2VuIjoiU3Rvcnlib2FyZFRva2VuLTc4..."
   // }
   

--- a/package.json
+++ b/package.json
@@ -64,6 +64,12 @@
       "require": "./dist/stega.cjs",
       "default": "./dist/stega.js"
     },
+    "./media-library": {
+      "source": "./src/media-library.ts",
+      "import": "./dist/media-library.js",
+      "require": "./dist/media-library.cjs",
+      "default": "./dist/media-library.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
@@ -81,6 +87,9 @@
       ],
       "stega": [
         "./dist/stega.d.ts"
+      ],
+      "media-library": [
+        "./dist/media-library.d.ts"
       ]
     }
   },

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -10,6 +10,10 @@ import {LiveClient} from './data/live'
 import {ObservablePatch, Patch} from './data/patch'
 import {ObservableTransaction, Transaction} from './data/transaction'
 import {DatasetsClient, ObservableDatasetsClient} from './datasets/DatasetsClient'
+import {
+  MediaLibraryVideoClient,
+  ObservableMediaLibraryVideoClient,
+} from './mediaLibrary/MediaLibraryVideoClient'
 import {ObservableProjectsClient, ProjectsClient} from './projects/ProjectsClient'
 import {ObservableReleasesClient, ReleasesClient} from './releases/ReleasesClient'
 import type {
@@ -54,8 +58,10 @@ export type {
   AssetsClient,
   DatasetsClient,
   LiveClient,
+  MediaLibraryVideoClient,
   ObservableAssetsClient,
   ObservableDatasetsClient,
+  ObservableMediaLibraryVideoClient,
   ObservableProjectsClient,
   ObservableUsersClient,
   ProjectsClient,
@@ -67,6 +73,9 @@ export class ObservableSanityClient {
   assets: ObservableAssetsClient
   datasets: ObservableDatasetsClient
   live: LiveClient
+  mediaLibrary: {
+    video: ObservableMediaLibraryVideoClient
+  }
   projects: ObservableProjectsClient
   users: ObservableUsersClient
   agent: {
@@ -93,6 +102,9 @@ export class ObservableSanityClient {
     this.assets = new ObservableAssetsClient(this, this.#httpRequest)
     this.datasets = new ObservableDatasetsClient(this, this.#httpRequest)
     this.live = new LiveClient(this)
+    this.mediaLibrary = {
+      video: new ObservableMediaLibraryVideoClient(this, this.#httpRequest),
+    }
     this.projects = new ObservableProjectsClient(this, this.#httpRequest)
     this.users = new ObservableUsersClient(this, this.#httpRequest)
     this.agent = {
@@ -1097,6 +1109,9 @@ export class SanityClient {
   assets: AssetsClient
   datasets: DatasetsClient
   live: LiveClient
+  mediaLibrary: {
+    video: MediaLibraryVideoClient
+  }
   projects: ProjectsClient
   users: UsersClient
   agent: {
@@ -1128,6 +1143,9 @@ export class SanityClient {
     this.assets = new AssetsClient(this, this.#httpRequest)
     this.datasets = new DatasetsClient(this, this.#httpRequest)
     this.live = new LiveClient(this)
+    this.mediaLibrary = {
+      video: new MediaLibraryVideoClient(this, this.#httpRequest),
+    }
     this.projects = new ProjectsClient(this, this.#httpRequest)
     this.users = new UsersClient(this, this.#httpRequest)
     this.agent = {

--- a/src/media-library.ts
+++ b/src/media-library.ts
@@ -1,0 +1,57 @@
+import type {
+  VideoPlaybackInfo,
+  VideoPlaybackInfoItem,
+  VideoPlaybackInfoItemSigned,
+  VideoPlaybackInfoSigned,
+  VideoPlaybackTokens,
+} from './types'
+
+/**
+ * Check if a playback info item (stream/thumbnail/etc) has a signed token
+ * @internal
+ */
+function isSignedPlayback(item: VideoPlaybackInfoItem): item is VideoPlaybackInfoItemSigned {
+  return 'token' in item
+}
+
+/**
+ * Check if the entire playback info response requires signed URLs
+ * @public
+ */
+export function isSignedPlaybackInfo(
+  playbackInfo: VideoPlaybackInfo,
+): playbackInfo is VideoPlaybackInfoSigned {
+  return isSignedPlayback(playbackInfo.stream)
+}
+
+/**
+ * Extract playback tokens from signed video playback info
+ * @param playbackInfo - The video playback info
+ * @returns The playback tokens or undefined if the response is not signed
+ * @public
+ * @example
+ * const tokens = getPlaybackTokens(playbackInfo)
+ * console.log(tokens)
+ * ```json
+ * {
+ *    stream: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+ *    thumbnail: "eyJ0a2VuIjoiVGh1bWJuYWlsVG9rZW4tMTIz...",
+ *    animated: "eyJ0a2VuIjoiQW5pbWF0ZWRUb2tlbi1kZWY...",
+ *    storyboard: "eyJ0a2VuIjoiU3Rvcnlib2FyZFRva2VuLTc4..."
+ * }
+ * ```
+ */
+export function getPlaybackTokens(
+  playbackInfo: VideoPlaybackInfo,
+): VideoPlaybackTokens | undefined {
+  if (isSignedPlaybackInfo(playbackInfo)) {
+    return {
+      stream: playbackInfo.stream.token,
+      thumbnail: playbackInfo.thumbnail.token,
+      storyboard: playbackInfo.storyboard.token,
+      animated: playbackInfo.animated.token,
+    }
+  }
+
+  return undefined
+}

--- a/src/mediaLibrary/MediaLibraryVideoClient.ts
+++ b/src/mediaLibrary/MediaLibraryVideoClient.ts
@@ -1,0 +1,217 @@
+import {lastValueFrom, type Observable} from 'rxjs'
+
+import {_request} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {
+  HttpRequest,
+  MediaLibraryAssetInstanceIdentifier,
+  MediaLibraryPlaybackInfoOptions,
+  VideoPlaybackInfo,
+  VideoPlaybackInfoItem,
+  VideoPlaybackInfoItemSigned,
+  VideoPlaybackInfoSigned,
+  VideoPlaybackTokens,
+} from '../types'
+
+/** @internal */
+export class ObservableMediaLibraryVideoClient {
+  #client: ObservableSanityClient
+  #httpRequest: HttpRequest
+  constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /**
+   * Get video playback information for a media library asset
+   *
+   * @param assetIdentifier - Asset instance identifier (GDR, video-prefixed ID, or container ID)
+   * @param options - Options for transformations and expiration
+   */
+  getPlaybackInfo(
+    assetIdentifier: MediaLibraryAssetInstanceIdentifier,
+    options: MediaLibraryPlaybackInfoOptions = {},
+  ): Observable<VideoPlaybackInfo> {
+    const {instanceId, libraryId} = parseAssetInstanceId(assetIdentifier)
+    const uri = buildVideoPlaybackInfoUrl(instanceId, libraryId)
+    const queryParams = buildQueryParams(options)
+
+    return _request<VideoPlaybackInfo>(this.#client, this.#httpRequest, {
+      method: 'GET',
+      uri,
+      query: queryParams,
+    })
+  }
+
+  /**
+   * Extract playback tokens from signed video playback info
+   *
+   * @param playbackInfo - The playback info response
+   * @returns Object containing playback, thumbnail, and storyboard tokens if signed, undefined otherwise
+   */
+  getPlaybackTokens(playbackInfo: VideoPlaybackInfo): VideoPlaybackTokens | undefined {
+    if (isSignedPlaybackInfo(playbackInfo)) {
+      return {
+        playback: playbackInfo.stream.token,
+        thumbnail: playbackInfo.thumbnail.token,
+        storyboard: playbackInfo.storyboard.token,
+        animated: playbackInfo.animated.token,
+      }
+    }
+
+    return undefined
+  }
+}
+
+/** @internal */
+export class MediaLibraryVideoClient {
+  #client: SanityClient
+  #httpRequest: HttpRequest
+  constructor(client: SanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /**
+   * Get video playback information for a media library asset
+   *
+   * @param assetIdentifier - Asset instance identifier (GDR, video-prefixed ID, or container ID)
+   * @param options - Options for transformations and expiration
+   */
+  getPlaybackInfo(
+    assetIdentifier: MediaLibraryAssetInstanceIdentifier,
+    options: MediaLibraryPlaybackInfoOptions = {},
+  ): Promise<VideoPlaybackInfo> {
+    return lastValueFrom(
+      new ObservableMediaLibraryVideoClient(
+        this.#client.observable,
+        this.#httpRequest,
+      ).getPlaybackInfo(assetIdentifier, options),
+    )
+  }
+
+  /**
+   * Extract playback tokens from signed video playback info
+   *
+   * @param playbackInfo - The playback info response
+   * @returns Object containing playback, thumbnail, and storyboard tokens if signed, undefined otherwise
+   */
+  getPlaybackTokens(playbackInfo: VideoPlaybackInfo): VideoPlaybackTokens | undefined {
+    if (isSignedPlaybackInfo(playbackInfo)) {
+      return {
+        playback: playbackInfo.stream.token,
+        thumbnail: playbackInfo.thumbnail.token,
+        storyboard: playbackInfo.storyboard.token,
+        animated: playbackInfo.animated.token,
+      }
+    }
+
+    return undefined
+  }
+}
+
+function parseAssetInstanceId(assetIdentifier: MediaLibraryAssetInstanceIdentifier): {
+  instanceId: string
+  libraryId?: string
+} {
+  if (typeof assetIdentifier === 'string') {
+    // Handle video-prefixed asset instance ID
+    if (assetIdentifier.startsWith('video-')) {
+      return {instanceId: assetIdentifier}
+    }
+    // Assume it's a container ID or plain instance ID
+    return {instanceId: assetIdentifier}
+  }
+
+  if (assetIdentifier && typeof assetIdentifier === 'object' && '_ref' in assetIdentifier) {
+    const ref = assetIdentifier._ref
+    if (typeof ref === 'string') {
+      // Parse GDR to extract library ID and instance ID
+      // Expected format: "media-library:libraryId:instanceId"
+      const gdrParts = ref.split(':')
+
+      // Valid GDR must have exactly 3 parts and start with 'media-library'
+      if (gdrParts.length === 3 && gdrParts[0] === 'media-library') {
+        const [, libraryId, instanceId] = gdrParts
+
+        // Validate that libraryId and instanceId are not empty
+        if (!libraryId || !instanceId) {
+          throw new Error(
+            `Invalid media library reference format: "${ref}". Expected format: "media-library:mlXXXX:instanceId"`,
+          )
+        }
+
+        // Validate that libraryId starts with 'ml' prefix
+        if (!libraryId.startsWith('ml')) {
+          throw new Error(
+            `Invalid library ID in reference: "${ref}". Library ID must start with "ml" prefix`,
+          )
+        }
+
+        return {
+          libraryId,
+          instanceId,
+        }
+      }
+
+      // Invalid GDR format
+      throw new Error(
+        `Invalid media library reference format: "${ref}". Expected format: "media-library:mlXXXX:instanceId"`,
+      )
+    }
+  }
+
+  throw new Error('Invalid asset identifier: must be a string or an object with a _ref property')
+}
+
+function buildVideoPlaybackInfoUrl(instanceId: string, libraryId?: string): string {
+  const effectiveLibraryId = libraryId || 'default'
+  return `/media-libraries/${effectiveLibraryId}/video/${instanceId}/playback-info`
+}
+
+function buildQueryParams(options: MediaLibraryPlaybackInfoOptions): Record<string, unknown> {
+  const params: Record<string, unknown> = {}
+
+  if (options.transformations) {
+    const {thumbnail, animated, storyboard} = options.transformations
+
+    if (thumbnail) {
+      if (thumbnail.width) params.thumbnailWidth = thumbnail.width
+      if (thumbnail.height) params.thumbnailHeight = thumbnail.height
+      if (thumbnail.time !== undefined) params.thumbnailTime = thumbnail.time
+      if (thumbnail.fit) params.thumbnailFit = thumbnail.fit
+      if (thumbnail.format) params.thumbnailFormat = thumbnail.format
+    }
+
+    if (animated) {
+      if (animated.width) params.animatedWidth = animated.width
+      if (animated.height) params.animatedHeight = animated.height
+      if (animated.start !== undefined) params.animatedStart = animated.start
+      if (animated.end !== undefined) params.animatedEnd = animated.end
+      if (animated.fps) params.animatedFps = animated.fps
+      if (animated.format) params.animatedFormat = animated.format
+    }
+
+    if (storyboard) {
+      if (storyboard.format) params.storyboardFormat = storyboard.format
+    }
+  }
+
+  if (options.expiration) {
+    params.expiration = options.expiration
+  }
+
+  return params
+}
+
+/** @internal */
+function isSignedPlayback(item: VideoPlaybackInfoItem): item is VideoPlaybackInfoItemSigned {
+  return 'token' in item
+}
+
+/** @internal */
+function isSignedPlaybackInfo(
+  playbackInfo: VideoPlaybackInfo,
+): playbackInfo is VideoPlaybackInfoSigned {
+  return isSignedPlayback(playbackInfo.stream)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1722,3 +1722,146 @@ export type {
  * @public
  */
 export const EXPERIMENTAL_API_WARNING = 'This is an experimental API version'
+
+// Media Libraries types
+/**
+ * Fit / resize modes accepted for thumbnail params.
+ * @public
+ */
+export type FitMode = 'preserve' | 'stretch' | 'crop' | 'smartcrop' | 'pad'
+
+/**
+ * Allowed still image formats (thumbnail + storyboard).
+ * @public
+ */
+export type StillImageFormat = 'jpg' | 'png' | 'webp'
+
+/**
+ * Allowed animated image formats.
+ * @public
+ */
+export type AnimatedImageFormat = 'gif' | 'webp'
+
+/**
+ * Thumbnail rendition (single frame) options.
+ * @public
+ */
+export interface ThumbnailTransformOptions {
+  /** Pixel width of the thumbnail frame. */
+  width?: number
+  /** Pixel height of the thumbnail frame. */
+  height?: number
+  /** Timestamp (seconds) from which to grab the frame. */
+  time?: number
+  /** Resize / fit mode applied to the extracted frame. */
+  fit?: FitMode
+  /** Output image format. */
+  format?: StillImageFormat
+}
+
+/**
+ * Animated preview rendition options (e.g. GIF / animated WebP).
+ * @public
+ */
+export interface AnimatedTransformOptions {
+  /** Pixel width of the animated output. Max 640 px. */
+  width?: number
+  /** Pixel height of the animated output. Max 640 px. */
+  height?: number
+  /** Start time in seconds (inclusive). */
+  start?: number
+  /** End time in seconds. */
+  end?: number
+  /** Frames per second (1–30). */
+  fps?: number
+  /** Output animated format. */
+  format?: AnimatedImageFormat
+}
+
+/**
+ * Storyboard (contact sheet) options.
+ * @public
+ */
+export interface StoryboardTransformOptions {
+  /** Output image format for the storyboard. */
+  format?: StillImageFormat
+}
+
+/**
+ * Video-specific playback transformation option groups.
+ * Only explicitly provided values are serialized into query parameters.
+ * @public
+ */
+export interface MediaLibraryVideoPlaybackTransformations {
+  /** Static thumbnail (single frame) options. */
+  thumbnail?: ThumbnailTransformOptions
+  /** Animated preview options (GIF / animated WebP). */
+  animated?: AnimatedTransformOptions
+  /** Storyboard (contact sheet) options. */
+  storyboard?: StoryboardTransformOptions
+}
+
+/**
+ * Backwards compatibility alias.
+ * @deprecated Use MediaLibraryVideoPlaybackTransformations instead.
+ * @public
+ */
+export type MediaLibraryPlaybackTransformations = MediaLibraryVideoPlaybackTransformations
+
+/**
+ * Options for requesting playback info (URLs + optional tokens) for a Media Library video asset.
+ *
+ * Removed: generic fallback parameters (width, height, fit, format). Supply per‑transformation values instead.
+ * Animated transformations intentionally exclude any fit option (not supported by Mux).
+ *
+ * includeTokens is a client-side flag (not sent to the server) controlling whether
+ * returned tokens should be appended to URLs when consumed.
+ * @public
+ */
+export interface MediaLibraryPlaybackInfoOptions {
+  /** Explicit per-video transformation options (thumbnail, animated, storyboard). */
+  transformations?: MediaLibraryVideoPlaybackTransformations
+  /** Expiration hint for secured/signed URLs (string or number, number will be stringified). */
+  expiration?: string | number
+}
+
+/** @public */
+export interface VideoPlaybackInfoItemPublic {
+  url: string
+}
+
+/** @public */
+export interface VideoPlaybackInfoItemSigned extends VideoPlaybackInfoItemPublic {
+  token: string
+}
+
+/** @public */
+export type VideoPlaybackInfoItem = VideoPlaybackInfoItemPublic | VideoPlaybackInfoItemSigned
+
+/** @public */
+export interface VideoPlaybackInfo<T extends VideoPlaybackInfoItem = VideoPlaybackInfoItem> {
+  id: string
+  thumbnail: T
+  animated: T
+  storyboard: T
+  stream: T
+  duration: number
+  aspectRatio: number
+}
+
+/** @public */
+export type VideoPlaybackInfoSigned = VideoPlaybackInfo<VideoPlaybackInfoItemSigned>
+
+/** @public */
+export type VideoPlaybackInfoPublic = VideoPlaybackInfo<VideoPlaybackInfoItemPublic>
+
+/** @public */
+export interface VideoPlaybackTokens {
+  playback?: string
+  thumbnail?: string
+  storyboard?: string
+  animated?: string
+}
+
+/** @public */
+export type MediaLibraryAssetInstanceIdentifier = string | SanityReference

--- a/src/types.ts
+++ b/src/types.ts
@@ -1802,13 +1802,6 @@ export interface MediaLibraryVideoPlaybackTransformations {
 }
 
 /**
- * Backwards compatibility alias.
- * @deprecated Use MediaLibraryVideoPlaybackTransformations instead.
- * @public
- */
-export type MediaLibraryPlaybackTransformations = MediaLibraryVideoPlaybackTransformations
-
-/**
  * Options for requesting playback info (URLs + optional tokens) for a Media Library video asset.
  *
  * Removed: generic fallback parameters (width, height, fit, format). Supply per‑transformation values instead.
@@ -1857,7 +1850,7 @@ export type VideoPlaybackInfoPublic = VideoPlaybackInfo<VideoPlaybackInfoItemPub
 
 /** @public */
 export interface VideoPlaybackTokens {
-  playback?: string
+  stream?: string
   thumbnail?: string
   storyboard?: string
   animated?: string


### PR DESCRIPTION
### TL;DR

Added Media Library API support, start with video playback functionality.

### What changed?

- Added a new `mediaLibrary` client interface with a `video` submodule
- Implemented `getPlaybackInfo()` method to retrieve video playback URLs and metadata
- Added typed `getPlaybackTokens()` helper to extract authentication tokens for secured videos
- Added support for various video transformation options (thumbnails, animated previews, etc.)
- Added type definitions for the Media Library API
- Updated README with usage examples and documentation

### How to test?

```
// Basic usage with video asset ID
const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo('video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4')

// With transformations
const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo('video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4', {
  transformations: {
    thumbnail: { width: 300, format: 'webp', fit: 'smartcrop' },
    animated: { width: 200, fps: 15, format: 'webp' }
  },
  expiration: 3600
})

// Using Global Dataset Reference (GDR)
const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo({
  _ref: 'media-library:mlZxz9rvqf76:30rh9U3GDEK3ToiId1Zje4uvalC'
})

// Extract tokens for secured videos
import {getPlaybackTokens} from '@sanity/client/media-library'
const tokens = getPlaybackTokens(playbackInfo)
```

```
// console.log(tokens)
{
   "stream": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
   "thumbnail": "eyJ0a2VuIjoiVGh1bWJuYWlsVG9rZW4tMTIz...",
   "animated": "eyJ0a2VuIjoiQW5pbWF0ZWRUb2tlbi1kZWY...",
   "storyboard": "eyJ0a2VuIjoiU3Rvcnlib2FyZFRva2VuLTc4..."
}
```

### Why make this change?

This change adds programmatic access to the Media Library, allowing developers to retrieve video playback information. The implementation supports both public and signed videos, with options for customizing video transformations like thumbnails and animated previews.

### Questions

- Does "utility" functions like `getPlaybackTokens`, that parses a playback response and gets you a typed object with the tokens you later need to pass to a player like the [Mux React Player](https://www.mux.com/docs/guides/player-advanced-usage#use-signed-urls) makes sense to put here?
- Are we okay with adding a new export `@sanity/client/media-library`?