### PR TITLE
feat(dataset): add embeddings configuration options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -464,6 +464,33 @@ export type AuthProviderResponse = {providers: AuthProvider[]}
 export type DatasetAclMode = 'public' | 'private' | 'custom'
 
 /** @public */
+export type DatasetCreateOptions = {
+  aclMode?: DatasetAclMode
+  embeddings?: {
+    enabled: boolean
+    projection?: string
+  }
+}
+
+/** @public */
+export type DatasetEditOptions = {
+  aclMode?: DatasetAclMode
+}
+
+/** @public */
+export type EmbeddingsSettings = {
+  enabled: boolean
+  projection?: string
+  status: string
+}
+
+/** @public */
+export type EmbeddingsSettingsBody = {
+  enabled: boolean
+  projection?: string
+}
+
+/** @public */
 export type DatasetResponse = {datasetName: string; aclMode: DatasetAclMode}
 /** @public */
 export type DatasetsResponse = {


### PR DESCRIPTION
### Description

Adds embeddings configuration options and new methods for managing embeddings settings. Also introduces named types replacing inline type definitions

**Enable embeddings when creating a dataset**

```ts
import {createClient} from '@sanity/client'

const client = createClient({
  projectId: 'my-project',
  dataset: 'production',
  apiVersion: '2025-02-19',
})

await client.datasets.create('my-dataset', {
  aclMode: 'public',
  embeddings: {
    enabled: true,
    projection: '{title, body}',
  },
})
```

**Get embeddings settings for a dataset**

```ts
const settings = await client.datasets.getEmbeddingsSettings('my-dataset')
console.log(settings)
// { enabled: true, projection: '{title, body}', status: 'active' }
```

**Edit embeddings settings**

```ts
await client.datasets.editEmbeddingsSettings('my-dataset', {
  enabled: true,
  projection: '{title, description, body}',
})
```

**Disable embeddings**

```ts
await client.datasets.editEmbeddingsSettings('my-dataset', {
  enabled: false,
})
```

### Testing

Adds tests covering happy paths, `useProjectHostname=false` URL variants, and input validation