### PR TITLE
feat(error): expose trace id from backend responses

### DIFF
--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -95,14 +95,14 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
     response: res,
     statusCode: res.statusCode,
     responseBody: stringifyBody(body, res),
-    traceId: traceId(res),
+    traceId: extractTraceId(res),
     message: '',
     details: undefined as Any,
   }
 
   // Fall back early if we didn't get a JSON object returned as expected
   if (!isRecord(body)) {
-    props.message = httpErrorMessage(res, body)
+    props.message = `${httpErrorMessage(res, body)}${formatTraceId(props.traceId)}`
     return props
   }
 
@@ -110,18 +110,18 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
 
   // API/Boom style errors ({statusCode, error, message})
   if (typeof error === 'string' && typeof body.message === 'string') {
-    props.message = `${error} - ${body.message}`
+    props.message = `${error} - ${body.message}${formatTraceId(props.traceId)}`
     return props
   }
 
   // Content Lake errors with a `error` prop being an object
   if (typeof error !== 'object' || error === null) {
     if (typeof error === 'string') {
-      props.message = error
+      props.message = `${error}${formatTraceId(props.traceId)}`
     } else if (typeof body.message === 'string') {
-      props.message = body.message
+      props.message = `${body.message}${formatTraceId(props.traceId)}`
     } else {
-      props.message = httpErrorMessage(res, body)
+      props.message = `${httpErrorMessage(res, body)}${formatTraceId(props.traceId)}`
     }
     return props
   }
@@ -137,7 +137,7 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
     if (allItems.length > MAX_ITEMS_IN_ERROR_MESSAGE) {
       itemsStr += `\n...and ${allItems.length - MAX_ITEMS_IN_ERROR_MESSAGE} more`
     }
-    props.message = `${error.description}${itemsStr}`
+    props.message = `${error.description}${formatTraceId(props.traceId)}${itemsStr}`
     props.details = body.error
     return props
   }
@@ -145,20 +145,20 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
   // Query parse errors
   if (isQueryParseError(error)) {
     const tag = context?.options?.query?.tag
-    props.message = formatQueryParseError(error, tag)
+    props.message = formatQueryParseError(error, tag, props.traceId)
     props.details = body.error
     return props
   }
 
   if ('description' in error && typeof error.description === 'string') {
     // Query/database errors ({error: {description, other, arb, props}})
-    props.message = error.description
+    props.message = `${error.description}${formatTraceId(props.traceId)}`
     props.details = error
     return props
   }
 
   // Other, more arbitrary errors
-  props.message = httpErrorMessage(res, body)
+  props.message = `${httpErrorMessage(res, body)}${formatTraceId(props.traceId)}`
   return props
 }
 
