### PR TITLE
fix: make releaseId optional in createVersion method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,16 +218,6 @@ jobs:
         with:
           name: build-output-${{ github.run_id }}
           path: .
-      - name: Debug - Check directory structure
-        run: |
-          echo "=== Current directory ==="
-          pwd
-          echo "=== List dist/ ==="
-          ls -la dist/ || echo "dist/ not found"
-          echo "=== List runtimes/node/ ==="
-          ls -la runtimes/node/ || echo "runtimes/node/ not found"
-          echo "=== Test without pipe ==="
-          cd runtimes/node && node --test --test-reporter=tap 2>&1 | head -50
       - run: npm run test:node-runtimes
 
   next-runtime:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,16 @@ jobs:
         with:
           name: build-output-${{ github.run_id }}
           path: .
+      - name: Debug - Check directory structure
+        run: |
+          echo "=== Current directory ==="
+          pwd
+          echo "=== List dist/ ==="
+          ls -la dist/ || echo "dist/ not found"
+          echo "=== List runtimes/node/ ==="
+          ls -la runtimes/node/ || echo "runtimes/node/ not found"
+          echo "=== Test without pipe ==="
+          cd runtimes/node && node --test --test-reporter=tap 2>&1 | head -50
       - run: npm run test:node-runtimes
 
   next-runtime:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
+          path: .
       - run: npm run test:edge-runtime -- --retry=30
 
   browser-runtime:
@@ -158,6 +159,7 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
+          path: .
       - run: npm run test:browser
 
   deno-runtime:
@@ -174,6 +176,7 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
+          path: .
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x.x
@@ -193,6 +196,7 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
+          path: .
       - uses: antongolub/action-setup-bun@f0b9f339a7ce9ba1174a58484e4dc9bbd6f7b133 # v1
       - run: npm run test:bun
 
@@ -213,6 +217,7 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
+          path: .
       - run: npm run test:node-runtimes
 
   next-runtime:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,6 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
-          path: .
       - run: npm run test:edge-runtime -- --retry=30
 
   browser-runtime:
@@ -159,7 +158,6 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
-          path: .
       - run: npm run test:browser
 
   deno-runtime:
@@ -176,7 +174,6 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
-          path: .
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x.x
@@ -196,7 +193,6 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
-          path: .
       - uses: antongolub/action-setup-bun@f0b9f339a7ce9ba1174a58484e4dc9bbd6f7b133 # v1
       - run: npm run test:bun
 
@@ -217,7 +213,6 @@ jobs:
         name: Restore build output
         with:
           name: build-output-${{ github.run_id }}
-          path: .
       - run: npm run test:node-runtimes
 
   next-runtime:

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-tsdoc": "^0.4.0",
         "eslint-plugin-unused-imports": "^4.1.4",
-        "faucet": "^0.0.4",
         "globals": "^16.0.0",
         "happy-dom": "^12.10.3",
         "json-diff": "^1.0.6",
@@ -1869,33 +1868,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@ljharb/resumer": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ljharb/resumer/-/resumer-0.1.3.tgz",
-      "integrity": "sha512-d+tsDgfkj9X5QTriqM4lKesCkMMJC3IrbPKHvayP00ELx2axdXvDfWkqjxrLXIzGcQzmj7VAUT1wopqARTvafw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/through": "^2.3.13",
-        "call-bind": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/@ljharb/through": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.14.tgz",
-      "integrity": "sha512-ajBvlKpWucBB17FuQYUShqpqy8GRgYEpJW0vWJbUu1CV9lWyrDCapy0lScU8T8Z6qn49sSwJB3+M+evYIdGg+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/@microsoft/api-extractor": {
@@ -4533,26 +4505,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array.prototype.every": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/array.prototype.every/-/array.prototype.every-1.1.7.tgz",
-      "integrity": "sha512-BIP72rKvrKd08ptbetLb4qvrlGjkv30yOKgKcTtOIbHyQt3shr/jyOzdApiCOh3LPYrpJo5M6i0zmVldOF2pUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "is-string": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
@@ -4564,49 +4516,6 @@
         "define-properties": "^1.2.1",
         "es-abstract": "^1.23.5",
         "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.foreach": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/array.prototype.foreach/-/array.prototype.foreach-1.0.7.tgz",
-      "integrity": "sha512-T6Y2wgc24suLW78a3Iq/Iu0zgucdBRtj11GElARgGZaqNC8ESFZV8qeJR9/I7bHCB3Vh5N6ATYUOBIZLLl9WCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.join": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.join/-/array.prototype.join-1.0.4.tgz",
-      "integrity": "sha512-x5u8B84876ps2lr1OjfIjE5ub63TSYGns8zOWddOoLlToWlUOcOGalTq8JTEhrtSTWlxzNyOPNPZ5uF7AMPJOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "is-string": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4629,51 +4538,6 @@
         "es-array-method-boxes-properly": "^1.0.0",
         "es-object-atoms": "^1.0.0",
         "is-string": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.push": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/array.prototype.push/-/array.prototype.push-1.0.7.tgz",
-      "integrity": "sha512-TYyNvrD1GpY3e6/tthQfwcuGPUtP99N1uDQ6WA8RBlOYZAYHpicIO1JXHP8t9CeC0EiiVZZu4Ikl1bI5BSZAEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "get-intrinsic": "^1.3.0",
-        "has-property-descriptors": "^1.0.2",
-        "is-string": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.slice/-/array.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-mBqKR+J5OMJd+CxH1KcyddtIHoci1aKTK23QWVScR/+1JvETDwZIadxMP1ynZa+InvPwcGV+THC0y2hHxwoO7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "is-string": "^1.0.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5359,13 +5223,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5498,39 +5355,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5594,16 +5418,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
-      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -5658,19 +5472,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dotignore": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
-      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "bin": {
-        "ignored": "bin/ignored"
-      }
-    },
     "node_modules/dreamopt": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
