### PR TITLE
fix: Update type DatasetsResponse

### DIFF
--- a/.changeset/pr-1183.md
+++ b/.changeset/pr-1183.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': patch
+---
+
+fix: Update type DatasetsResponse

--- a/src/types.ts
+++ b/src/types.ts
@@ -474,7 +474,10 @@ export type DatasetsResponse = {
   addonFor: string | null
   datasetProfile: string
   features: string[]
-  tags: string[]
+  tags: {
+    name: string
+    title: string
+  }[]
 }[]
 
 /** @public */

--- a/src/types.ts
+++ b/src/types.ts
@@ -658,7 +658,10 @@ export type DatasetsResponse = {
   addonFor: string | null
   datasetProfile: string
   features: string[]
-  tags: string[]
+  tags: {
+    name: string
+    title: string
+  }[]
 }[]
 
 /** @public */


### PR DESCRIPTION
### Description

Updates type to align with what client returns

### What to review

Whether it is needed: object can be transferred to its own type

### Testing

Data returned is aligned with the new type 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public type-only change with no runtime logic; may surface TypeScript errors where code treated tags as plain strings.
> 
> **Overview**
> Corrects the public **`DatasetsResponse`** typing so each dataset’s **`tags`** field matches what the API returns: an array of objects with **`name`** and **`title`**, instead of **`string[]`**.
> 
> Ships as a **patch** release via changeset. Consumers who assumed tag strings may need to update property access (e.g. use **`tag.name`** / **`tag.title`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146879b311ab19e823d7b5add3237e9a928c0568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->