### PR TITLE
feat(projects): add `onlyExplicitMembership` option to `projects.list()`

### DIFF
--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -19,15 +19,22 @@ export class ObservableProjectsClient {
    * @param options - Options for the list request
    *   - `includeMembers` - Whether to include members in the response (default: true)
    *   - `organizationId` - ID of the organization to fetch projects for
+   *   - `onlyExplicitMembership` - Only include projects where the user has explicit membership (default: false)
    */
-  list(options?: {includeMembers?: true; organizationId?: string}): Observable<SanityProject[]>
+  list(options?: {
+    includeMembers?: true
+    organizationId?: string
+    onlyExplicitMembership?: boolean
+  }): Observable<SanityProject[]>
   list(options?: {
     includeMembers?: false
     organizationId?: string
+    onlyExplicitMembership?: boolean
   }): Observable<Omit<SanityProject, 'members'>[]>
   list(options?: {
     includeMembers?: boolean
     organizationId?: string
+    onlyExplicitMembership?: boolean
   }): Observable<SanityProject[] | Omit<SanityProject, 'members'>[]> {
     const query: Record<string, string> = {}
     const uri = '/projects'
@@ -36,6 +43,9 @@ export class ObservableProjectsClient {
     }
     if (options?.organizationId) {
       query.organizationId = options.organizationId
+    }
+    if (options?.onlyExplicitMembership === true) {
+      query.onlyExplicitMembership = 'true'
     }
 
     return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query})
@@ -66,15 +76,22 @@ export class ProjectsClient {
    * @param options - Options for the list request
    *   - `includeMembers` - Whether to include members in the response (default: true)
    *   - `organizationId` - ID of the organization to fetch projects for
+   *   - `onlyExplicitMembership` - Only include projects where the user has explicit membership (default: false)
    */
-  list(options?: {includeMembers?: true; organizationId?: string}): Promise<SanityProject[]>
+  list(options?: {
+    includeMembers?: true
+    organizationId?: string
+    onlyExplicitMembership?: boolean
+  }): Promise<SanityProject[]>
   list(options?: {
     includeMembers?: false
     organizationId?: string
+    onlyExplicitMembership?: boolean
   }): Promise<Omit<SanityProject, 'members'>[]>
   list(options?: {
     includeMembers?: boolean
     organizationId?: string
+    onlyExplicitMembership?: boolean
   }): Promise<SanityProject[] | Omit<SanityProject, 'members'>[]> {
     const query: Record<string, string> = {}
     const uri = '/projects'
@@ -83,6 +100,9 @@ export class ProjectsClient {
     }
     if (options?.organizationId) {
       query.organizationId = options.organizationId
+    }
+    if (options?.onlyExplicitMembership === true) {
+      query.onlyExplicitMembership = 'true'
     }
     return lastValueFrom(_request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query}))
   }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -726,6 +726,42 @@ describe('client', async () => {
       expect(projects[0].id, 'should have project id').toBe('foo')
     })
 
+    test('can request list of projects with only explicit membership', async () => {
+      nock(`https://${apiHost}`)
+        .get('/v1/projects?onlyExplicitMembership=true')
+        .reply(200, [{id: 'foo'}, {id: 'bar'}])
+
+      const client = createClient({useProjectHostname: false, apiHost: `https://${apiHost}`})
+      const projects = await client.projects.list({onlyExplicitMembership: true})
+      expect(projects.length, 'should have two projects').toBe(2)
+      expect(projects[0].id, 'should have project id').toBe('foo')
+    })
+
+    test('does not include onlyExplicitMembership param when false', async () => {
+      nock(`https://${apiHost}`)
+        .get('/v1/projects')
+        .reply(200, [{id: 'foo'}, {id: 'bar'}])
+
+      const client = createClient({useProjectHostname: false, apiHost: `https://${apiHost}`})
+      const projects = await client.projects.list({onlyExplicitMembership: false})
+      expect(projects.length, 'should have two projects').toBe(2)
+      expect(projects[0].id, 'should have project id').toBe('foo')
+    })
+
+    test('can combine onlyExplicitMembership with other options', async () => {
+      nock(`https://${apiHost}`)
+        .get('/v1/projects?organizationId=org_123&onlyExplicitMembership=true')
+        .reply(200, [{id: 'foo'}])
+
+      const client = createClient({useProjectHostname: false, apiHost: `https://${apiHost}`})
+      const projects = await client.projects.list({
+        organizationId: 'org_123',
+        onlyExplicitMembership: true,
+      })
+      expect(projects.length, 'should have one project').toBe(1)
+      expect(projects[0].id, 'should have project id').toBe('foo')
+    })
+
     test('can request list of projects, ignoring non-false `includeMembers` option', async () => {
       nock(`https://${apiHost}`)
         .get('/v1/projects')


### PR DESCRIPTION
## Summary
- Adds `onlyExplicitMembership` boolean option to `projects.list()` on both `ObservableProjectsClient` and `ProjectsClient`
- When set to `true`, filters projects to only those where the user has explicit membership (as opposed to implicit membership via organization)
- Parameter is omitted from the API request when `false` or unset (default behavior unchanged)

## Test plan
- [x] Added test: `onlyExplicitMembership: true` sends `?onlyExplicitMembership=true`
- [x] Added test: `onlyExplicitMembership: false` does not include the parameter
- [x] Added test: combines correctly with other options (`organizationId`)
- [x] All 488 existing tests pass
- [x] No type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)