@@ -199,17 +199,22 @@ export function isQueryParseError(error: object): error is QueryParseError {
  * @returns A formatted error message string.
  * @public
  */
-export function formatQueryParseError(error: QueryParseError, tag?: string | null) {
+export function formatQueryParseError(
+  error: QueryParseError,
+  tag?: string | null,
+  traceId?: string,
+) {
   const {query, start, end, description} = error
+  const withTraceId = traceId ? `\nTraceId: ${traceId}` : ''
 
   if (!query || typeof start === 'undefined') {
-    return `GROQ query parse error: ${description}`
+    return `GROQ query parse error: ${description}${withTraceId}`
   }
 
   const withTag = tag ? `\n\nTag: ${tag}` : ''
   const framed = codeFrame(query, {start, end}, description)
 
-  return `GROQ query parse error:\n${framed}${withTag}`
+  return `GROQ query parse error:\n${framed}${withTag}${withTraceId}`
 }
 
 function httpErrorMessage(res: Any, body: unknown) {
@@ -228,7 +233,7 @@ function httpErrorMessage(res: Any, body: unknown) {
  * @see https://www.w3.org/TR/trace-context/
  * @returns The traceId for HTTP response
  */
-function traceId(res: Any): string | undefined {
+function extractTraceId(res: Any): string | undefined {
   const traceparent = res?.headers?.['traceparent']
   if (!traceparent) return
 
@@ -239,6 +244,10 @@ function stringifyBody(body: Any, res: Any) {
   const contentType = (res.headers['content-type'] || '').toLowerCase()
   const isJson = contentType.indexOf('application/json') !== -1
   return isJson ? JSON.stringify(body, null, 2) : body
+}
+
+function formatTraceId(traceId: string | undefined): string {
+  return traceId ? ` (traceId: ${traceId})` : ''
 }
 
 function sliceWithEllipsis(str: string, max: number) {

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -95,14 +95,14 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
     response: res,
     statusCode: res.statusCode,
     responseBody: stringifyBody(body, res),
-    traceId: traceId(res),
+    traceId: extractTraceId(res),
     message: '',
     details: undefined as Any,
   }
 
   // Fall back early if we didn't get a JSON object returned as expected
   if (!isRecord(body)) {
-    props.message = httpErrorMessage(res, body)
+    props.message = `${httpErrorMessage(res, body)}${formatTraceId(props.traceId)}`
     return props
   }
 
@@ -110,18 +110,18 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
 
   // API/Boom style errors ({statusCode, error, message})
   if (typeof error === 'string' && typeof body.message === 'string') {
-    props.message = `${error} - ${body.message}`
+    props.message = `${error} - ${body.message}${formatTraceId(props.traceId)}`
     return props
   }
 
   // Content Lake errors with a `error` prop being an object
   if (typeof error !== 'object' || error === null) {
     if (typeof error === 'string') {
-      props.message = error
+      props.message = `${error}${formatTraceId(props.traceId)}`
     } else if (typeof body.message === 'string') {
-      props.message = body.message
+      props.message = `${body.message}${formatTraceId(props.traceId)}`
     } else {
-      props.message = httpErrorMessage(res, body)
+      props.message = `${httpErrorMessage(res, body)}${formatTraceId(props.traceId)}`
     }
     return props
   }
@@ -137,7 +137,7 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
     if (allItems.length > MAX_ITEMS_IN_ERROR_MESSAGE) {
       itemsStr += `\n...and ${allItems.length - MAX_ITEMS_IN_ERROR_MESSAGE} more`
     }
-    props.message = `${error.description}${itemsStr}`
+    props.message = `${error.description}${formatTraceId(props.traceId)}${itemsStr}`
     props.details = body.error
     return props
   }
@@ -145,20 +145,20 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
   // Query parse errors
   if (isQueryParseError(error)) {
     const tag = context?.options?.query?.tag
-    props.message = formatQueryParseError(error, tag)
+    props.message = formatQueryParseError(error, tag, props.traceId)
     props.details = body.error
     return props
   }
 
   if ('description' in error && typeof error.description === 'string') {
     // Query/database errors ({error: {description, other, arb, props}})
-    props.message = error.description
+    props.message = `${error.description}${formatTraceId(props.traceId)}`
     props.details = error
     return props
   }
 
   // Other, more arbitrary errors
-  props.message = httpErrorMessage(res, body)
+  props.message = `${httpErrorMessage(res, body)}${formatTraceId(props.traceId)}`
   return props
 }
 
@@ -199,17 +199,22 @@ export function isQueryParseError(error: object): error is QueryParseError {
  * @returns A formatted error message string.
  * @public
  */
-export function formatQueryParseError(error: QueryParseError, tag?: string | null) {
+export function formatQueryParseError(
+  error: QueryParseError,
+  tag?: string | null,
+  traceId?: string,
+) {
   const {query, start, end, description} = error
+  const withTraceId = traceId ? `\n(traceId: ${traceId})` : ''
 
   if (!query || typeof start === 'undefined') {
-    return `GROQ query parse error: ${description}`
+    return `GROQ query parse error: ${description}${withTraceId}`
   }
 
   const withTag = tag ? `\n\nTag: ${tag}` : ''
   const framed = codeFrame(query, {start, end}, description)
 
-  return `GROQ query parse error:\n${framed}${withTag}`
+  return `GROQ query parse error:\n${framed}${withTag}${withTraceId}`
 }
 
 function httpErrorMessage(res: Any, body: unknown) {
@@ -228,7 +233,7 @@ function httpErrorMessage(res: Any, body: unknown) {
  * @see https://www.w3.org/TR/trace-context/
  * @returns The traceId for HTTP response
  */
-function traceId(res: Any): string | undefined {
+function extractTraceId(res: Any): string | undefined {
   const traceparent = res?.headers?.['traceparent']
   if (!traceparent) return
 
@@ -239,6 +244,10 @@ function stringifyBody(body: Any, res: Any) {
   const contentType = (res.headers['content-type'] || '').toLowerCase()
   const isJson = contentType.indexOf('application/json') !== -1
   return isJson ? JSON.stringify(body, null, 2) : body
+}
+
+function formatTraceId(traceId: string | undefined): string {
+  return traceId ? ` (traceId: ${traceId})` : ''
 }
 
 function sliceWithEllipsis(str: string, max: number) {

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -64,6 +64,7 @@ export class ClientError extends Error {
   response: ErrorProps['response']
   statusCode: ErrorProps['statusCode'] = 400
   responseBody: ErrorProps['responseBody']
+  traceId: ErrorProps['traceId']
   details: ErrorProps['details']
 
   constructor(res: Any, context?: HttpContext) {
@@ -78,6 +79,7 @@ export class ServerError extends Error {
   response: ErrorProps['response']
   statusCode: ErrorProps['statusCode'] = 500
   responseBody: ErrorProps['responseBody']
+  traceId: ErrorProps['traceId']
   details: ErrorProps['details']
 
   constructor(res: Any) {
@@ -93,6 +95,7 @@ function extractErrorProps(res: Any, context?: HttpContext): ErrorProps {
     response: res,
     statusCode: res.statusCode,
     responseBody: stringifyBody(body, res),
+    traceId: traceId(res),
     message: '',
     details: undefined as Any,
   }
@@ -213,6 +216,23 @@ function httpErrorMessage(res: Any, body: unknown) {
   const details = typeof body === 'string' ? ` (${sliceWithEllipsis(body, 100)})` : ''
   const statusMessage = res.statusMessage ? ` ${res.statusMessage}` : ''
   return `${res.method}-request to ${res.url} resulted in HTTP ${res.statusCode}${statusMessage}${details}`
+}
+
+/**
+ * Extract the traceId from the traceparent header on the response.
+ *
+ * The traceparent is on the format [version]-[traceId]-[parentId]-[traceFlags], but
+ * when debugging end-user issues it's the traceId we need to be able to get hold of
+ * the relevant traces.
+ *
+ * @see https://www.w3.org/TR/trace-context/
+ * @returns The traceId for HTTP response
+ */
+function traceId(res: Any): string | undefined {
+  const traceparent = res?.headers?.['traceparent']
+  if (!traceparent) return
+
+  return traceparent.split('-')[1]
 }
 
 function stringifyBody(body: Any, res: Any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -433,6 +433,7 @@ export interface ErrorProps {
   response: Any
   statusCode: number
   responseBody: Any
+  traceId?: string
   details: Any
 }
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -248,6 +248,106 @@ describe('traceId', () => {
   })
 })
 
+describe('traceId in error messages', () => {
+  const traceId = '0af7651916cd43dd8448eb211c80319c'
+  const headers = {traceparent: `00-${traceId}-b7ad6b7169203331-01`}
+  const headersNoTrace = {}
+
+  test('includes traceId in non-JSON body errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: 'Bad Request',
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers,
+    })
+    expect(err.message).toContain(`(traceId: ${traceId})`)
+  })
+
+  test('includes traceId in API/Boom style errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {statusCode: 400, error: 'Bad Request', message: 'Invalid parameters'},
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe(`Bad Request - Invalid parameters (traceId: ${traceId})`)
+  })
+
+  test('includes traceId in mutation errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {
+        error: {
+          type: 'mutationError',
+          description: 'Mutation failed',
+          items: [{error: {description: 'Document not found'}}],
+        },
+      },
+      url: 'https://api.sanity.io/v1/data/mutate',
+      method: 'POST',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe(`Mutation failed (traceId: ${traceId}):\n- Document not found`)
+  })
+
+  test('includes traceId in query parse errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {
+        error: {
+          type: 'queryParseError',
+          query: '*[_type == "event]',
+          description: 'unexpected token',
+          start: 11,
+          end: 18,
+        },
+      },
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toContain('GROQ query parse error:')
+    expect(err.message).toContain(`TraceId: ${traceId}`)
+  })
+
+  test('includes traceId in generic description errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {
+        error: {description: 'Something went wrong'},
+      },
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe(`Something went wrong (traceId: ${traceId})`)
+  })
+
+  test('includes traceId in fallback errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {error: {unexpected: 'shape'}},
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toContain(`(traceId: ${traceId})`)
+  })
+
+  test('omits traceId from message when traceparent header is missing', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {statusCode: 400, error: 'Bad Request', message: 'Invalid parameters'},
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headersNoTrace, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe('Bad Request - Invalid parameters')
+  })
+})
+
 describe('isHttpError', () => {
   const res = {headers: {}, body: '', url: 'https://api.sanity.io/v1/data/query', method: 'GET'}
   const clientErr = new ClientError({statusCode: 400, ...res}) satisfies HttpError

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -206,6 +206,48 @@ describe('http errors', async () => {
   })
 })
 
+describe('traceId', () => {
+  const baseRes = {
+    statusCode: 400,
+    body: 'Bad Request',
+    url: 'https://api.sanity.io/v1/data/query',
+    method: 'GET',
+  }
+
+  test('extracts traceId from traceparent header', () => {
+    const err = new ClientError({
+      ...baseRes,
+      headers: {traceparent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01'},
+    })
+    expect(err).toHaveProperty('traceId', '0af7651916cd43dd8448eb211c80319c')
+  })
+
+  test('traceId is undefined when traceparent header is missing', () => {
+    const err = new ClientError({
+      ...baseRes,
+      headers: {},
+    })
+    expect(err).toHaveProperty('traceId', undefined)
+  })
+
+  test('traceId is undefined when no headers are set', () => {
+    const err = new ClientError({
+      ...baseRes,
+      headers: {'content-type': 'text/plain'},
+    })
+    expect(err).toHaveProperty('traceId', undefined)
+  })
+
+  test('extracts traceId on ServerError', () => {
+    const err = new ServerError({
+      ...baseRes,
+      statusCode: 500,
+      headers: {traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'},
+    })
+    expect(err).toHaveProperty('traceId', '4bf92f3577b34da6a3ce929d0e0e4736')
+  })
+})
+
 describe('isHttpError', () => {
   const res = {headers: {}, body: '', url: 'https://api.sanity.io/v1/data/query', method: 'GET'}
   const clientErr = new ClientError({statusCode: 400, ...res}) satisfies HttpError

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -248,6 +248,106 @@ describe('traceId', () => {
   })
 })
 
+describe('traceId in error messages', () => {
+  const traceId = '0af7651916cd43dd8448eb211c80319c'
+  const headers = {traceparent: `00-${traceId}-b7ad6b7169203331-01`}
+  const headersNoTrace = {}
+
+  test('includes traceId in non-JSON body errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: 'Bad Request',
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers,
+    })
+    expect(err.message).toContain(`(traceId: ${traceId})`)
+  })
+
+  test('includes traceId in API/Boom style errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {statusCode: 400, error: 'Bad Request', message: 'Invalid parameters'},
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe(`Bad Request - Invalid parameters (traceId: ${traceId})`)
+  })
+
+  test('includes traceId in mutation errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {
+        error: {
+          type: 'mutationError',
+          description: 'Mutation failed',
+          items: [{error: {description: 'Document not found'}}],
+        },
+      },
+      url: 'https://api.sanity.io/v1/data/mutate',
+      method: 'POST',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe(`Mutation failed (traceId: ${traceId}):\n- Document not found`)
+  })
+
+  test('includes traceId in query parse errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {
+        error: {
+          type: 'queryParseError',
+          query: '*[_type == "event]',
+          description: 'unexpected token',
+          start: 11,
+          end: 18,
+        },
+      },
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toContain('GROQ query parse error:')
+    expect(err.message).toContain(`traceId: ${traceId}`)
+  })
+
+  test('includes traceId in generic description errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {
+        error: {description: 'Something went wrong'},
+      },
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe(`Something went wrong (traceId: ${traceId})`)
+  })
+
+  test('includes traceId in fallback errors', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {error: {unexpected: 'shape'}},
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headers, 'content-type': 'application/json'},
+    })
+    expect(err.message).toContain(`(traceId: ${traceId})`)
+  })
+
+  test('omits traceId from message when traceparent header is missing', () => {
+    const err = new ClientError({
+      statusCode: 400,
+      body: {statusCode: 400, error: 'Bad Request', message: 'Invalid parameters'},
+      url: 'https://api.sanity.io/v1/data/query',
+      method: 'GET',
+      headers: {...headersNoTrace, 'content-type': 'application/json'},
+    })
+    expect(err.message).toBe('Bad Request - Invalid parameters')
+  })
+})
+
 describe('isHttpError', () => {
   const res = {headers: {}, body: '', url: 'https://api.sanity.io/v1/data/query', method: 'GET'}
   const clientErr = new ClientError({statusCode: 400, ...res}) satisfies HttpError


### PR DESCRIPTION
## Summary

Expose the W3C `traceparent` trace ID on `ClientError` and `ServerError` for correlating client errors with backend traces.

## What changed

`extractErrorProps` parses the `traceparent` header and extracts the trace ID segment. Added `traceId` to `ErrorProps` and both error classes.

## Why

Makes it easy to go from a client-side error to the corresponding backend trace without digging through response headers.

Kong returns a `traceparent` containing the information we need but to be able to surface it in a sensible way we need to expose it through the error from the client. The end goal is to make it easier to debug end-user issues by making it easier for them to find and provide us with the trace ID.

## Testing

Unit tests for trace ID extraction on both error classes, including missing/absent header cases.