### PR TITLE
chore: update repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/sanity-io/client.git"
+    "url": "git+https://github.com/sanity-io/client.git"
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",


### PR DESCRIPTION
### Description
Setting up pkg.pr.new in #1155 and it seems like its [not happy ](https://github.com/sanity-io/client/actions/runs/19143369661/job/54714384214?pr=1155#step:6:6)with the git+ssh protocol, so changing to https instead.

~Edit: on second glance I wonder if it's actually wrong, and should instead have been `git+ssh://git@github.com:sanity-io/client.git`.~ nvm, doesn't look like it. Anyway, this PR shouldn't change it much.


### What to review
Makes sense?

### Testing
n/a