### PR TITLE
feat(types): add VideoSubtitleInfo types to playback info

### DIFF
--- a/src/media-library.ts
+++ b/src/media-library.ts
@@ -7,6 +7,7 @@ import type {
 } from './types'
 
 export type {VideoRenditionInfo, VideoRenditionInfoPublic, VideoRenditionInfoSigned} from './types'
+export type {VideoSubtitleInfo, VideoSubtitleInfoPublic, VideoSubtitleInfoSigned} from './types'
 
 /**
  * Check if a playback info item (stream/thumbnail/etc) has a signed token

--- a/src/types.ts
+++ b/src/types.ts
@@ -1997,11 +1997,35 @@ export interface VideoRenditionInfoSigned extends VideoRenditionInfoPublic {
 export type VideoRenditionInfo = VideoRenditionInfoPublic | VideoRenditionInfoSigned
 
 /** @public */
+export interface VideoSubtitleInfoPublic {
+  /** Subtitle track identifier */
+  trackId: string
+  /** ISO 639-1 language code */
+  languageCode: string
+  /** URL to the subtitle file */
+  url: string
+}
+
+/** @public */
+export interface VideoSubtitleInfoSigned extends VideoSubtitleInfoPublic {
+  /** Authentication token for signed playback */
+  token: string
+  /** Token expiration time in ISO 8601 format */
+  expiresAt: string
+}
+
+/** @public */
+export type VideoSubtitleInfo = VideoSubtitleInfoPublic | VideoSubtitleInfoSigned
+
+/** @public */
 export interface VideoPlaybackInfo<
   T extends VideoPlaybackInfoItem = VideoPlaybackInfoItem,
   R extends VideoRenditionInfo = T extends VideoPlaybackInfoItemSigned
     ? VideoRenditionInfoSigned
     : VideoRenditionInfo,
+  S extends VideoSubtitleInfo = T extends VideoPlaybackInfoItemSigned
+    ? VideoSubtitleInfoSigned
+    : VideoSubtitleInfo,
 > {
   id: string
   thumbnail: T
@@ -2011,6 +2035,7 @@ export interface VideoPlaybackInfo<
   duration: number
   aspectRatio: number
   renditions?: R[]
+  subtitles?: S[]
 }
 
 /** @public */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2004,6 +2004,8 @@ export interface VideoSubtitleInfoPublic {
   languageCode: string
   /** URL to the subtitle file */
   url: string
+  /** Whether this track contains closed captions */
+  closedCaptions: boolean
 }
 
 /** @public */


### PR DESCRIPTION
## Summary

Adds subtitle type definitions for the video playback info response, split out from #1186 (renditions PR) to keep concerns separate.

### Types added
- `VideoSubtitleInfoPublic` — trackId, languageCode, url
- `VideoSubtitleInfoSigned` — extends public with token + expiresAt
- `VideoSubtitleInfo` — union type
- `subtitles?: VideoSubtitleInfo[]` field on `VideoPlaybackInfo`

Re-exported from `@sanity/client/media-library`.