### PR TITLE
docs: document video playback CORS and authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -2284,9 +2284,14 @@ The Media Library provides centralized asset management for your organization. S
 
 #### Getting video playback information
 
+> [!NOTE]
+>
+> Requires API version `2025-03-25` or later.
+
 ```js
 const client = createClient({
   token: 'valid-token',
+  apiVersion: '2025-03-25'
   useCdn: false,
   '~experimental_resource': {
     type: 'media-library',

--- a/README.md
+++ b/README.md
@@ -2260,11 +2260,16 @@ When you configure the client with a Media Library resource, you can use familia
 
 #### Configuration
 
+> [!NOTE]
+>
+> Requires API version `2025-03-25` or later.
+
 ```js
 import {createClient} from '@sanity/client'
 
 const client = createClient({
   token: 'valid-token',
+  apiVersion: '2025-03-25'
   useCdn: false,
   resource: {
     type: 'media-library',

--- a/README.md
+++ b/README.md
@@ -2285,6 +2285,19 @@ const client = createClient({
 })
 ```
 
+For browser usage, configure the client with a project ID so requests use the CORS-enabled project
+API host. Enable credentials and include the browser's origin in
+[your project's CORS settings](https://www.sanity.io/docs/content-lake/browser-security-and-cors):
+
+```js
+const browserClient = createClient({
+  projectId: 'yourProjectId',
+  apiVersion: '2025-03-25',
+  useCdn: false,
+  withCredentials: true,
+})
+```
+
 #### Querying assets
 
 Use `client.fetch()` to query assets in your Media Library using GROQ:
@@ -2341,6 +2354,10 @@ await client
 
 For video assets, use the specialized `getPlaybackInfo()` method to retrieve streaming URLs:
 
+> [!NOTE]
+>
+> See [Configuration](#configuration) for authentication and browser CORS requirements.
+
 ```js
 // Basic usage with video asset ID
 const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo(
@@ -2361,24 +2378,6 @@ const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo(
 
 // Using a Media Library asset reference
 const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo({
-  _ref: 'media-library:mlZxz9rvqf76:video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4',
-})
-```
-
-To call this API from a browser, use a project-configured client so the request is sent to the project
-API host (`<projectId>.api.sanity.io`), which supports CORS. Pass the existing Media Library asset
-reference to `getPlaybackInfo`, and make sure the browser's origin is included in
-[your project's CORS settings](https://www.sanity.io/docs/content-lake/browser-security-and-cors):
-
-```js
-const browserClient = createClient({
-  projectId: 'yourProjectId',
-  apiVersion: '2025-03-25',
-  useCdn: false,
-  withCredentials: true,
-})
-
-const playbackInfo = await browserClient.mediaLibrary.video.getPlaybackInfo({
   _ref: 'media-library:mlZxz9rvqf76:video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4',
 })
 ```

--- a/README.md
+++ b/README.md
@@ -2264,12 +2264,19 @@ When you configure the client with a Media Library resource, you can use familia
 >
 > Requires API version `2025-03-25` or later.
 
+Getting playback information requires authentication. Use a token when calling this API from
+server-side code. In a browser, use `withCredentials: true` instead of exposing a token in client-side
+code.
+
+Media Library resource clients send requests to the global API host (`api.sanity.io`), which does not
+support CORS. This configuration therefore only works outside the browser:
+
 ```js
 import {createClient} from '@sanity/client'
 
 const client = createClient({
-  token: 'valid-token',
-  apiVersion: '2025-03-25'
+  token: process.env.SANITY_API_READ_TOKEN,
+  apiVersion: '2025-03-25',
   useCdn: false,
   resource: {
     type: 'media-library',
@@ -2354,7 +2361,25 @@ const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo(
 
 // Using Global Dataset Reference (GDR)
 const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo({
-  _ref: 'media-library:mlZxz9rvqf76:30rh9U3GDEK3ToiId1Zje4uvalC',
+  _ref: 'media-library:mlZxz9rvqf76:video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4',
+})
+```
+
+To call this API from a browser, use a project-configured client so the request is sent to the project
+API host (`<projectId>.api.sanity.io`), which supports CORS. Pass a Global Dataset Reference (GDR) so
+the client can determine the Media Library ID, and make sure the browser's origin is included in
+[your project's CORS settings](https://www.sanity.io/docs/content-lake/browser-security-and-cors):
+
+```js
+const browserClient = createClient({
+  projectId: 'yourProjectId',
+  apiVersion: '2025-03-25',
+  useCdn: false,
+  withCredentials: true,
+})
+
+const playbackInfo = await browserClient.mediaLibrary.video.getPlaybackInfo({
+  _ref: 'media-library:mlZxz9rvqf76:video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4',
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -2359,15 +2359,15 @@ const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo(
   },
 )
 
-// Using Global Dataset Reference (GDR)
+// Using a Media Library asset reference
 const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo({
   _ref: 'media-library:mlZxz9rvqf76:video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4',
 })
 ```
 
 To call this API from a browser, use a project-configured client so the request is sent to the project
-API host (`<projectId>.api.sanity.io`), which supports CORS. Pass a Global Dataset Reference (GDR) so
-the client can determine the Media Library ID, and make sure the browser's origin is included in
+API host (`<projectId>.api.sanity.io`), which supports CORS. Pass the existing Media Library asset
+reference to `getPlaybackInfo`, and make sure the browser's origin is included in
 [your project's CORS settings](https://www.sanity.io/docs/content-lake/browser-security-and-cors):
 
 ```js


### PR DESCRIPTION
### TL;DR

Document the API version, authentication, and CORS requirements for fetching Media Library video playback information.

Fixes DAM-899

### What changed?

- Kept the note that video playback information requires API version `2025-03-25` or later
- Documented that playback information requires authentication
- Explained that Media Library resource clients use the global API host, which does not support browser CORS
- Updated the server-side example to read its token from an environment variable
- Added project-host browser configuration with `withCredentials: true` to the central Media Library configuration section
- Added a one-line callout from video playback information back to the authentication and CORS configuration
- Linked to the project CORS configuration documentation
- Corrected the Media Library asset reference example and the missing comma in the client configuration

### How to test?

- Verify the two examples clearly distinguish server-side and browser usage
- Verify each DAM-899 requirement is represented in the README
- Run `git diff --check`

### Why make this change?

The previous update only mentioned the minimum API version. Without the authentication and CORS constraints, browser users could copy a configuration that sends requests to the global API host and fails before reaching the playback endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README updates; no runtime or API behavior changes.
> 
> **Overview**
> Expands **Media Library API** README guidance so video playback setup is harder to misconfigure in the browser.
> 
> The **Configuration** section now states the `2025-03-25` minimum API version, that **playback requires authentication**, and that **media-library `resource` clients hit `api.sanity.io` (no CORS)**—so that pattern is documented for server-side use with an env-based token. A separate **browser** example uses `projectId`, `apiVersion`, and **`withCredentials: true`**, with a link to project CORS settings.
> 
> The **Getting video playback information** section adds a short note pointing back to that configuration, and the **`_ref` example** is corrected to a full Media Library video asset id (replacing the old “GDR” wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bcdb80d171dc62fc0506ba6af4b5f58a54fdc6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->