### PR TITLE
fix(csm): resolve root path mappings

### DIFF
--- a/src/csm/resolveMapping.ts
+++ b/src/csm/resolveMapping.ts
@@ -28,7 +28,7 @@ export function resolveMapping(
   }
 
   const resultMappingPathArray = jsonPathArray(jsonPathToMappingPath(resultPath))
-  for (let i = resultMappingPathArray.length - 1; i > 0; i--) {
+  for (let i = resultMappingPathArray.length - 1; i >= 0; i--) {
     const key = `$${resultMappingPathArray.slice(0, i).join('')}`
     const mappingFound = csm.mappings[key]
     if (mappingFound) {

--- a/test/stega/encodeIntoResult.test.ts
+++ b/test/stega/encodeIntoResult.test.ts
@@ -246,6 +246,252 @@ const encodeTestCases: {
       ],
     },
   },
+  {
+    name: 'resolves root only mapping',
+    queryResult: {
+      result: [
+        {
+          _id: 'foo',
+          this: 'that',
+        },
+      ],
+      resultSourceMap: {
+        documents: [
+          {
+            _id: 'foo',
+            _type: 'bar',
+          },
+        ],
+        paths: ['$'],
+        mappings: {
+          $: {
+            source: {
+              document: 0,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+        },
+      },
+    },
+    expected: {
+      encoderCalls: 2,
+      encoderArgs: [
+        [
+          {
+            sourcePath: [0, '_id'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: [0, '_id'],
+            value: 'foo',
+          },
+        ],
+        [
+          {
+            sourcePath: [0, 'this'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: [0, 'this'],
+            value: 'that',
+          },
+        ],
+      ],
+    },
+  },
+  {
+    name: 'single result resolves root only mapping',
+    queryResult: {
+      result: {
+        _id: 'foo',
+        this: 'that',
+      },
+      resultSourceMap: {
+        documents: [
+          {
+            _id: 'foo',
+            _type: 'bar',
+          },
+        ],
+        paths: ['$'],
+        mappings: {
+          $: {
+            source: {
+              document: 0,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+        },
+      },
+    },
+    expected: {
+      encoderCalls: 2,
+      encoderArgs: [
+        [
+          {
+            sourcePath: ['_id'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: ['_id'],
+            value: 'foo',
+          },
+        ],
+        [
+          {
+            sourcePath: ['this'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: ['this'],
+            value: 'that',
+          },
+        ],
+      ],
+    },
+  },
+  {
+    name: 'resolves mixture of root and non-root mappings',
+    queryResult: {
+      result: [
+        {
+          _id: 'foo',
+          this: 'that',
+          projected: {
+            fred: 'yolo',
+          },
+        },
+      ],
+      resultSourceMap: {
+        documents: [
+          {
+            _id: 'foo',
+            _type: 'bar',
+          },
+        ],
+        paths: ["$['_id']", "$['this']", "$['nested']"],
+        mappings: {
+          "$[0]['_id']": {
+            source: {
+              document: 0,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[0]['this']": {
+            source: {
+              document: 0,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$[0]['projected']": {
+            source: {
+              document: 0,
+              path: 2,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+        },
+      },
+    },
+    expected: {
+      encoderCalls: 3,
+      encoderArgs: [
+        [
+          {
+            sourcePath: ['_id'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: [0, '_id'],
+            value: 'foo',
+          },
+        ],
+        [
+          {
+            sourcePath: ['this'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: [0, 'this'],
+            value: 'that',
+          },
+        ],
+        [
+          {
+            sourcePath: ['nested', 'fred'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: [0, 'projected', 'fred'],
+            value: 'yolo',
+          },
+        ],
+      ],
+    },
+  },
+  {
+    name: 'single result resolves mixture of root and non-root mappings',
+    queryResult: {
+      result: {
+        _id: 'foo',
+        this: 'that',
+        projected: {
+          fred: 'yolo',
+        },
+      },
+      resultSourceMap: {
+        documents: [
+          {
+            _id: 'foo',
+            _type: 'bar',
+          },
+        ],
+        paths: ['$', "$['nested']"],
+        mappings: {
+          $: {
+            source: {
+              document: 0,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+          "$['projected']": {
+            source: {
+              document: 0,
+              path: 1,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+        },
+      },
+    },
+    expected: {
+      encoderCalls: 3,
+      encoderArgs: [
+        [
+          {
+            sourcePath: ['_id'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: ['_id'],
+            value: 'foo',
+          },
+        ],
+        [
+          {
+            sourcePath: ['this'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: ['this'],
+            value: 'that',
+          },
+        ],
+        [
+          {
+            sourcePath: ['nested', 'fred'],
+            sourceDocument: {_id: 'foo', _type: 'bar'},
+            resultPath: ['projected', 'fred'],
+            value: 'yolo',
+          },
+        ],
+      ],
+    },
+  },
 ]
 
 test.each(encodeTestCases)('encode $name', ({queryResult, expected}) => {


### PR DESCRIPTION
### Description

Fixes regression from 7165b6ea2f0f58292c0208a468c42c06c55a82ea

Now resolves the below CSM correctly...
```json
{
    "documents": [
        {
            "_id": "6efbfbb5-8324-4868-843c-b1da42cccd02",
            "_type": "movie"
        }
    ],
    "paths": [
        "$"
    ],
    "mappings": {
        "$": {
            "source": {
                "document": 0,
                "path": 0,
                "type": "documentValue"
            },
            "type": "value"
        }
    }
}
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
