### PR TITLE
feat(listen): return event type based on options.events

### DIFF
--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -4,6 +4,7 @@ import {filter, map} from 'rxjs/operators'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import {
   type Any,
+  type ListenEvent,
   type ListenEventName,
   type ListenOptions,
   type ListenParams,
@@ -78,7 +79,8 @@ export type ListenEventFromOptions<
 > = Opts extends ListenOptions
   ? Opts['events'] extends ListenEventName[]
     ? MapListenEventNamesToListenEvents<R, Opts['events']>
-    : MutationEvent<R>
+    : // fall back to ListenEvent if opts events is present, but we can't infer the literal event names
+      ListenEvent<R>
   : MutationEvent<R>
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1142,8 +1142,6 @@ export type WelcomeEvent = {
 /** @public */
 export type ListenEvent<R extends Record<string, Any>> =
   | MutationEvent<R>
-  | ChannelErrorEvent
-  | DisconnectEvent
   | ReconnectEvent
   | WelcomeEvent
   | OpenEvent

--- a/src/types.ts
+++ b/src/types.ts
@@ -1156,6 +1156,11 @@ export type ListenEventName =
   | 'welcome'
   /** The listener has been disconnected, and a reconnect attempt is scheduled */
   | 'reconnect'
+  /**
+   * The listener connection has been established
+   * note: it's usually a better option to use the 'welcome' event
+   */
+  | 'open'
 
 /** @public */
 export type ListenParams = {[key: string]: Any}

--- a/test/listen.test-d.ts
+++ b/test/listen.test-d.ts
@@ -21,6 +21,8 @@ describe('client.listen', () => {
       Observable<WelcomeEvent>
     >()
 
+    expectTypeOf(client.listen('*', {}, {events: []})).toEqualTypeOf<Observable<never>>()
+
     expectTypeOf(client.listen('*', {}, {events: ['welcome']})).toEqualTypeOf<
       // @ts-expect-error - Only WelcomeEvents should be emitted
       Observable<MutationEvent>

--- a/test/listen.test-d.ts
+++ b/test/listen.test-d.ts
@@ -1,5 +1,6 @@
 import {
   createClient,
+  type ListenEvent,
   type MutationEvent,
   type OpenEvent,
   type ReconnectEvent,
@@ -19,6 +20,14 @@ describe('client.listen', () => {
 
     expectTypeOf(client.listen('*', {}, {events: ['welcome']})).toEqualTypeOf<
       Observable<WelcomeEvent>
+    >()
+
+    type MyDoc = {foo: 'bar'}
+    // Note – due to typescript's lack of support for partial type argument inference, TypeScript will see options
+    // here as `ListenOptions`, meaning the literal event names can no longer be inferred.
+    // see https://github.com/microsoft/TypeScript/pull/26349
+    expectTypeOf(client.listen<MyDoc>('*', {}, {events: ['welcome', 'mutation']})).toEqualTypeOf<
+      Observable<ListenEvent<MyDoc>>
     >()
 
     expectTypeOf(client.listen('*', {}, {events: []})).toEqualTypeOf<Observable<never>>()

--- a/test/listen.test-d.ts
+++ b/test/listen.test-d.ts
@@ -1,0 +1,33 @@
+import {
+  createClient,
+  type MutationEvent,
+  type OpenEvent,
+  type ReconnectEvent,
+  type WelcomeEvent,
+} from '@sanity/client'
+import type {Observable} from 'rxjs'
+import {describe, expectTypeOf, test} from 'vitest'
+
+describe('client.listen', () => {
+  const client = createClient({})
+  test('event types', async () => {
+    // mutation event is default
+    expectTypeOf(client.listen('*')).toEqualTypeOf<Observable<MutationEvent>>()
+
+    // @ts-expect-error - WelcomeEvent should not be emitted
+    expectTypeOf(client.listen('*')).toEqualTypeOf<Observable<WelcomeEvent>>()
+
+    expectTypeOf(client.listen('*', {}, {events: ['welcome']})).toEqualTypeOf<
+      Observable<WelcomeEvent>
+    >()
+
+    expectTypeOf(client.listen('*', {}, {events: ['welcome']})).toEqualTypeOf<
+      // @ts-expect-error - Only WelcomeEvents should be emitted
+      Observable<MutationEvent>
+    >()
+
+    expectTypeOf(
+      client.listen('*', {}, {events: ['welcome', 'mutation', 'open', 'reconnect']}),
+    ).toEqualTypeOf<Observable<WelcomeEvent | MutationEvent | ReconnectEvent | OpenEvent>>()
+  })
+})


### PR DESCRIPTION
### Description
Currently, `client.listen()` returns Observable<ListenEvent>, where `ListenEvent` is a union all events that listen _can potentially_ emit:
https://github.com/sanity-io/client/blob/7e956b84c93d75a0a07d501598e222087dcfa6d0/src/types.ts#L1143-L1149

However, if you pass e.g. `{events: ['mutation', 'welcome']}`, in reality you'll only get `Observable<MutationEvent | WelcomeEvent>`

This PR narrows the returned event type based on the list of events names provided by the listener options.

Also adds `open` to the list of possible events to subscribe to. Don't think this event is super useful for most cases (better off using `welcome` which represents e2e connection with the backend stream), but could be of interest for debugging, etc.

Also removes `ChannelErrorEvent` and `DisconnectEvent` from the `ListenEvent` union since these are thrown as errors on the observable, not emitted as events.


### Testing
This mainly affects the type system, runtime behavior should not change.

See added type tests: [`fix/map-listen-events-to-event-types?expand=1`#diff-b88c5f3110](https://github.com/sanity-io/client/compare/fix/map-listen-events-to-event-types?expand=1#diff-b88c5f3110425a87b8eecabf1167328edc676c9c7f74f8018a84edbb4fc8b2fb)