### PR TITLE
feat: add more query options to listing projects

### DIFF
--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -4,6 +4,17 @@ import {_request} from '../data/dataMethods'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import type {HttpRequest, SanityProject} from '../types'
 
+type ListOptions = {
+  includeMembers?: boolean
+  includeFeatures?: boolean
+  organizationId?: string
+  onlyExplicitMembership?: boolean
+}
+
+type OmittedProjectFields<T extends ListOptions | undefined> =
+  | (T extends {includeMembers: false} ? 'members' : never)
+  | (T extends {includeFeatures: false} ? 'features' : never)
+
 /** @internal */
 export class ObservableProjectsClient {
   #client: ObservableSanityClient
@@ -18,37 +29,31 @@ export class ObservableProjectsClient {
    *
    * @param options - Options for the list request
    *   - `includeMembers` - Whether to include members in the response (default: true)
+   *   - `includeFeatures` - Whether to include features in the response (default: true)
    *   - `organizationId` - ID of the organization to fetch projects for
-   *   - `onlyExplicitMembership` - Only include projects where the user has explicit membership (default: false)
+   *   - `onlyExplicitMembership` - Whether to include only projects with explicit membership (default: false)
    */
-  list(options?: {
-    includeMembers?: true
-    organizationId?: string
-    onlyExplicitMembership?: boolean
-  }): Observable<SanityProject[]>
-  list(options?: {
-    includeMembers?: false
-    organizationId?: string
-    onlyExplicitMembership?: boolean
-  }): Observable<Omit<SanityProject, 'members'>[]>
-  list(options?: {
-    includeMembers?: boolean
-    organizationId?: string
-    onlyExplicitMembership?: boolean
-  }): Observable<SanityProject[] | Omit<SanityProject, 'members'>[]> {
+  list<T extends ListOptions>(
+    options?: T,
+  ): Observable<Omit<SanityProject, OmittedProjectFields<T>>[]> {
     const query: Record<string, string> = {}
     const uri = '/projects'
     if (options?.includeMembers === false) {
       query.includeMembers = 'false'
     }
+    if (options?.includeFeatures === false) {
+      query.includeFeatures = 'false'
+    }
     if (options?.organizationId) {
       query.organizationId = options.organizationId
     }
-    if (options?.onlyExplicitMembership === true) {
+    if (options?.onlyExplicitMembership) {
       query.onlyExplicitMembership = 'true'
     }
 
-    return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query})
+    return _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query}) as Observable<
+      Omit<SanityProject, OmittedProjectFields<T>>[]
+    >
   }
 
   /**
@@ -75,36 +80,32 @@ export class ProjectsClient {
    *
    * @param options - Options for the list request
    *   - `includeMembers` - Whether to include members in the response (default: true)
+   *   - `includeFeatures` - Whether to include features in the response (default: true)
    *   - `organizationId` - ID of the organization to fetch projects for
-   *   - `onlyExplicitMembership` - Only include projects where the user has explicit membership (default: false)
+   *   - `onlyExplicitMembership` - Whether to include only projects with explicit membership (default: false)
    */
-  list(options?: {
-    includeMembers?: true
-    organizationId?: string
-    onlyExplicitMembership?: boolean
-  }): Promise<SanityProject[]>
-  list(options?: {
-    includeMembers?: false
-    organizationId?: string
-    onlyExplicitMembership?: boolean
-  }): Promise<Omit<SanityProject, 'members'>[]>
-  list(options?: {
-    includeMembers?: boolean
-    organizationId?: string
-    onlyExplicitMembership?: boolean
-  }): Promise<SanityProject[] | Omit<SanityProject, 'members'>[]> {
+  list<T extends ListOptions>(
+    options?: T,
+  ): Promise<Omit<SanityProject, OmittedProjectFields<T>>[]> {
     const query: Record<string, string> = {}
     const uri = '/projects'
     if (options?.includeMembers === false) {
       query.includeMembers = 'false'
     }
+    if (options?.includeFeatures === false) {
+      query.includeFeatures = 'false'
+    }
     if (options?.organizationId) {
       query.organizationId = options.organizationId
     }
-    if (options?.onlyExplicitMembership === true) {
+    if (options?.onlyExplicitMembership) {
       query.onlyExplicitMembership = 'true'
     }
-    return lastValueFrom(_request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query}))
+    return lastValueFrom(
+      _request<SanityProject[]>(this.#client, this.#httpRequest, {uri, query}) as Observable<
+        Omit<SanityProject, OmittedProjectFields<T>>[]
+      >,
+    )
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -529,6 +529,7 @@ export interface SanityProject {
   pendingInvites?: number
   maxRetentionDays?: number
   members: SanityProjectMember[]
+  features: string[]
   metadata: {
     cliInitializedAt?: string
     color?: string


### PR DESCRIPTION
This pull request enhances the flexibility of the `ProjectsClient` by introducing new options for filtering and customizing the returned project data. The main improvements are the ability to include or exclude project `features`, filter projects by explicit membership, and improvements to the type definitions to support these new options.