### PR TITLE
fix(docs): fix incorrect releases method name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1646,7 +1646,7 @@ Create a new release.
 ```js
 client
   .action({
-    actionType: 'sanity.action.releases.create',
+    actionType: 'sanity.action.release.create',
     releaseId: 'new-bikes-release',
     metadata: {
       title: 'New bikes',

--- a/README.md
+++ b/README.md
@@ -1336,7 +1336,7 @@ const client = createClient({
 1. Create a new release
 
 ```js
-const {releaseId} = await client.release.create({
+const {releaseId} = await client.releases.create({
   metadata: {
     title: 'New bike drop'
     releaseType: 'scheduled'
@@ -1646,7 +1646,7 @@ Create a new release.
 ```js
 client
   .action({
-    actionType: 'sanity.action.release.create',
+    actionType: 'sanity.action.releases.create',
     releaseId: 'new-bikes-release',
     metadata: {
       title: 'New bikes',


### PR DESCRIPTION
### Description

The create release example uses the singular `client.release` instead of `client.releases`.

### What to review

Confirm this matches expected behavior of the releases client.

