### PR TITLE
feat: add description field to dataset

### DIFF
--- a/.changeset/pr-1182.md
+++ b/.changeset/pr-1182.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': minor
+---
+
+feat: add description field to dataset

--- a/src/types.ts
+++ b/src/types.ts
@@ -466,6 +466,7 @@ export type DatasetAclMode = 'public' | 'private' | 'custom'
 /** @public */
 export type DatasetCreateOptions = {
   aclMode?: DatasetAclMode
+  description?: string
   embeddings?: {
     enabled: boolean
     projection?: string
@@ -475,6 +476,7 @@ export type DatasetCreateOptions = {
 /** @public */
 export type DatasetEditOptions = {
   aclMode?: DatasetAclMode
+  description?: string
 }
 
 /** @public */
@@ -491,11 +493,12 @@ export type EmbeddingsSettingsBody = {
 }
 
 /** @public */
-export type DatasetResponse = {datasetName: string; aclMode: DatasetAclMode}
+export type DatasetResponse = {datasetName: string; aclMode: DatasetAclMode; description: string}
 /** @public */
 export type DatasetsResponse = {
   name: string
   aclMode: DatasetAclMode
+  description: string
   createdAt: string
   createdByUserId: string
   addonFor: string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -620,6 +620,7 @@ export type DatasetAclMode = 'public' | 'private' | 'custom'
 /** @public */
 export type DatasetCreateOptions = {
   aclMode?: DatasetAclMode
+  description?: string
   embeddings?: {
     enabled: boolean
     projection?: string
@@ -629,6 +630,7 @@ export type DatasetCreateOptions = {
 /** @public */
 export type DatasetEditOptions = {
   aclMode?: DatasetAclMode
+  description?: string
 }
 
 /** @public */
@@ -645,11 +647,12 @@ export type EmbeddingsSettingsBody = {
 }
 
 /** @public */
-export type DatasetResponse = {datasetName: string; aclMode: DatasetAclMode}
+export type DatasetResponse = {datasetName: string; aclMode: DatasetAclMode; description: string}
 /** @public */
 export type DatasetsResponse = {
   name: string
   aclMode: DatasetAclMode
+  description: string
   createdAt: string
   createdByUserId: string
   addonFor: string | null


### PR DESCRIPTION
Adds in the `description` field to datasets.
Related to AIGRO-4484 but doesn't close it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only surface change with pass-through request bodies; the main caveat is stricter response typings if consumers use incomplete mocks.
> 
> **Overview**
> Extends the public dataset typings so callers can set and read a **`description`** on datasets, aligned with the backend API (related to AIGRO-4484).
> 
> **`DatasetCreateOptions`** and **`DatasetEditOptions`** gain an optional `description` for `datasets.create()` / `datasets.edit()` (the client already forwards the options body). **`DatasetResponse`** and each entry in **`DatasetsResponse`** now include a required `description: string` so list/get/edit/create responses are typed correctly.
> 
> Ships as a **minor** `@sanity/client` release via the changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9896f83ee5c8dc7d4b38bd2eb400d8b7d34faeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->