### PR TITLE
fix: remove resource guard from live client

### DIFF
--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -13,7 +13,6 @@ import type {
   SyncTag,
 } from '../types'
 import {shareReplayLatest} from '../util/shareReplayLatest'
-import * as validate from '../validators'
 import {_getDataUrl} from './dataMethods'
 import {connectEventSource} from './eventsource'
 import {eventSourcePolyfill} from './eventsourcePolyfill'
@@ -45,7 +44,6 @@ export class LiveClient {
      */
     tag?: string
   } = {}): Observable<LiveEvent> {
-    validate.resourceGuard('live', this.#client.config())
     const {
       projectId,
       apiVersion: _apiVersion,

--- a/test/helpers/sseServer.ts
+++ b/test/helpers/sseServer.ts
@@ -14,7 +14,7 @@ export const createSseServer = (onRequest: OnRequest): Promise<http.Server> =>
       let channel
       if (
         request?.url?.indexOf('/v1/data/listen/') === 0 ||
-        request?.url?.indexOf('/vX/data/live/events/') === 0 ||
+        /\/live\/events/.test(request?.url || '') ||
         request?.url?.indexOf('/listen/beerns?query=') === 0
       ) {
         channel = new SseChannel({jsonEncode: true})


### PR DESCRIPTION
FIXES SDK-733

### Description
There's no longer much need to have a resource guard in the live content API, since, as far as I can tell, live events are available for resources (ref https://api.sanity.io/v2025-05-06/media-libraries/mlPGY7BEqt52/live/events and https://api.sanity.io/vX/canvases/cag5gSK37IGV/live/events)

### What to review
Any issues in removing this?

### Testing
Don't believe this is required.
