### PR TITLE
feat: add support for resuming listener events

### DIFF
--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -33,6 +33,8 @@ const possibleOptions = [
   'includeAllVersions',
   'visibility',
   'effectFormat',
+  // @todo: remove when dated api is ready
+  'enableResume',
   'tag',
 ]
 

--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -118,7 +118,7 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
  */
 export function _listen<
   R extends Record<string, Any> = Record<string, Any>,
-  Opts extends ListenOptions | ResumableListenOptions = ListenOptions,
+  Opts extends ListenOptions | ResumableListenOptions = ListenOptions | ResumableListenOptions,
 >(
   this: SanityClient | ObservableSanityClient,
   query: string,
@@ -128,7 +128,7 @@ export function _listen<
 /** @public */
 export function _listen<
   R extends Record<string, Any> = Record<string, Any>,
-  Opts extends ListenOptions = ListenOptions,
+  Opts extends ListenOptions | ResumableListenOptions = ListenOptions | ResumableListenOptions,
 >(
   this: SanityClient | ObservableSanityClient,
   query: string,

--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -11,6 +11,10 @@ import {
   type MutationEvent,
   type OpenEvent,
   type ReconnectEvent,
+  type ResetEvent,
+  type ResumableListenEventNames,
+  type ResumableListenOptions,
+  type WelcomeBackEvent,
   type WelcomeEvent,
 } from '../types'
 import defaults from '../util/defaults'
@@ -33,7 +37,6 @@ const possibleOptions = [
   'includeAllVersions',
   'visibility',
   'effectFormat',
-  // @todo: remove when dated api is ready
   'enableResume',
   'tag',
 ]
@@ -53,7 +56,10 @@ const defaultOptions = {
  */
 export type MapListenEventNamesToListenEvents<
   R extends Record<string, Any> = Record<string, Any>,
-  Events extends ListenEventName[] = ListenEventName[],
+  Events extends (ResumableListenEventNames | ListenEventName)[] = (
+    | ResumableListenEventNames
+    | ListenEventName
+  )[],
 > = Events extends (infer E)[]
   ? E extends 'welcome'
     ? WelcomeEvent
@@ -61,9 +67,13 @@ export type MapListenEventNamesToListenEvents<
       ? MutationEvent<R>
       : E extends 'reconnect'
         ? ReconnectEvent
-        : E extends 'open'
-          ? OpenEvent
-          : never
+        : E extends 'welcomeback'
+          ? WelcomeBackEvent
+          : E extends 'reset'
+            ? ResetEvent
+            : E extends 'open'
+              ? OpenEvent
+              : never
   : never
 
 /**
@@ -77,9 +87,9 @@ export type MapListenEventNamesToListenEvents<
  */
 export type ListenEventFromOptions<
   R extends Record<string, Any> = Record<string, Any>,
-  Opts extends ListenOptions | undefined = undefined,
-> = Opts extends ListenOptions
-  ? Opts['events'] extends ListenEventName[]
+  Opts extends ListenOptions | ResumableListenOptions | undefined = undefined,
+> = Opts extends ListenOptions | ResumableListenOptions
+  ? Opts['events'] extends (ResumableListenEventNames | ListenEventName)[]
     ? MapListenEventNamesToListenEvents<R, Opts['events']>
     : // fall back to ListenEvent if opts events is present, but we can't infer the literal event names
       ListenEvent<R>
@@ -108,7 +118,7 @@ export function _listen<R extends Record<string, Any> = Record<string, Any>>(
  */
 export function _listen<
   R extends Record<string, Any> = Record<string, Any>,
-  Opts extends ListenOptions = ListenOptions,
+  Opts extends ListenOptions | ResumableListenOptions = ListenOptions,
 >(
   this: SanityClient | ObservableSanityClient,
   query: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1182,7 +1182,7 @@ export type ResetEvent = {
 }
 
 /** @public */
-export type ListenEvent<R extends Record<string, Any>> =
+export type ListenEvent<R extends Record<string, Any> = Record<string, Any>> =
   | MutationEvent<R>
   | ReconnectEvent
   | WelcomeBackEvent
@@ -1198,15 +1198,19 @@ export type ListenEventName =
   | 'welcome'
   /** The listener has been disconnected, and a reconnect attempt is scheduled */
   | 'reconnect'
-  /** The listener has reconnected and successfully resumed from where it left off */
-  | 'welcomeback'
-  /** The listener can't be resumed or otherwise need to reset its local state */
-  | 'reset'
   /**
    * The listener connection has been established
    * note: it's usually a better option to use the 'welcome' event
    */
   | 'open'
+
+/** @public */
+export type ResumableListenEventNames =
+  | ListenEventName
+  /** The listener has reconnected and successfully resumed from where it left off */
+  | 'welcomeback'
+  /** The listener can't be resumed or otherwise need to reset its local state */
+  | 'reset'
 
 /** @public */
 export type ListenParams = {[key: string]: Any}
@@ -1281,6 +1285,24 @@ export interface ListenOptions {
    * @defaultValue `undefined`
    */
   tag?: string
+
+  /**
+   * Resumes events upon reconnect
+   * @beta
+   * @defaultValue `false`
+   */
+  enableResume?: boolean
+}
+
+export interface ResumableListenOptions extends Omit<ListenOptions, 'events' | 'enableResume'> {
+  /**
+   * Resumes events upon reconnect
+   * @beta
+   * @defaultValue `false`
+   */
+  enableResume: true
+
+  events?: ResumableListenEventNames[]
 }
 
 /** @public */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1151,9 +1151,14 @@ export type OpenEvent = {
 }
 
 /**
- * The listener has been established, and will start receiving events.
- * Before apiVersion vTBD this is also emitted when reconnected
- * As of apiVersion vTBD this is no longer emitted on reconnect, instead the `welcomeback` event is emitted
+ * Emitted when the listener connection has been successfully established
+ * and is ready to receive events.
+ *
+ * If the listener was created with `enableResume: true` and resume support
+ * is available, the `welcome` event will only be emitted on the initial
+ * connection. On subsequent reconnects, a `welcomeback` event will be
+ * emitted instead, followed by any events that were missed while the
+ * connection was disconnected.
  *
  * @public
  */
@@ -1163,7 +1168,16 @@ export type WelcomeEvent = {
 }
 
 /**
- * The listener has reconnected and successfully resumed from where it left off
+ * Emitted when the listener reconnects and successfully resumes from
+ * its previous position.
+ *
+ * Even if the listener is created with `enableResume: true`, resume support
+ * may not be available. In that case, a reconnect will emit `welcome`
+ * instead of `welcomeback`.
+ *
+ * If resumability is unavailable, even listeners created with `enableResume: true` may still
+ * emit `welcome` when reconnected. Subscribers should therefore treat `welcome` after a reconnect
+ * the same way they would otherwise treat a `reset` event.
  *
  * @public
  */
@@ -1174,6 +1188,10 @@ export type WelcomeBackEvent = {
 
 /**
  * The listener can't be resumed or otherwise need to reset its local state
+ *
+ * If resumability is unavailable, even listeners created with `enableResume: true` may still
+ * emit `welcome` when reconnected. Subscribers should therefore treat `welcome` after a reconnect
+ * the same way they would otherwise treat a `reset` event.
  *
  * @public
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1173,7 +1173,7 @@ export type WelcomeBackEvent = {
 }
 
 /**
- * The listener has reconnected and successfully resumed from where it left off
+ * The listener can't be resumed or otherwise need to reset its local state
  *
  * @public
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1152,7 +1152,8 @@ export type OpenEvent = {
 
 /**
  * The listener has been established, and will start receiving events.
- * Note that this is also emitted upon _reconnection_.
+ * Before apiVersion vTBD this is also emitted when reconnected
+ * As of apiVersion vTBD this is no longer emitted on reconnect, instead the `welcomeback` event is emitted
  *
  * @public
  */
@@ -1161,10 +1162,31 @@ export type WelcomeEvent = {
   listenerName: string
 }
 
+/**
+ * The listener has reconnected and successfully resumed from where it left off
+ *
+ * @public
+ */
+export type WelcomeBackEvent = {
+  type: 'welcomeback'
+  listenerName: string
+}
+
+/**
+ * The listener has reconnected and successfully resumed from where it left off
+ *
+ * @public
+ */
+export type ResetEvent = {
+  type: 'reset'
+}
+
 /** @public */
 export type ListenEvent<R extends Record<string, Any>> =
   | MutationEvent<R>
   | ReconnectEvent
+  | WelcomeBackEvent
+  | ResetEvent
   | WelcomeEvent
   | OpenEvent
 
@@ -1176,6 +1198,10 @@ export type ListenEventName =
   | 'welcome'
   /** The listener has been disconnected, and a reconnect attempt is scheduled */
   | 'reconnect'
+  /** The listener has reconnected and successfully resumed from where it left off */
+  | 'welcomeback'
+  /** The listener can't be resumed or otherwise need to reset its local state */
+  | 'reset'
   /**
    * The listener connection has been established
    * note: it's usually a better option to use the 'welcome' event

--- a/src/types.ts
+++ b/src/types.ts
@@ -1263,7 +1263,7 @@ export interface ListenOptions {
 
   /**
    * Array of event names to include in the observable. By default, only mutation events are included.
-   *
+   * Note: `welcomeback` and `reset` events requires `enableResume: true`
    * @defaultValue `['mutation']`
    */
   events?: ListenEventName[]
@@ -1287,21 +1287,29 @@ export interface ListenOptions {
   tag?: string
 
   /**
-   * Resumes events upon reconnect
+   * If this is enabled, the client will normally resume events upon reconnect
+   * When if enabling this, you should also add the `reset` to the events array and handle the case where the backend is unable to resume.
    * @beta
    * @defaultValue `false`
    */
   enableResume?: boolean
 }
 
+/** @public */
 export interface ResumableListenOptions extends Omit<ListenOptions, 'events' | 'enableResume'> {
   /**
-   * Resumes events upon reconnect
+   * If this is enabled, the client will normally resume events upon reconnect
+   * Note that you should also subscribe to `reset`-events and handle the case where the backend is unable to resume
    * @beta
    * @defaultValue `false`
    */
   enableResume: true
 
+  /**
+   * Array of event names to include in the observable. By default, only mutation events are included.
+   *
+   * @defaultValue `['mutation']`
+   */
   events?: ResumableListenEventNames[]
 }
 

--- a/test/listen.test-d.ts
+++ b/test/listen.test-d.ts
@@ -4,6 +4,8 @@ import {
   type MutationEvent,
   type OpenEvent,
   type ReconnectEvent,
+  type ResetEvent,
+  type WelcomeBackEvent,
   type WelcomeEvent,
 } from '@sanity/client'
 import type {Observable} from 'rxjs'
@@ -31,6 +33,22 @@ describe('client.listen', () => {
     >()
 
     expectTypeOf(client.listen('*', {}, {events: []})).toEqualTypeOf<Observable<never>>()
+
+    //@ts-expect-error – welcomeback and reset requires `enableResume`
+    expectTypeOf(client.listen('*', {}, {events: ['welcomeback', 'reset']})).toEqualTypeOf<
+      Observable<ListenEvent>
+    >()
+
+    expectTypeOf(
+      client.listen('*', {}, {enableResume: true, events: ['welcome', 'mutation']}),
+    ).toEqualTypeOf<Observable<WelcomeEvent | MutationEvent>>()
+
+    const observable = client.listen(
+      '*',
+      {},
+      {enableResume: true, events: ['welcomeback', 'reset']},
+    )
+    expectTypeOf(observable).toEqualTypeOf<Observable<WelcomeBackEvent | ResetEvent>>()
 
     expectTypeOf(client.listen('*', {}, {events: ['welcome']})).toEqualTypeOf<
       // @ts-expect-error - Only WelcomeEvents should be emitted

--- a/test/listen.test-d.ts
+++ b/test/listen.test-d.ts
@@ -32,6 +32,18 @@ describe('client.listen', () => {
       Observable<ListenEvent<MyDoc>>
     >()
 
+    expectTypeOf(
+      client.listen<MyDoc>(
+        '*[_type=="match" && !completed]',
+        {},
+        {
+          events: ['mutation', 'welcome', 'reconnect', 'welcomeback'],
+          includeResult: true,
+          enableResume: true,
+        },
+      ),
+    ).toEqualTypeOf<Observable<ListenEvent<MyDoc>>>()
+
     expectTypeOf(client.listen('*', {}, {events: []})).toEqualTypeOf<Observable<never>>()
 
     //@ts-expect-error – welcomeback and reset requires `enableResume`

--- a/test/listen.test.ts
+++ b/test/listen.test.ts
@@ -179,11 +179,17 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       })
 
       const events = await lastValueFrom(
-        client.listen('*', {}, {events: ['reconnect', 'mutation', 'welcome', 'welcomeback']}).pipe(
-          take(5),
-          catchError((err) => of(err)),
-          toArray(),
-        ),
+        client
+          .listen(
+            '*',
+            {},
+            {enableResume: true, events: ['reconnect', 'mutation', 'welcome', 'welcomeback']},
+          )
+          .pipe(
+            take(5),
+            catchError((err) => of(err)),
+            toArray(),
+          ),
       )
       expect(events).toEqual([
         {type: 'welcome', listenerName: 'foo1'},
@@ -217,7 +223,14 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
 
       const events = await lastValueFrom(
         client
-          .listen('*', {}, {events: ['reconnect', 'mutation', 'welcome', 'welcomeback', 'reset']})
+          .listen(
+            '*',
+            {},
+            {
+              enableResume: true,
+              events: ['reconnect', 'mutation', 'welcome', 'welcomeback', 'reset'],
+            },
+          )
           .pipe(
             take(5),
             catchError((err) => of(err)),

--- a/test/listen.test.ts
+++ b/test/listen.test.ts
@@ -159,6 +159,82 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       server.close()
     })
 
+    test('forwards welcome and welcomeback events if opted for', async () => {
+      expect.assertions(2)
+
+      let attempt = 0
+      const {server, client} = await testSse(({channel, request}) => {
+        attempt++
+        if (attempt === 1) {
+          channel!.send({event: 'welcome', data: {listenerName: 'foo1'}})
+          channel!.send({event: 'mutation', id: '123', data: {foo: 'bar'}})
+          channel!.close()
+        }
+        if (attempt === 2) {
+          expect(request.headers['last-event-id'], 'should send last-event-id').toBe('123')
+          channel!.send({event: 'welcomeback', data: {listenerName: 'foo2'}})
+          channel!.send({event: 'mutation', id: '345', data: {bar: 'baz'}})
+          process.nextTick(() => channel!.close())
+        }
+      })
+
+      const events = await lastValueFrom(
+        client.listen('*', {}, {events: ['reconnect', 'mutation', 'welcome', 'welcomeback']}).pipe(
+          take(5),
+          catchError((err) => of(err)),
+          toArray(),
+        ),
+      )
+      expect(events).toEqual([
+        {type: 'welcome', listenerName: 'foo1'},
+        {type: 'mutation', foo: 'bar'},
+        {type: 'reconnect'},
+        {type: 'welcomeback', listenerName: 'foo2'},
+        {type: 'mutation', bar: 'baz'},
+      ])
+
+      server.close()
+    })
+
+    test('forwards reset events if opted for', async () => {
+      expect.assertions(2)
+
+      let attempt = 0
+      const {server, client} = await testSse(({channel, request}) => {
+        attempt++
+        if (attempt === 1) {
+          channel!.send({event: 'welcome', data: {listenerName: 'foo1'}})
+          channel!.send({event: 'mutation', id: '123', data: {foo: 'bar'}})
+          channel!.close()
+        }
+        if (attempt === 2) {
+          expect(request.headers['last-event-id'], 'should send last-event-id').toBe('123')
+          channel!.send({event: 'reset'})
+          channel!.send({event: 'mutation', id: '345', data: {bar: 'baz'}})
+          process.nextTick(() => channel!.close())
+        }
+      })
+
+      const events = await lastValueFrom(
+        client
+          .listen('*', {}, {events: ['reconnect', 'mutation', 'welcome', 'welcomeback', 'reset']})
+          .pipe(
+            take(5),
+            catchError((err) => of(err)),
+            toArray(),
+          ),
+      )
+      expect(events).toEqual([
+        {type: 'welcome', listenerName: 'foo1'},
+        {type: 'mutation', foo: 'bar'},
+        {type: 'reconnect'},
+        {type: 'reset'},
+        {type: 'mutation', bar: 'baz'},
+      ])
+
+      server.close()
+    })
+
     test('emits channel errors', async () => {
       expect.assertions(1)
 


### PR DESCRIPTION
Note: This enableResume is currently only available on vX so this is not ready to be merged yet, but otherwise it's ready for review.

### Description
Adds `enableResume: boolean` to `ListenerOptions`. This instructs the listen-endpoint to push down events based on the `Last-Event-Id` header, and adds two more listener events:

- `welcomeback` – when the listener has reconnected successfully. This event is emitted immediately when listener has successfully reconnected, and any resumed mutation events will arrive after.
- `reset` –  signals that listener can't resume events. Consumers should respond to this event by resetting local state.


### What to review
- ~What apiVersion should we require for this?~ (this will be available on all apiVersions with `enableResume=true`)

### Testing

Unit tests added.