@@ -5697,13 +5498,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -6470,45 +6264,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/faucet": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/faucet/-/faucet-0.0.4.tgz",
-      "integrity": "sha512-vSUB+9iT2n77DPv2x3zYEt3rEIGIhVZJmNTfrx3Y0XVXlBiNOPq2jJVOucqkZ6MNHCgVQUZ5xxe78LkkYCRSFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.foreach": "^1.0.4",
-        "array.prototype.join": "^1.0.1",
-        "array.prototype.map": "^1.0.5",
-        "array.prototype.push": "^1.0.3",
-        "array.prototype.slice": "^1.0.1",
-        "defined": "^1.0.1",
-        "duplexer": "^0.1.2",
-        "minimist": "^1.2.7",
-        "npm-which": "^1.0.2",
-        "readable-stream": "^2.3.7",
-        "safe-regex-test": "^1.0.0",
-        "sprintf-js": "^1.1.2",
-        "string.prototype.split": "^1.0.7",
-        "string.prototype.trim": "^1.2.7",
-        "tap-parser": "^0.7.0",
-        "tape": "^5.6.3",
-        "through2": "^0.2.3"
-      },
-      "bin": {
-        "faucet": "bin/cmd.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/faucet/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fdir": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
@@ -6960,16 +6715,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -7228,24 +6973,6 @@
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-dynamic-import": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/has-dynamic-import/-/has-dynamic-import-2.1.1.tgz",
-      "integrity": "sha512-DuTCn6K/RW8S27npDMumGKsjG6HE7MxzedZka5tJP+9dqfxks+UMqKBmeCijHtIhsBEZPlbMg0qMHi2nKYVtKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -9273,28 +9000,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mock-property": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mock-property/-/mock-property-1.1.0.tgz",
-      "integrity": "sha512-1/JjbLoGwv87xVsutkX0XJc0M0W4kb40cZl/K41xtTViBOD9JuFPKfyMNTrLJ/ivYAd0aPqu/vduamXO0emTFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "functions-have-names": "^1.2.3",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2",
-        "hasown": "^2.0.2",
-        "isarray": "^2.0.5",
-        "object-inspect": "^1.13.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9840,32 +9545,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm-path": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
-      "integrity": "sha512-wsL+YXGWlE3DWEqhpgKdt0RWxQrHKpVZ5u6uDYFSpxrxKYVPOctOun8q77VwD02zPTQD4wkc35elWPcocaICag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which": "^1.2.4"
-      },
-      "bin": {
-        "npm-path": "bin/npm-path"
-      }
-    },
-    "node_modules/npm-path/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/npm-pick-manifest": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.2.tgz",
@@ -9989,34 +9668,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/npm-which": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-1.0.2.tgz",
-      "integrity": "sha512-y1s2PrTct2DuRudZNyu4+l4HteWFzaHcN+mMtA54htjA8xIzYza9casIqUdf+/Lqb4Zg2harBpCxBUt83Dwnuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.2.0",
-        "npm-path": "^1.0.0",
-        "which": "^1.0.5"
-      },
-      "bin": {
-        "npm-which": "bin/npm-which.js"
-      }
-    },
-    "node_modules/npm-which/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/npmlog": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-7.0.1.tgz",
@@ -10040,23 +9691,6 @@
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10706,13 +10340,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -11008,36 +10635,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -12145,28 +11742,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.split": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.split/-/string.prototype.split-1.0.9.tgz",
-      "integrity": "sha512-chFmJKYnperPnXRDYVwW3u2/ZnrQh4f6ONkhuzgayT/099jD+NJSXvh2qXmPn9tn7STk2cgAI5IOl4YlojWvwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "is-regex": "^1.1.4",
-        "regexp.prototype.flags": "^1.5.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
@@ -12435,135 +12010,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tap-parser": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.7.0.tgz",
-      "integrity": "sha512-eg6Vt2kTjxJyjrt1luqrMD6jbOM2W5MCZ53ci6+9K97f/aQFI0R/01l70hTES66fTuqhMkNQQGjZESz+/7wsGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.1",
-        "minimist": "^0.2.0",
-        "readable-stream": "~1.1.11"
-      },
-      "bin": {
-        "tap-parser": "bin/cmd.js"
-      }
-    },
-    "node_modules/tap-parser/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tap-parser/node_modules/minimist": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
-      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tap-parser/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/tap-parser/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tape": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.9.0.tgz",
-      "integrity": "sha512-czbGgxSVwRlbB3Ly/aqQrNwrDAzKHDW/kVXegp4hSFmR2c8qqm3hCgZbUy1+3QAQFGhPDG7J56UsV1uNilBFCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ljharb/resumer": "^0.1.3",
-        "@ljharb/through": "^2.3.13",
-        "array.prototype.every": "^1.1.6",
-        "call-bind": "^1.0.7",
-        "deep-equal": "^2.2.3",
-        "defined": "^1.0.1",
-        "dotignore": "^0.1.2",
-        "for-each": "^0.3.3",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.2.3",
-        "has-dynamic-import": "^2.1.0",
-        "hasown": "^2.0.2",
-        "inherits": "^2.0.4",
-        "is-regex": "^1.1.4",
-        "minimist": "^1.2.8",
-        "mock-property": "^1.1.0",
-        "object-inspect": "^1.13.2",
-        "object-is": "^1.1.6",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "resolve": "^2.0.0-next.5",
-        "string.prototype.trim": "^1.2.9"
-      },
-      "bin": {
-        "tape": "bin/tape"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tape/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tape/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -12697,44 +12143,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/through2": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-      "integrity": "sha512-mLa8Bn2mZurjyomGKWRu3Bo2mvoQojFks9NvOK8H+k4kDJNkdEqG522KFZsEFBEl6rKkxTgFbE5+OPcgfvPEHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.1.9",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/through2/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -13832,25 +13240,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dev": true,
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/xtend/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "test:deno:update_import_map": "deno run --allow-read --allow-write runtimes/deno/update_import_map.ts",
     "test:edge-runtime": "npm test -- --config vitest.edge.config.ts",
     "test:next": "npm test -- --config ./vitest.next.config.ts",
-    "test:node-runtimes": "(cd runtimes/node && node --test | npx faucet)"
+    "test:node-runtimes": "(cd runtimes/node && node --test)"
   },
   "browserslist": "extends @sanity/browserslist-config",
   "prettier": {
@@ -156,7 +156,6 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-tsdoc": "^0.4.0",
     "eslint-plugin-unused-imports": "^4.1.4",
-    "faucet": "^0.0.4",
     "globals": "^16.0.0",
     "happy-dom": "^12.10.3",
     "json-diff": "^1.0.6",

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -601,7 +601,7 @@ export class ObservableSanityClient {
   createVersion(
     args: {
       baseId: string
-      releaseId: string
+      releaseId?: string
       publishedId: string
       ifBaseRevisionId?: string
     },
@@ -1647,7 +1647,7 @@ export class SanityClient {
     args: {
       publishedId: string
       baseId: string
-      releaseId: string
+      releaseId?: string
       ifBaseRevisionId?: string
     },
     options?: BaseActionOptions,

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2936,7 +2936,7 @@ describe('client', async () => {
             transactionId: 'abc123',
           })
 
-        const res = await getClient().createVersion({baseId, publishedId} as any)
+        const res = await getClient().createVersion({baseId, publishedId})
         expect(res.transactionId).toEqual('abc123')
       })
 


### PR DESCRIPTION
### Description
`releaseId` can validly be `undefined` for the `createVersion` method. In this case, as the existing comment notes, the version created will be a draft.

Wrongly the type definition did not mark `releaseId` as optional. This PR resolves this.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
There was already a test covering this, but silly-ly I had used `as any` cast and so this issue didn't surface. Corrected the test to verify the type fix.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
