### PR TITLE
fix(types): add import release action type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -622,6 +622,7 @@ export type ReleaseAction =
   | ScheduleReleaseAction
   | UnscheduleReleaseAction
   | DeleteReleaseAction
+  | ImportReleaseAction
 
 /** @public */
 export type VersionAction =
@@ -641,6 +642,21 @@ export type Action =
   | UnpublishAction
   | VersionAction
   | ReleaseAction
+
+/** @public */
+export type ImportReleaseAction =
+  | {
+      actionType: 'sanity.action.release.import'
+      attributes: IdentifiedSanityDocumentStub
+      releaseId: string
+      ifExists: 'fail' | 'ignore' | 'replace'
+    }
+  | {
+      actionType: 'sanity.action.release.import'
+      document: IdentifiedSanityDocumentStub
+      releaseId: string
+      ifExists: 'fail' | 'ignore' | 'replace'
+    }
 
 /**
  * Creates a new release under the given id, with metadata.


### PR DESCRIPTION
### TL;DR

Added support for importing releases with a new `ImportReleaseAction` type. Please correct me if I am wrong 

### What changed?

- Added a new `ImportReleaseAction` interface to the types system
- Added the new action type to the `ReleaseAction` union type
- The new action type includes properties for document attributes, the document itself, the release ID, and a conflict resolution strategy (`ifExists`)

### How to test?

1. Import the new `ImportReleaseAction` type in your code
2. Create an action with `actionType: 'sanity.action.release.import'`
3. Verify the action works with different `ifExists` strategies ('fail', 'ignore', 'replace')
4. Confirm the action properly handles the document and its attributes

### Why make this change?

This change enables importing existing documents into releases, providing flexibility in how content is managed across environments. The `ifExists` parameter gives users control over conflict resolution when importing documents that may already exist in a release.