### PR TITLE
feat(live): add waitFor option to defer events until Sanity Function processing

### DIFF
--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -35,6 +35,7 @@ export class LiveClient {
   events({
     includeDrafts = false,
     tag: _tag,
+    waitFor,
   }: {
     includeDrafts?: boolean
     /**
@@ -43,6 +44,11 @@ export class LiveClient {
      * @defaultValue `undefined`
      */
     tag?: string
+    /**
+     * Delays events until after a Sanity Function has processed them and called the callback endpoint.
+     * When omitted, events are delivered immediately.
+     */
+    waitFor?: 'function'
   } = {}): Observable<LiveEvent> {
     const {
       projectId,
@@ -73,6 +79,9 @@ export class LiveClient {
     }
     if (includeDrafts) {
       url.searchParams.set('includeDrafts', 'true')
+    }
+    if (waitFor) {
+      url.searchParams.set('waitFor', waitFor)
     }
     const esOptions: EventSourceInit & {headers?: Record<string, string>} = {}
     if (includeDrafts && withCredentials) {


### PR DESCRIPTION
### Description

Adds a new `waitFor` option to LiveClient.events() that accepts 'function' as its value. When set, the live events stream delays delivery until after a Sanity Function has processed the event and called the callback endpoint. 

When `waitFor` is omitted (default), events continue to be delivered immediately — no behavior change for existing consumers.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
