### PR TITLE
feat(types): add VideoRenditionInfo types with typed resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ export async function updateDocumentTitle(_id, title) {
   - [Media Library API](#media-library-api)
     - [Getting video playback information](#getting-video-playback-information)
     - [Working with signed playback information](#working-with-signed-playback-information)
+    - [Downloading MP4 renditions](#downloading-mp4-renditions)
 - [License](#license)
 - [From `v5`](#from-v5)
   - [The default `useCdn` is changed to `true`](#the-default-usecdn-is-changed-to-true)
@@ -2390,7 +2391,12 @@ The response contains playback URLs and metadata:
   animated: { url: "https://image.m.sanity-cdn.com/..." },
   storyboard: { url: "https://storyboard.m.sanity-cdn.com/..." },
   duration: 120.5,
-  aspectRatio: 1.77
+  aspectRatio: 1.77,
+  renditions: [
+    { url: "https://apicdn.sanity.io/.../renditions/1080p.mp4", resolution: "1080p" },
+    { url: "https://apicdn.sanity.io/.../renditions/480p.mp4", resolution: "480p" },
+    { url: "https://apicdn.sanity.io/.../renditions/270p.mp4", resolution: "270p" }
+  ]
 }
 
 // Signed playback response (when video requires authentication)
@@ -2413,7 +2419,21 @@ The response contains playback URLs and metadata:
     token: "eyJ0a2VuIjoiU3Rvcnlib2FyZFRva2VuLTc4..."
   },
   duration: 120.5,
-  aspectRatio: 1.77
+  aspectRatio: 1.77,
+  renditions: [
+    {
+      url: "https://apicdn.sanity.io/.../renditions/1080p.mp4",
+      resolution: "1080p",
+      token: "eyJhbGciOiJSUzI1NiIs...",
+      expiresAt: "2026-02-17T21:00:00Z"
+    },
+    {
+      url: "https://apicdn.sanity.io/.../renditions/480p.mp4",
+      resolution: "480p",
+      token: "eyJhbGciOiJSUzI1NiIs...",
+      expiresAt: "2026-02-17T21:00:00Z"
+    }
+  ]
 }
 ```
 
@@ -2442,6 +2462,30 @@ if (isSignedPlaybackInfo(playbackInfo)) {
   // The tokens authenticate access to the video resources
 }
 ```
+
+#### Downloading MP4 renditions
+
+Videos may include downloadable MP4 renditions at fixed resolutions. These are available via the `renditions` array in the playback info response:
+
+```js
+const playbackInfo = await client.mediaLibrary.video.getPlaybackInfo(
+  'video-30rh9U3GDEK3ToiId1Zje4uvalC-mp4',
+)
+
+if (playbackInfo.renditions?.length) {
+  const hd = playbackInfo.renditions.find((r) => r.resolution === '1080p')
+  if (hd) {
+    // Stream the rendition
+    const response = await fetch(hd.url)
+
+    // Or trigger a browser download with a custom filename
+    const downloadUrl = `${hd.url}?dl=my-video-1080p.mp4`
+    window.open(downloadUrl)
+  }
+}
+```
+
+Available resolutions depend on the source video but typically include `1080p`, `480p`, and `270p`.
 
 ## License
 

--- a/src/media-library.ts
+++ b/src/media-library.ts
@@ -6,6 +6,8 @@ import type {
   VideoPlaybackTokens,
 } from './types'
 
+export type {VideoRenditionInfo, VideoRenditionInfoPublic, VideoRenditionInfoSigned} from './types'
+
 /**
  * Check if a playback info item (stream/thumbnail/etc) has a signed token
  * @internal

--- a/src/types.ts
+++ b/src/types.ts
@@ -1978,7 +1978,31 @@ export interface VideoPlaybackInfoItemSigned extends VideoPlaybackInfoItemPublic
 export type VideoPlaybackInfoItem = VideoPlaybackInfoItemPublic | VideoPlaybackInfoItemSigned
 
 /** @public */
-export interface VideoPlaybackInfo<T extends VideoPlaybackInfoItem = VideoPlaybackInfoItem> {
+export interface VideoRenditionInfoPublic {
+  /** URL to the MP4 rendition (redirects to CDN) */
+  url: string
+  /** Resolution identifier, e.g. "1080p", "480p", "270p" */
+  resolution: '1080p' | '480p' | '270p' | (string & {})
+}
+
+/** @public */
+export interface VideoRenditionInfoSigned extends VideoRenditionInfoPublic {
+  /** Authentication token for signed playback */
+  token: string
+  /** Token expiration time in ISO 8601 format */
+  expiresAt: string
+}
+
+/** @public */
+export type VideoRenditionInfo = VideoRenditionInfoPublic | VideoRenditionInfoSigned
+
+/** @public */
+export interface VideoPlaybackInfo<
+  T extends VideoPlaybackInfoItem = VideoPlaybackInfoItem,
+  R extends VideoRenditionInfo = T extends VideoPlaybackInfoItemSigned
+    ? VideoRenditionInfoSigned
+    : VideoRenditionInfo,
+> {
   id: string
   thumbnail: T
   animated: T
@@ -1986,6 +2010,7 @@ export interface VideoPlaybackInfo<T extends VideoPlaybackInfoItem = VideoPlayba
   stream: T
   duration: number
   aspectRatio: number
+  renditions?: R[]
 }
 
 /** @public */


### PR DESCRIPTION
## Summary

Adds rendition type definitions to `@sanity/client` to match the backend response shape.

Part of DAM-1038

## Changes

### Types (`src/types.ts`)
- `VideoRenditionInfoPublic` — `url` + `resolution`
- `VideoRenditionInfoSigned` — extends public with `token` + `expiresAt`
- `VideoRenditionInfo` — union type
- `renditions?` field added to `VideoPlaybackInfo`

The `resolution` property is typed as `'1080p' | '480p' | '270p' | (string & {})` — gives IDE autocomplete for known values while accepting any string for future resolutions.

### Exports (`src/media-library.ts`)
Re-exports all 3 rendition types from the media library entry point.

### Documentation (`README.md`)
- Added rendition examples to both public and signed playback info responses
- Added "Downloading MP4 renditions" section with usage example

## Note
Subtitle types have been split into a separate PR (#1191) for independent rollout.