### PR TITLE
feat: support intercepting requests via internal requestHandler config

### DIFF
--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -43,6 +43,7 @@ import type {
   RawQuerylessQueryResponse,
   RawQueryResponse,
   RawRequestOptions,
+  RequestOptions,
   SanityDocument,
   SanityDocumentStub,
   SingleActionResult,
@@ -87,6 +88,7 @@ export class ObservableSanityClient {
    * Private properties
    */
   #clientConfig: InitializedClientConfig
+  #originalHttpRequest: HttpRequest
   #httpRequest: HttpRequest
 
   /**
@@ -97,7 +99,15 @@ export class ObservableSanityClient {
   constructor(httpRequest: HttpRequest, config: ClientConfig = defaultConfig) {
     this.config(config)
 
-    this.#httpRequest = httpRequest
+    this.#originalHttpRequest = httpRequest
+    const requestHandler = config.requestHandler
+
+    this.#httpRequest = requestHandler
+      ? (options, requester) => {
+          const opts = options as RequestOptions & {url: string}
+          return requestHandler(opts, (o) => httpRequest(o, requester))
+        }
+      : httpRequest
 
     this.assets = new ObservableAssetsClient(this, this.#httpRequest)
     this.datasets = new ObservableDatasetsClient(this, this.#httpRequest)
@@ -117,7 +127,7 @@ export class ObservableSanityClient {
    * Clone the client - returns a new instance
    */
   clone(): ObservableSanityClient {
-    return new ObservableSanityClient(this.#httpRequest, this.config())
+    return new ObservableSanityClient(this.#originalHttpRequest, this.config())
   }
 
   /**
@@ -150,7 +160,7 @@ export class ObservableSanityClient {
    */
   withConfig(newConfig?: Partial<ClientConfig>): ObservableSanityClient {
     const thisConfig = this.config()
-    return new ObservableSanityClient(this.#httpRequest, {
+    return new ObservableSanityClient(this.#originalHttpRequest, {
       ...thisConfig,
       ...newConfig,
       stega: {
@@ -1128,6 +1138,7 @@ export class SanityClient {
    * Private properties
    */
   #clientConfig: InitializedClientConfig
+  #originalHttpRequest: HttpRequest
   #httpRequest: HttpRequest
 
   /**
@@ -1138,7 +1149,14 @@ export class SanityClient {
   constructor(httpRequest: HttpRequest, config: ClientConfig = defaultConfig) {
     this.config(config)
 
-    this.#httpRequest = httpRequest
+    this.#originalHttpRequest = httpRequest
+    const requestHandler = config.requestHandler
+    this.#httpRequest = requestHandler
+      ? (options, requester) => {
+          const opts = options as RequestOptions & {url: string}
+          return requestHandler(opts, (o) => httpRequest(o, requester))
+        }
+      : httpRequest
 
     this.assets = new AssetsClient(this, this.#httpRequest)
     this.datasets = new DatasetsClient(this, this.#httpRequest)
@@ -1160,7 +1178,7 @@ export class SanityClient {
    * Clone the client - returns a new instance
    */
   clone(): SanityClient {
-    return new SanityClient(this.#httpRequest, this.config())
+    return new SanityClient(this.#originalHttpRequest, this.config())
   }
 
   /**
@@ -1197,7 +1215,7 @@ export class SanityClient {
    */
   withConfig(newConfig?: Partial<ClientConfig>): SanityClient {
     const thisConfig = this.config()
-    return new SanityClient(this.#httpRequest, {
+    return new SanityClient(this.#originalHttpRequest, {
       ...thisConfig,
       ...newConfig,
       stega: {

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -100,7 +100,7 @@ export class ObservableSanityClient {
     this.config(config)
 
     this.#originalHttpRequest = httpRequest
-    const requestHandler = config.requestHandler
+    const requestHandler = config._requestHandler
 
     this.#httpRequest = requestHandler
       ? (() => {
@@ -108,7 +108,7 @@ export class ObservableSanityClient {
           const wrapped: HttpRequest = (options, requester) => {
             const opts = options as RequestOptions & {url: string}
             if (!bareClient) {
-              bareClient = new SanityClient(httpRequest, {...config, requestHandler: undefined})
+              bareClient = new SanityClient(httpRequest, {...config, _requestHandler: undefined})
             }
             return requestHandler(opts, (o) => httpRequest(o, requester), bareClient)
           }
@@ -1157,14 +1157,14 @@ export class SanityClient {
     this.config(config)
 
     this.#originalHttpRequest = httpRequest
-    const requestHandler = config.requestHandler
+    const requestHandler = config._requestHandler
     this.#httpRequest = requestHandler
       ? (() => {
           let bareClient: SanityClient | undefined
           const wrapped: HttpRequest = (options, requester) => {
             const opts = options as RequestOptions & {url: string}
             if (!bareClient) {
-              bareClient = new SanityClient(httpRequest, {...config, requestHandler: undefined})
+              bareClient = new SanityClient(httpRequest, {...config, _requestHandler: undefined})
             }
             return requestHandler(opts, (o) => httpRequest(o, requester), bareClient)
           }

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -103,10 +103,17 @@ export class ObservableSanityClient {
     const requestHandler = config.requestHandler
 
     this.#httpRequest = requestHandler
-      ? (options, requester) => {
-          const opts = options as RequestOptions & {url: string}
-          return requestHandler(opts, (o) => httpRequest(o, requester))
-        }
+      ? (() => {
+          let bareClient: SanityClient | undefined
+          const wrapped: HttpRequest = (options, requester) => {
+            const opts = options as RequestOptions & {url: string}
+            if (!bareClient) {
+              bareClient = new SanityClient(httpRequest, {...config, requestHandler: undefined})
+            }
+            return requestHandler(opts, (o) => httpRequest(o, requester), bareClient)
+          }
+          return wrapped
+        })()
       : httpRequest
 
     this.assets = new ObservableAssetsClient(this, this.#httpRequest)
@@ -1152,10 +1159,17 @@ export class SanityClient {
     this.#originalHttpRequest = httpRequest
     const requestHandler = config.requestHandler
     this.#httpRequest = requestHandler
-      ? (options, requester) => {
-          const opts = options as RequestOptions & {url: string}
-          return requestHandler(opts, (o) => httpRequest(o, requester))
-        }
+      ? (() => {
+          let bareClient: SanityClient | undefined
+          const wrapped: HttpRequest = (options, requester) => {
+            const opts = options as RequestOptions & {url: string}
+            if (!bareClient) {
+              bareClient = new SanityClient(httpRequest, {...config, requestHandler: undefined})
+            }
+            return requestHandler(opts, (o) => httpRequest(o, requester), bareClient)
+          }
+          return wrapped
+        })()
       : httpRequest
 
     this.assets = new AssetsClient(this, this.#httpRequest)

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 
 import type {Requester} from 'get-it'
+import type {Observable} from 'rxjs'
 
 import type {InitializedStegaConfig, StegaConfig} from './stega/types'
 
@@ -203,6 +204,31 @@ export interface ClientConfig {
    * Lineage token for recursion control
    */
   lineage?: string
+
+  /**
+   * A custom request handler that intercepts all HTTP requests made by the client.
+   *
+   * Useful for logging, adding custom headers, refreshing auth tokens, rate limiting, etc.
+   *
+   * When using `withConfig()`, the new `requestHandler` **replaces** the previous one (it does not
+   * wrap it). To compose handlers, you can chain them manually:
+   *
+   * ```ts
+   * const parent = createClient({...config, requestHandler: handlerA})
+   * const child = parent.withConfig({
+   *   requestHandler: (req, defaultRequester) =>
+   *     handlerB(req, (opts) => handlerA(opts, defaultRequester)),
+   * })
+   * ```
+   *
+   * Setting `requestHandler` to `undefined` via `withConfig()` removes the handler.
+   *
+   * Note: This only applies to HTTP requests. Real-time listener connections
+   * (`client.listen()`) use EventSource and are not intercepted by this handler.
+   *
+   * @see {@link RequestHandler}
+   */
+  requestHandler?: RequestHandler
 }
 
 /** @public */
@@ -411,6 +437,60 @@ export interface ErrorProps {
 export type HttpRequest = {
   (options: RequestOptions, requester: Requester): ReturnType<Requester>
 }
+
+/**
+ * A function that intercepts HTTP requests made by the client.
+ *
+ * Receives the resolved request options and a `defaultRequester` function that
+ * executes the request through the normal get-it pipeline.
+ *
+ * The consumer can:
+ * - Modify request options before calling `defaultRequester`
+ * - Transform the response stream (e.g. via `pipe`)
+ * - Skip `defaultRequester` entirely and return a custom Observable
+ *
+ * When set via `withConfig()`, the new handler **replaces** (not wraps) the previous one.
+ *
+ * Note: This only applies to HTTP requests. Real-time listener connections
+ * (`client.listen()`) use EventSource and are not intercepted by this handler.
+ *
+ * @example Add a custom header to every request
+ * ```ts
+ * const client = createClient({
+ *   projectId: 'my-project',
+ *   dataset: 'production',
+ *   requestHandler: (request, defaultRequester) => {
+ *     return defaultRequester({...request, headers: {...request.headers, 'X-Custom': 'value'}})
+ *   },
+ * })
+ * ```
+ *
+ * @example Log requests and responses
+ * ```ts
+ * import {tap} from 'rxjs'
+ *
+ * const client = createClient({
+ *   projectId: 'my-project',
+ *   dataset: 'production',
+ *   requestHandler: (request, defaultRequester) => {
+ *     console.log('Request:', request.method, request.url)
+ *     return defaultRequester(request).pipe(
+ *       tap((event) => {
+ *         if (event.type === 'response') {
+ *           console.log('Response:', event.statusCode)
+ *         }
+ *       }),
+ *     )
+ *   },
+ * })
+ * ```
+ *
+ * @public
+ */
+export type RequestHandler = (
+  request: RequestOptions & {url: string},
+  defaultRequester: (options: RequestOptions & {url: string}) => Observable<HttpRequestEvent>,
+) => Observable<HttpRequestEvent>
 
 /** @internal */
 export interface RequestObservableOptions extends Omit<RequestOptions, 'url'> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -442,7 +442,7 @@ export type HttpRequest = {
  * A function that intercepts HTTP requests made by the client.
  *
  * Receives the resolved request options and a `defaultRequester` function that
- * executes the request through the normal get-it pipeline.
+ * executes the request through the normal pipeline.
  *
  * The consumer can:
  * - Modify request options before calling `defaultRequester`

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,25 +211,27 @@ export interface ClientConfig {
    *
    * Useful for logging, adding custom headers, refreshing auth tokens, rate limiting, etc.
    *
-   * When using `withConfig()`, the new `requestHandler` **replaces** the previous one (it does not
+   * When using `withConfig()`, the new handler **replaces** the previous one (it does not
    * wrap it). To compose handlers, you can chain them manually:
    *
    * ```ts
-   * const parent = createClient({...config, requestHandler: handlerA})
+   * const parent = createClient({...config, _requestHandler: handlerA})
    * const child = parent.withConfig({
-   *   requestHandler: (req, defaultRequester) =>
+   *   _requestHandler: (req, defaultRequester) =>
    *     handlerB(req, (opts) => handlerA(opts, defaultRequester)),
    * })
    * ```
    *
-   * Setting `requestHandler` to `undefined` via `withConfig()` removes the handler.
+   * Setting `_requestHandler` to `undefined` via `withConfig()` removes the handler.
    *
    * Note: This only applies to HTTP requests. Real-time listener connections
    * (`client.listen()`) use EventSource and are not intercepted by this handler.
    *
+   * @internal
+   * @deprecated Don't use outside of Sanity internals
    * @see {@link RequestHandler}
    */
-  requestHandler?: RequestHandler
+  _requestHandler?: RequestHandler
 }
 
 /** @public */
@@ -444,7 +446,7 @@ export type HttpRequest = {
  *
  * Receives the resolved request options, a `defaultRequester` function that
  * executes the request through the normal pipeline, and a `client` instance
- * without a `requestHandler` (to avoid recursive interception).
+ * without a `_requestHandler` (to avoid recursive interception).
  *
  * The consumer can:
  * - Modify request options before calling `defaultRequester`
@@ -459,41 +461,11 @@ export type HttpRequest = {
  *
  * @param request - The resolved request options including `url`
  * @param defaultRequester - Executes the request through the normal pipeline
- * @param client - A client instance with the same configuration but without a `requestHandler`,
+ * @param client - A client instance with the same configuration but without a `_requestHandler`,
  *   useful for making side requests (e.g. token refresh) without triggering the handler recursively
  *
- * @example Add a custom header to every request
- * ```ts
- * const client = createClient({
- *   projectId: 'my-project',
- *   dataset: 'production',
- *   requestHandler: (request, defaultRequester) => {
- *     return defaultRequester({...request, headers: {...request.headers, 'X-Custom': 'value'}})
- *   },
- * })
- * ```
- *
- * @example Log requests and responses
- * ```ts
- * import {tap} from 'rxjs'
- *
- * const client = createClient({
- *   projectId: 'my-project',
- *   dataset: 'production',
- *   requestHandler: (request, defaultRequester) => {
- *     console.log('Request:', request.method, request.url)
- *     return defaultRequester(request).pipe(
- *       tap((event) => {
- *         if (event.type === 'response') {
- *           console.log('Response:', event.statusCode)
- *         }
- *       }),
- *     )
- *   },
- * })
- * ```
- *
- * @public
+ * @internal
+ * @deprecated Don't use outside of Sanity internals
  */
 export type RequestHandler = (
   request: RequestOptions & {url: string},

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@
 import type {Requester} from 'get-it'
 import type {Observable} from 'rxjs'
 
+import type {SanityClient} from './SanityClient'
 import type {InitializedStegaConfig, StegaConfig} from './stega/types'
 
 /**
@@ -441,18 +442,25 @@ export type HttpRequest = {
 /**
  * A function that intercepts HTTP requests made by the client.
  *
- * Receives the resolved request options and a `defaultRequester` function that
- * executes the request through the normal pipeline.
+ * Receives the resolved request options, a `defaultRequester` function that
+ * executes the request through the normal pipeline, and a `client` instance
+ * without a `requestHandler` (to avoid recursive interception).
  *
  * The consumer can:
  * - Modify request options before calling `defaultRequester`
  * - Transform the response stream (e.g. via `pipe`)
  * - Skip `defaultRequester` entirely and return a custom Observable
+ * - Use `client` to make additional requests (e.g. refresh an auth token on 401)
  *
  * When set via `withConfig()`, the new handler **replaces** (not wraps) the previous one.
  *
  * Note: This only applies to HTTP requests. Real-time listener connections
  * (`client.listen()`) use EventSource and are not intercepted by this handler.
+ *
+ * @param request - The resolved request options including `url`
+ * @param defaultRequester - Executes the request through the normal pipeline
+ * @param client - A client instance with the same configuration but without a `requestHandler`,
+ *   useful for making side requests (e.g. token refresh) without triggering the handler recursively
  *
  * @example Add a custom header to every request
  * ```ts
@@ -490,6 +498,7 @@ export type HttpRequest = {
 export type RequestHandler = (
   request: RequestOptions & {url: string},
   defaultRequester: (options: RequestOptions & {url: string}) => Observable<HttpRequestEvent>,
+  client: SanityClient,
 ) => Observable<HttpRequestEvent>
 
 /** @internal */

--- a/test/requestHandler.test.ts
+++ b/test/requestHandler.test.ts
@@ -1,0 +1,201 @@
+import {createClient, type RequestHandler, type RequestOptions} from '@sanity/client'
+import {firstValueFrom, map, of as observableOf} from 'rxjs'
+import {describe, expect, test, vi} from 'vitest'
+
+const apiHost = 'api.sanity.url'
+const defaultProjectId = 'bf1942'
+const projectHost = (projectId?: string) => `https://${projectId || defaultProjectId}.${apiHost}`
+const globalApiHost = `https://${apiHost}`
+const clientConfig = {
+  apiHost: globalApiHost,
+  projectId: 'bf1942',
+  apiVersion: '1',
+  dataset: 'foo',
+  useCdn: false,
+}
+
+describe('requestHandler', async () => {
+  const isEdge = typeof EdgeRuntime === 'string'
+  let nock: typeof import('nock') = (() => {
+    throw new Error('Not supported in EdgeRuntime')
+  }) as any
+  if (!isEdge) {
+    const _nock = await import('nock')
+    nock = _nock.default
+  }
+
+  test.skipIf(isEdge)('can add a custom header to every request', async () => {
+    let receivedHeaders: Record<string, string> = {}
+
+    nock(projectHost())
+      .get('/v1/ping')
+      .reply(function () {
+        receivedHeaders = this.req.headers as any
+        return [200, {pong: true}]
+      })
+
+    const handler: RequestHandler = (request, defaultRequester) => {
+      return defaultRequester({
+        ...request,
+        headers: {...request.headers, 'x-custom-header': 'custom-value'},
+      })
+    }
+
+    const client = createClient({...clientConfig, requestHandler: handler})
+    const result = await client.request({uri: '/ping'})
+
+    expect(result).toMatchObject({pong: true})
+    expect(receivedHeaders['x-custom-header']).toBe('custom-value')
+  })
+
+  test.skipIf(isEdge)('can pass through as a no-op wrapper', async () => {
+    nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+
+    const onRequest = vi.fn()
+    const handler: RequestHandler = (request, defaultRequester) => {
+      onRequest(request)
+      return defaultRequester(request)
+    }
+
+    const client = createClient({...clientConfig, requestHandler: handler})
+    const result = await client.request({uri: '/ping'})
+
+    expect(result).toMatchObject({pong: true})
+    expect(onRequest).toHaveBeenCalledTimes(1)
+    expect(onRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining('/v1/ping'),
+      }),
+    )
+  })
+
+  test.skipIf(isEdge)('can transform the response', async () => {
+    nock(projectHost()).get('/v1/ping').reply(200, {value: 42})
+
+    const handler: RequestHandler = (request, defaultRequester) => {
+      return defaultRequester(request).pipe(
+        map((event) => {
+          if (event.type === 'response') {
+            return {...event, body: {...(event.body as any), injected: true}}
+          }
+          return event
+        }),
+      )
+    }
+
+    const client = createClient({...clientConfig, requestHandler: handler})
+    const result = await client.request({uri: '/ping'})
+
+    expect(result).toMatchObject({value: 42, injected: true})
+  })
+
+  test.skipIf(isEdge)('can short-circuit and skip defaultRequester', async () => {
+    // No nock setup — the default requester should never be called
+    const handler: RequestHandler = () => {
+      return observableOf({
+        type: 'response' as const,
+        body: {custom: true},
+        url: 'https://example.com',
+        method: 'GET',
+        statusCode: 200,
+        statusMessage: 'OK',
+        headers: {},
+      })
+    }
+
+    const client = createClient({...clientConfig, requestHandler: handler})
+    const result = await client.request({uri: '/ping'})
+
+    expect(result).toMatchObject({custom: true})
+  })
+
+  test.skipIf(isEdge)('withConfig() preserves the handler from the original client', async () => {
+    let handlerCalled = false
+
+    nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+
+    const handler: RequestHandler = (request, defaultRequester) => {
+      handlerCalled = true
+      return defaultRequester(request)
+    }
+
+    const client = createClient({...clientConfig, requestHandler: handler})
+    const newClient = client.withConfig({dataset: 'bar'})
+
+    // The handler should still be called even though we used withConfig
+    const result = await newClient.request({uri: '/ping'})
+
+    expect(result).toMatchObject({pong: true})
+    expect(handlerCalled).toBe(true)
+  })
+
+  test.skipIf(isEdge)('handler receives resolved request options with url', async () => {
+    nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+
+    let receivedOptions: (RequestOptions & {url: string}) | undefined
+    const handler: RequestHandler = (request, defaultRequester) => {
+      receivedOptions = request
+      return defaultRequester(request)
+    }
+
+    const client = createClient({
+      ...clientConfig,
+      requestHandler: handler,
+    })
+    await client.request({uri: '/ping'})
+
+    expect(receivedOptions).toMatchObject({
+      url: expect.stringContaining('/v1/ping'),
+    })
+  })
+
+  test.skipIf(isEdge)('withConfig() can override the handler', async () => {
+    nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+    nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+
+    const originalHandler = vi.fn<RequestHandler>((request, defaultRequester) =>
+      defaultRequester(request),
+    )
+    const overrideHandler = vi.fn<RequestHandler>((request, defaultRequester) =>
+      defaultRequester(request),
+    )
+
+    const client = createClient({...clientConfig, requestHandler: originalHandler})
+    await client.request({uri: '/ping'})
+    expect(originalHandler).toHaveBeenCalledTimes(1)
+    expect(overrideHandler).toHaveBeenCalledTimes(0)
+
+    const newClient = client.withConfig({requestHandler: overrideHandler})
+    await newClient.request({uri: '/ping'})
+    expect(originalHandler).toHaveBeenCalledTimes(1) // not called again
+    expect(overrideHandler).toHaveBeenCalledTimes(1)
+  })
+
+  test.skipIf(isEdge)('withConfig() can remove the handler', async () => {
+    nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+
+    const handler = vi.fn<RequestHandler>((request, defaultRequester) => defaultRequester(request))
+
+    const client = createClient({...clientConfig, requestHandler: handler})
+    const newClient = client.withConfig({requestHandler: undefined})
+    await newClient.request({uri: '/ping'})
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test.skipIf(isEdge)('handler works with observable API', async () => {
+    nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+
+    const onRequest = vi.fn()
+    const handler: RequestHandler = (request, defaultRequester) => {
+      return defaultRequester(request)
+    }
+
+    const client = createClient({...clientConfig, requestHandler: handler})
+
+    const result = await firstValueFrom(client.observable.request({uri: '/ping'}))
+
+    expect(result).toMatchObject({pong: true})
+    expect(onRequest).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/requestHandler.test.ts
+++ b/test/requestHandler.test.ts
@@ -188,6 +188,7 @@ describe('requestHandler', async () => {
 
     const onRequest = vi.fn()
     const handler: RequestHandler = (request, defaultRequester) => {
+      onRequest()
       return defaultRequester(request)
     }
 

--- a/test/requestHandler.test.ts
+++ b/test/requestHandler.test.ts
@@ -1,4 +1,4 @@
-import {createClient, type RequestHandler, type RequestOptions} from '@sanity/client'
+import {createClient, type RequestHandler, type RequestOptions, type SanityClient} from '@sanity/client'
 import {firstValueFrom, map, of as observableOf} from 'rxjs'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -199,4 +199,37 @@ describe('requestHandler', async () => {
     expect(result).toMatchObject({pong: true})
     expect(onRequest).toHaveBeenCalledTimes(1)
   })
+
+  test.skipIf(isEdge)(
+    'handler receives a client without requestHandler for side requests',
+    async () => {
+      // First request returns 401, side request refreshes token, retry succeeds
+      nock(projectHost()).get('/v1/ping').reply(401, {error: 'Unauthorized'})
+      nock(projectHost()).get('/v1/auth/refresh').reply(200, {token: 'new-token'})
+      nock(projectHost()).get('/v1/ping').reply(200, {pong: true})
+
+      let bareClient: SanityClient | undefined
+      const handler: RequestHandler = (request, defaultRequester, client) => {
+        bareClient = client
+        return defaultRequester(request)
+      }
+
+      const client = createClient({...clientConfig, requestHandler: handler})
+
+      // The first request will fail with 401, but we just want to verify the bare client works
+      try {
+        await client.request({uri: '/ping'})
+      } catch {
+        // expected 401
+      }
+
+      // Verify the bare client is a SanityClient without the handler
+      expect(bareClient).toBeDefined()
+      expect(bareClient!.config().requestHandler).toBeUndefined()
+
+      // Verify the bare client can make requests (no handler interception)
+      const refreshResult = await bareClient!.request({uri: '/auth/refresh'})
+      expect(refreshResult).toMatchObject({token: 'new-token'})
+    },
+  )
 })

--- a/test/requestHandler.test.ts
+++ b/test/requestHandler.test.ts
@@ -1,4 +1,9 @@
-import {createClient, type RequestHandler, type RequestOptions, type SanityClient} from '@sanity/client'
+import {
+  createClient,
+  type RequestHandler,
+  type RequestOptions,
+  type SanityClient,
+} from '@sanity/client'
 import {firstValueFrom, map, of as observableOf} from 'rxjs'
 import {describe, expect, test, vi} from 'vitest'
 

--- a/test/requestHandler.test.ts
+++ b/test/requestHandler.test.ts
@@ -46,7 +46,7 @@ describe('requestHandler', async () => {
       })
     }
 
-    const client = createClient({...clientConfig, requestHandler: handler})
+    const client = createClient({...clientConfig, _requestHandler: handler})
     const result = await client.request({uri: '/ping'})
 
     expect(result).toMatchObject({pong: true})
@@ -62,7 +62,7 @@ describe('requestHandler', async () => {
       return defaultRequester(request)
     }
 
-    const client = createClient({...clientConfig, requestHandler: handler})
+    const client = createClient({...clientConfig, _requestHandler: handler})
     const result = await client.request({uri: '/ping'})
 
     expect(result).toMatchObject({pong: true})
@@ -88,7 +88,7 @@ describe('requestHandler', async () => {
       )
     }
 
-    const client = createClient({...clientConfig, requestHandler: handler})
+    const client = createClient({...clientConfig, _requestHandler: handler})
     const result = await client.request({uri: '/ping'})
 
     expect(result).toMatchObject({value: 42, injected: true})
@@ -108,7 +108,7 @@ describe('requestHandler', async () => {
       })
     }
 
-    const client = createClient({...clientConfig, requestHandler: handler})
+    const client = createClient({...clientConfig, _requestHandler: handler})
     const result = await client.request({uri: '/ping'})
 
     expect(result).toMatchObject({custom: true})
@@ -124,7 +124,7 @@ describe('requestHandler', async () => {
       return defaultRequester(request)
     }
 
-    const client = createClient({...clientConfig, requestHandler: handler})
+    const client = createClient({...clientConfig, _requestHandler: handler})
     const newClient = client.withConfig({dataset: 'bar'})
 
     // The handler should still be called even though we used withConfig
@@ -145,7 +145,7 @@ describe('requestHandler', async () => {
 
     const client = createClient({
       ...clientConfig,
-      requestHandler: handler,
+      _requestHandler: handler,
     })
     await client.request({uri: '/ping'})
 
@@ -165,12 +165,12 @@ describe('requestHandler', async () => {
       defaultRequester(request),
     )
 
-    const client = createClient({...clientConfig, requestHandler: originalHandler})
+    const client = createClient({...clientConfig, _requestHandler: originalHandler})
     await client.request({uri: '/ping'})
     expect(originalHandler).toHaveBeenCalledTimes(1)
     expect(overrideHandler).toHaveBeenCalledTimes(0)
 
-    const newClient = client.withConfig({requestHandler: overrideHandler})
+    const newClient = client.withConfig({_requestHandler: overrideHandler})
     await newClient.request({uri: '/ping'})
     expect(originalHandler).toHaveBeenCalledTimes(1) // not called again
     expect(overrideHandler).toHaveBeenCalledTimes(1)
@@ -181,8 +181,8 @@ describe('requestHandler', async () => {
 
     const handler = vi.fn<RequestHandler>((request, defaultRequester) => defaultRequester(request))
 
-    const client = createClient({...clientConfig, requestHandler: handler})
-    const newClient = client.withConfig({requestHandler: undefined})
+    const client = createClient({...clientConfig, _requestHandler: handler})
+    const newClient = client.withConfig({_requestHandler: undefined})
     await newClient.request({uri: '/ping'})
 
     expect(handler).not.toHaveBeenCalled()
@@ -197,7 +197,7 @@ describe('requestHandler', async () => {
       return defaultRequester(request)
     }
 
-    const client = createClient({...clientConfig, requestHandler: handler})
+    const client = createClient({...clientConfig, _requestHandler: handler})
 
     const result = await firstValueFrom(client.observable.request({uri: '/ping'}))
 
@@ -219,7 +219,7 @@ describe('requestHandler', async () => {
         return defaultRequester(request)
       }
 
-      const client = createClient({...clientConfig, requestHandler: handler})
+      const client = createClient({...clientConfig, _requestHandler: handler})
 
       // The first request will fail with 401, but we just want to verify the bare client works
       try {
@@ -230,7 +230,7 @@ describe('requestHandler', async () => {
 
       // Verify the bare client is a SanityClient without the handler
       expect(bareClient).toBeDefined()
-      expect(bareClient!.config().requestHandler).toBeUndefined()
+      expect(bareClient!.config()._requestHandler).toBeUndefined()
 
       // Verify the bare client can make requests (no handler interception)
       const refreshResult = await bareClient!.request({uri: '/auth/refresh'})


### PR DESCRIPTION
### Description

  Adds a `requestHandler` config option that lets consumers intercept HTTP requests for logging, custom headers, auth token refresh, metrics, rate limiting, etc. My primary use case for this is to improve handling of expired token, cors checks etc. in the Studio. Happy to make it hidden/private if we want to reduce public exposure/dependence of request options, etc.

I did consider the deprecated `requester` config, but that seems to tie us to get-it internals, which I'd like to avoid.

Example:
```ts
const client = createClient({
  projectId: 'my-project',
  dataset: 'production',
  requestHandler: (request, defaultRequester, client) => {
    return defaultRequester({
      ...request,
      headers: {...request.headers, 'CustomHeader': 'value'},
    })
  },
})
```

  The handler receives resolved request options, a `defaultRequester` that executes the request through the normal get-it pipeline, and a `client` instance without a `requestHandler` for making  side requests (e.g. token refresh on 401) without recursive interception. Consumers can modify requests, transform responses, or skip the default requester entirely.

- Works with both promise and observable APIs
- `withConfig()` can override or remove the handler (replaces, does not wrap)
- Does not apply to `client.listen()`
- The bare `client` is lazily created on first handler invocation

### What to review 
- `src/types.ts` — `RequestHandler` type and `requestHandler` config option (does the naming make sense?)
- `src/SanityClient.ts` — handler applied in constructors of both client classes, `#originalHttpRequest` stored so `clone()`/`withConfig()` can re-wrap
 
### Testing
New test file covering: custom header injection, no-op passthrough, response transformation, short-circuit, `withConfig()` override/remove/preserve, bare client for side requests, and observable API compatibility.

Note: implemented by claude, reviewed by me.