### PR TITLE
fix(live): verify CORS via /check/cors (credentials-aware) before reporting CorsOriginError

### DIFF
--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -124,7 +124,8 @@ export class LiveClient {
 
     const checkCors = checkCorsObservable(
       new URL(this.#client.getUrl('/check/cors', false)),
-      projectId!,
+      projectId,
+      esOptions.withCredentials === true,
     )
 
     const observable = events
@@ -177,14 +178,25 @@ export class LiveClient {
  * so we use this side-channel purely to tell "the server actively rejected our
  * origin" apart from every other class of failure.
  *
- * Errors with `CorsOriginError` only when `/check/cors` responds with
- * `result.allowed === false`. Every other outcome is intentionally treated as
- * "we don't know": the observable emits a single `void` value and then
- * completes, so downstream `mergeMap(() => ...)` consumers can continue. No
- * error is surfaced for any of these cases:
+ * Errors with `CorsOriginError` when either:
  *
- * - `allowed: true` or an unrecognised body shape: the server did not confirm
- *   a CORS rejection.
+ * - `requireCredentials` is `true` (the EventSource was about to send
+ *   credentials) and `/check/cors` reports `result.withCredentials === false`.
+ *   The credentialed request would fail due to a missing
+ *   `access-control-allow-credentials` header. The resulting error carries
+ *   `credentials: true` so its `addOriginUrl` deep-link pre-selects the
+ *   "Allow credentials" toggle in the Sanity management form.
+ * - `/check/cors` reports `result.allowed === false` (origin is not on the
+ *   project's CORS allow-list). The error carries `credentials: requireCredentials`
+ *   so the deep-link still pre-selects credentials when the caller needed them.
+ *
+ * Every other outcome is intentionally treated as "we don't know": the
+ * observable emits a single `void` value and then completes, so downstream
+ * `mergeMap(() => ...)` consumers can continue. No error is surfaced for any
+ * of these cases:
+ *
+ * - `allowed: true` (with credentials satisfied if required) or an
+ *   unrecognised body shape: the server did not confirm a CORS rejection.
  * - Non-2xx HTTP response from `/check/cors`: same - no signal either way, and
  *   a 5xx on the probe shouldn't poison the EventSource's original error.
  * - `fetch` / network / JSON parse failures: indistinguishable from ordinary
@@ -196,7 +208,11 @@ export class LiveClient {
  * In all of those cases the caller's original underlying error from the
  * EventSource is allowed to propagate unchanged.
  */
-function checkCorsObservable(url: URL, projectId: string): Observable<void> {
+function checkCorsObservable(
+  url: URL,
+  projectId: string | undefined,
+  requireCredentials: boolean,
+): Observable<void> {
   return new Observable<void>((observer) => {
     const controller = new AbortController()
     const {signal} = controller
@@ -205,17 +221,32 @@ function checkCorsObservable(url: URL, projectId: string): Observable<void> {
         // Aborted or non-2xx: not a confirmed CORS rejection. Fall through with
         // an undefined body so the next step takes the silent-completion path.
         if (signal.aborted || !response.ok) return
-        return response.json() as Promise<{result?: {allowed?: boolean}}>
+        return response.json() as Promise<{
+          result?: {allowed?: boolean; withCredentials?: boolean}
+        }>
       })
       .then((body) => {
         if (signal.aborted) return
-        if (body?.result?.allowed === false) {
-          observer.error(new CorsOriginError({projectId}))
+        // Check the credentialed case first: if the EventSource was about to
+        // send credentials but the project's CORS config doesn't permit them,
+        // the credentialed request would fail with a missing
+        // `access-control-allow-credentials` header. Surface this as a CORS
+        // rejection with `credentials: true` so the deep-link pre-selects the
+        // "Allow credentials" toggle.
+        if (requireCredentials && body?.result?.withCredentials === false) {
+          observer.error(new CorsOriginError({projectId, credentials: true}))
           return
         }
-        // Anything other than an explicit `allowed: false` is treated as
-        // "not a confirmed CORS rejection" - let the caller's original error
-        // surface instead.
+        // Generic case: the server actively rejected this origin. Propagate
+        // `credentials: requireCredentials` so the deep-link still pre-selects
+        // credentials when the caller needed them.
+        if (body?.result?.allowed === false) {
+          observer.error(new CorsOriginError({projectId, credentials: requireCredentials}))
+          return
+        }
+        // Anything else (allowed + credentials satisfied, unrecognised body)
+        // is treated as "not a confirmed CORS rejection" - let the caller's
+        // original error surface instead.
         observer.next()
         observer.complete()
       })

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -1,4 +1,4 @@
-import {catchError, mergeMap, Observable, of} from 'rxjs'
+import {catchError, mergeMap, Observable, of, throwError} from 'rxjs'
 import {finalize, map} from 'rxjs/operators'
 
 import {CorsOriginError} from '../http/errors'
@@ -122,16 +122,9 @@ export class LiveClient {
       'goaway',
     ])
 
-    const checkCors = fetchObservable(url, {
-      method: 'OPTIONS',
-      mode: 'cors',
-      credentials: esOptions.withCredentials ? 'include' : 'omit',
-      headers: esOptions.headers,
-    }).pipe(
-      catchError(() => {
-        // If the request fails, then we assume it was due to CORS, and we rethrow a special error that allows special handling in userland
-        throw new CorsOriginError({projectId: projectId!})
-      }),
+    const checkCors = checkCorsObservable(
+      new URL(this.#client.getUrl('/check/cors', false)),
+      projectId!,
     )
 
     const observable = events
@@ -145,6 +138,12 @@ export class LiveClient {
           return of(event)
         }),
         catchError((err) => {
+          // If a prior `reconnect` already ran the CORS probe and produced a
+          // `CorsOriginError`, just rethrow it instead of calling `/check/cors`
+          // a second time only to get the same answer.
+          if (err instanceof CorsOriginError) {
+            return throwError(() => err)
+          }
           return checkCors.pipe(
             mergeMap(() => {
               // rethrow the original error if checkCors passed
@@ -172,21 +171,62 @@ export class LiveClient {
   }
 }
 
-function fetchObservable(url: URL, init: RequestInit) {
-  return new Observable((observer) => {
+/**
+ * Probes the `/check/cors` endpoint to confirm whether the current origin is
+ * allowed by the project's CORS configuration. EventSource failures are opaque,
+ * so we use this side-channel purely to tell "the server actively rejected our
+ * origin" apart from every other class of failure.
+ *
+ * Errors with `CorsOriginError` only when `/check/cors` responds with
+ * `result.allowed === false`. Every other outcome is intentionally treated as
+ * "we don't know": the observable emits a single `void` value and then
+ * completes, so downstream `mergeMap(() => ...)` consumers can continue. No
+ * error is surfaced for any of these cases:
+ *
+ * - `allowed: true` or an unrecognised body shape: the server did not confirm
+ *   a CORS rejection.
+ * - Non-2xx HTTP response from `/check/cors`: same - no signal either way, and
+ *   a 5xx on the probe shouldn't poison the EventSource's original error.
+ * - `fetch` / network / JSON parse failures: indistinguishable from ordinary
+ *   connectivity hiccups (offline, DNS, certs, transient outages). Reporting
+ *   those as CORS errors is exactly the false-positive class this helper
+ *   exists to prevent.
+ * - The subscription was aborted: nothing to emit and nothing to complete.
+ *
+ * In all of those cases the caller's original underlying error from the
+ * EventSource is allowed to propagate unchanged.
+ */
+function checkCorsObservable(url: URL, projectId: string): Observable<void> {
+  return new Observable<void>((observer) => {
     const controller = new AbortController()
-    const signal = controller.signal
-    fetch(url, {...init, signal: controller.signal}).then(
-      (response) => {
-        observer.next(response)
-        observer.complete()
-      },
-      (err) => {
-        if (!signal.aborted) {
-          observer.error(err)
+    const {signal} = controller
+    fetch(url, {method: 'GET', mode: 'cors', credentials: 'omit', signal})
+      .then((response) => {
+        // Aborted or non-2xx: not a confirmed CORS rejection. Fall through with
+        // an undefined body so the next step takes the silent-completion path.
+        if (signal.aborted || !response.ok) return
+        return response.json() as Promise<{result?: {allowed?: boolean}}>
+      })
+      .then((body) => {
+        if (signal.aborted) return
+        if (body?.result?.allowed === false) {
+          observer.error(new CorsOriginError({projectId}))
+          return
         }
-      },
-    )
+        // Anything other than an explicit `allowed: false` is treated as
+        // "not a confirmed CORS rejection" - let the caller's original error
+        // surface instead.
+        observer.next()
+        observer.complete()
+      })
+      // Fetch/network/JSON parse errors are intentionally ignored - see the
+      // helper's docblock for the rationale. We still need to settle the
+      // observer so downstream `mergeMap(checkCors, ...)` consumers can proceed.
+      .catch(() => {
+        if (signal.aborted || observer.closed) return
+        observer.next()
+        observer.complete()
+      })
     return () => controller.abort()
   })
 }

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -256,23 +256,33 @@ function sliceWithEllipsis(str: string, max: number) {
 
 /** @public */
 export class CorsOriginError extends Error {
-  projectId: string
+  projectId?: string
   addOriginUrl?: URL
 
-  constructor({projectId}: {projectId: string}) {
+  constructor({projectId, credentials}: {projectId?: string; credentials?: boolean} = {}) {
     super('CorsOriginError')
     this.name = 'CorsOriginError'
     this.projectId = projectId
 
-    const url = new URL(`https://sanity.io/manage/project/${projectId}/api`)
-    if (typeof location !== 'undefined') {
+    // Only build a deep-link when we know which project the user needs to
+    // configure - without `projectId` the management URL can't actually route
+    // them anywhere useful.
+    if (projectId && typeof location !== 'undefined') {
+      const url = new URL(`https://sanity.io/manage/project/${projectId}/api`)
       const {origin} = location
       url.searchParams.set('cors', 'add')
       url.searchParams.set('origin', origin)
+      if (credentials) {
+        // Pre-selects the "Allow credentials (token-based auth)" toggle in
+        // the Sanity management CORS form.
+        url.searchParams.set('credentials', '')
+      }
       this.addOriginUrl = url
       this.message = `The current origin is not allowed to connect to the Live Content API. Add it here: ${url}`
+    } else if (projectId) {
+      this.message = `The current origin is not allowed to connect to the Live Content API. Change your configuration here: https://sanity.io/manage/project/${projectId}/api`
     } else {
-      this.message = `The current origin is not allowed to connect to the Live Content API. Change your configuration here: ${url}`
+      this.message = `The current origin is not allowed to connect to the Live Content API.`
     }
   }
 }

--- a/test/helpers/sseServer.ts
+++ b/test/helpers/sseServer.ts
@@ -11,6 +11,15 @@ export type OnRequest = (options: {
 export const createSseServer = (onRequest: OnRequest): Promise<http.Server> =>
   new Promise((resolve, reject) => {
     const server = http.createServer((request, response) => {
+      // Respond to the CORS-check endpoint with a permissive `allowed: true` so
+      // tests that trigger reconnect/error paths in `live.events()` don't hang
+      // on a missing `/check/cors` handler.
+      if (/\/check\/cors$/.test(request?.url || '')) {
+        response.writeHead(200, {'content-type': 'application/json'})
+        response.end(JSON.stringify({result: {allowed: true, withCredentials: false}}))
+        return
+      }
+
       let channel
       if (
         request?.url?.indexOf('/v1/data/listen/') === 0 ||

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -364,6 +364,84 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect(checkCorsHits).toBeGreaterThan(0)
     })
 
+    test('reports CorsOriginError when EventSource needs credentials but /check/cors reports withCredentials: false', async () => {
+      // Regression for the principal-engineer feedback: an origin can be
+      // allow-listed without credentials, in which case `allowed: true` alone
+      // doesn't guarantee the credentialed EventSource request will succeed.
+      // We must treat `withCredentials: false` as a CORS rejection when the
+      // caller subscribed with credentials, and surface a deep-link that
+      // pre-selects "Allow credentials" in the management form.
+      expect.assertions(3)
+
+      const {default: nock} = await import('nock')
+
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: false}}),
+        ),
+      )
+
+      nock('https://abc123.api.sanity.io')
+        .get('/vX/data/live/events/creds-not-allowed?includeDrafts=true')
+        .reply(403, '')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'creds-not-allowed',
+        useCdn: false,
+        apiVersion: 'X',
+        withCredentials: true,
+        // `withCredentials` alone doesn't activate `esOptions.withCredentials` -
+        // the implementation only sets it when `includeDrafts: true` is also
+        // passed at call time.
+      })
+
+      // `CorsOriginError.addOriginUrl` is only constructed when `location` is
+      // available (i.e. in browser-ish environments). Stub it here so we can
+      // assert the `credentials=` query param ends up on the deep-link.
+      vitest.stubGlobal('location', {origin: 'https://example.com'})
+      try {
+        const error = (await firstValueFrom(
+          client.live.events({includeDrafts: true}).pipe(catchError((err) => of(err))),
+        )) as CorsOriginError
+        expect(error).toBeInstanceOf(CorsOriginError)
+        expect(error.addOriginUrl?.searchParams.get('credentials')).toBe('')
+        expect(error.addOriginUrl?.searchParams.get('origin')).toBe('https://example.com')
+      } finally {
+        vitest.unstubAllGlobals()
+      }
+    })
+
+    test('does not report CorsOriginError when /check/cors reports allowed: true, withCredentials: true and the EventSource needs credentials', async () => {
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: true}}),
+        ),
+      )
+
+      nock('https://abc123.api.sanity.io')
+        .get('/vX/data/live/events/creds-ok?includeDrafts=true')
+        .reply(500, 'Internal Server Error')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'creds-ok',
+        useCdn: false,
+        apiVersion: 'X',
+        withCredentials: true,
+      })
+
+      const event = await firstValueFrom(
+        client.live.events({includeDrafts: true}).pipe(catchError((err) => of(err))),
+      )
+      expect(event).not.toBeInstanceOf(CorsOriginError)
+      expect(event.type).toBe('reconnect')
+    })
+
     test('can immediately unsubscribe, does not connect to server', async () => {
       const onMessage = vitest.fn()
       const onError = vitest.fn()

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -28,16 +28,7 @@ const testSse = async (onRequest: OnRequest, options: ClientConfig = {}) => {
 describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefined')(
   '.live.events()',
   () => {
-    const server = setupServer(
-      http.options(
-        '/vX/data/live/events/prod',
-        () =>
-          new HttpResponse(null, {
-            status: 204,
-            headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-          }),
-      ),
-    )
+    const server = setupServer()
 
     beforeAll(() => {
       server.listen({onUnhandledRequest: 'bypass'})
@@ -203,59 +194,57 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
 
     test('handles CORS errors', async () => {
       expect.assertions(3)
-      const restoreFetch = global.fetch
-
-      global.fetch = async (info, init) => {
-        const response = await restoreFetch(info, init)
-        if (!response.headers.has('access-control-allow-origin')) {
-          throw new Error('CORS preflight request failed')
-        }
-        return response
-      }
 
       const {default: nock} = await import('nock')
 
-      // The OPTIONS request is done with `global.fetch`, and so nock can't intercept it.
+      // Mock /check/cors via msw (it's hit through `fetch`, which msw intercepts).
+      // Use distinct projectIds so the cors-check URL differs between the two clients.
       server.use(
-        http.options(
-          'https://abc123.api.sanity.io/vX/data/live/events/no-cors',
-          () => new HttpResponse(null, {status: 204, headers: {'Content-Length': '0'}}),
+        http.get('https://no-cors.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: false, withCredentials: false}}),
         ),
-        http.options(
-          'https://abc123.api.sanity.io/vX/data/live/events/cors',
-          () =>
-            new HttpResponse(null, {
-              status: 204,
-              headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-            }),
+        http.get('https://cors.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: false}}),
         ),
       )
 
-      // The EventSource can't be intercepted by msw, so we use nock
-      nock('https://abc123.api.sanity.io')
-        .get('/vX/data/live/events/cors')
+      // The EventSource can't be intercepted by msw, so we use nock.
+      // For the no-cors project, simulate a 403 (the typical CORS-rejection response)
+      // which causes the listener to reconnect and trigger the CORS check.
+      nock('https://no-cors.api.sanity.io').get('/vX/data/live/events/prod').reply(403, '')
+
+      nock('https://cors.api.sanity.io')
+        .get('/vX/data/live/events/prod')
         .reply(200, ['event: welcome', 'data: {}', '', '.', ''].join('\n'), {
           'Access-Control-Allow-Origin': '*',
           'Content-Type': 'text/event-stream',
         })
 
-      const client = createClient({
-        projectId: 'abc123',
-        dataset: 'no-cors',
+      const noCorsClient = createClient({
+        projectId: 'no-cors',
+        dataset: 'prod',
         useCdn: false,
         apiVersion: 'X',
       })
 
-      const error = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
+      const error = await firstValueFrom(
+        noCorsClient.live.events().pipe(catchError((err) => of(err))),
+      )
       expect(error).toBeInstanceOf(CorsOriginError)
       expect(error.message).toMatchInlineSnapshot(
-        `"The current origin is not allowed to connect to the Live Content API. Change your configuration here: https://sanity.io/manage/project/abc123/api"`,
+        `"The current origin is not allowed to connect to the Live Content API. Change your configuration here: https://sanity.io/manage/project/no-cors/api"`,
       )
 
-      const client2 = client.withConfig({dataset: 'cors'})
-      const event = await firstValueFrom(client2.live.events().pipe(catchError((err) => of(err))))
+      const corsClient = createClient({
+        projectId: 'cors',
+        dataset: 'prod',
+        useCdn: false,
+        apiVersion: 'X',
+      })
+      const event = await firstValueFrom(
+        corsClient.live.events().pipe(catchError((err) => of(err))),
+      )
       expect(event.type).toBe('welcome')
-      global.fetch = restoreFetch
     })
 
     test('handles non-CORS reconnect errors correctly', async () => {
@@ -264,13 +253,8 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       const {default: nock} = await import('nock')
 
       server.use(
-        http.options(
-          'https://abc123.api.sanity.io/vX/data/live/events/error-dataset',
-          () =>
-            new HttpResponse(null, {
-              status: 204,
-              headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-            }),
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: false}}),
         ),
       )
 
@@ -286,9 +270,98 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
         apiVersion: 'X',
       })
 
-      // Since CORS check passes, should get reconnect event (not CorsOriginError)
+      // Since CORS check reports allowed: true, should get a reconnect event (not CorsOriginError)
       const event = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
       expect(event.type).toBe('reconnect')
+    })
+
+    test('does not report CorsOriginError when /check/cors returns a non-2xx response', async () => {
+      // Regression: a non-2xx response from /check/cors is not a confirmed
+      // CORS rejection (the probe never reaches `response.json()` in this
+      // case). The original underlying error must propagate instead.
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.text('boom', {status: 500}),
+        ),
+      )
+
+      nock('https://abc123.api.sanity.io')
+        .get('/vX/data/live/events/check-cors-non-2xx')
+        .reply(500, 'Internal Server Error')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'check-cors-non-2xx',
+        useCdn: false,
+        apiVersion: 'X',
+      })
+
+      const event = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
+      expect(event).not.toBeInstanceOf(CorsOriginError)
+      expect(event.type).toBe('reconnect')
+    })
+
+    test('does not report CorsOriginError when /check/cors returns invalid JSON', async () => {
+      // Regression: a 2xx response with a body that fails JSON parsing must
+      // also not be treated as a confirmed CORS rejection. This exercises the
+      // `.catch` branch in `checkCorsObservable()` (the JSON-parse / network-
+      // error path), not the `!response.ok` short-circuit.
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.text('not json at all', {status: 200}),
+        ),
+      )
+
+      nock('https://abc123.api.sanity.io')
+        .get('/vX/data/live/events/check-cors-bad-json')
+        .reply(500, 'Internal Server Error')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'check-cors-bad-json',
+        useCdn: false,
+        apiVersion: 'X',
+      })
+
+      const event = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
+      expect(event).not.toBeInstanceOf(CorsOriginError)
+      expect(event.type).toBe('reconnect')
+    })
+
+    test('uses non-project hostname for /check/cors when useProjectHostname is false', async () => {
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      let checkCorsHits = 0
+      server.use(
+        http.get('https://api.sanity.io/vX/check/cors', () => {
+          checkCorsHits++
+          return HttpResponse.json({result: {allowed: false, withCredentials: false}})
+        }),
+      )
+
+      nock('https://api.sanity.io').get('/vX/data/live/events/global').reply(403, '')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'global',
+        useProjectHostname: false,
+        useCdn: false,
+        apiVersion: 'X',
+      })
+
+      const error = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
+      expect(error).toBeInstanceOf(CorsOriginError)
+      expect(checkCorsHits).toBeGreaterThan(0)
     })
 
     test('can immediately unsubscribe, does not connect to server', async () => {
@@ -352,29 +425,7 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect.assertions(5)
       let instanceCount = 0
 
-      const restoreFetch = global.fetch
-
-      global.fetch = async (info, init) => {
-        const response = await restoreFetch(info, init)
-        if (!response.headers.has('access-control-allow-origin')) {
-          throw new Error('CORS preflight request failed')
-        }
-        return response
-      }
-
       const {default: nock} = await import('nock')
-
-      // The OPTIONS request is done with `global.fetch`, and so nock can't intercept it.
-      server.use(
-        http.options(
-          'https://abc123.api.sanity.io/v2021-03-26/data/live/events/dedupe',
-          () =>
-            new HttpResponse(null, {
-              status: 204,
-              headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-            }),
-        ),
-      )
 
       // The EventSource can't be intercepted by msw, so we use nock
       nock('https://abc123.api.sanity.io')
@@ -422,8 +473,6 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect(msg2a).toEqual(msg2b)
       expect(msg1a).toEqual({id: 'NjA5MDk3MTQ0fFduQzE3KzVTTTBv', type: 'welcome'})
       expect(msg2a).toEqual({id: 'NjI0MTk4MzExfHFkS2twak9CcjRF', type: 'message', tags: []})
-
-      global.fetch = restoreFetch
     })
 
     test('works with global API endpoints', async () => {


### PR DESCRIPTION
## Summary

Today, `live.events()` reports a `CorsOriginError` on _any_ failure of a side-band OPTIONS preflight, so transient network issues (offline, DNS, certificate, 5xx, etc.) get misreported as CORS rejections.

This PR replaces that probe with a `GET /check/cors` request that asks the server whether the current origin is actually allowed, and only raises `CorsOriginError` when the server explicitly says it isn't.

- New `checkCorsObservable(url, projectId, requireCredentials)` helper in [`src/data/live.ts`](src/data/live.ts) encapsulates the probe; the call site is a single line.
- The cors-check URL is resolved via `client.getUrl('/check/cors')`, so it respects the existing `useProjectHostname`, `apiHost`, `apiVersion`, and `projectId` config (e.g. `https://api.sanity.io/v<apiVersion>/check/cors` or `https://<projectId>.api.sanity.io/v<apiVersion>/check/cors`).
- Errors with `CorsOriginError` only when `/check/cors` responds with `result.allowed === false` (or, in the credentialed case below, `result.withCredentials === false`). Every other outcome (`allowed: true`, non-2xx response, network error, malformed body, aborted subscription) is intentionally silent: the probe emits a single `void` value and completes so downstream `mergeMap` consumers can continue, and the EventSource's original underlying error propagates unchanged.
- The outer `catchError` in `events()` short-circuits when the error is already a `CorsOriginError`, so a CORS rejection results in exactly one `/check/cors` call (previously two: one from the `reconnect` event, then a redundant second one from `catchError` swallowing the same error).

### Credentials-aware probe

Following review feedback from @rexxars: an origin can be allow-listed for CORS _without_ credentials, in which case `/check/cors` returns `{result: {allowed: true, withCredentials: false}}`. Previously we only inspected `result.allowed`, so a credentialed listener (`includeDrafts: true` + `withCredentials: true`) would silently swallow the CORS issue and let an opaque error from the EventSource propagate instead.

The probe is now credentials-aware:

- `checkCorsObservable` takes a `requireCredentials` flag set from `esOptions.withCredentials`.
- When `requireCredentials && result.withCredentials === false`, a `CorsOriginError` is raised with `credentials: true` so its `addOriginUrl` deep-link includes a `credentials=` query param. The Sanity management CORS form opens with the "Allow credentials" toggle pre-selected.
- When `result.allowed === false`, the error is raised with `credentials: requireCredentials`, so the deep-link still pre-selects credentials whenever the caller needed them - regardless of which rejection branch fired.

### `CorsOriginError` shape change

`CorsOriginError`'s `projectId` is now optional and the constructor accepts a new `credentials?: boolean`. Existing callers passing `{projectId}` remain source-compatible.

Although the type signature change (`projectId: string` -> `projectId?: string`) _looks_ breaking, it isn't:

- The internal call site has always passed `projectId!` from `client.config().projectId`, which is itself `string | undefined`. The non-null assertion was lying - in resource-config mode (`resource: {...}`) there is no `projectId`.
- When that happened at runtime, the template literal `` `https://sanity.io/manage/project/${projectId}/api` `` interpolated the string `"undefined"`, producing the broken URL `https://sanity.io/manage/project/undefined/api`.
- Making `projectId` optional finally lets us drop the `!`, and in the missing-`projectId` branch we now construct a generic message without the broken URL (the deep-link is skipped because it can't actually route the user anywhere useful).

Users who construct `CorsOriginError` themselves (uncommon - it's primarily a class the SDK throws, not one consumers instantiate) lose no real capability; the new shape is a strict superset of what was actually safe to do before.

## Live test deployments

Both apps use `@sanity/client`; one runs `@latest` (before) and one runs this branch (after). Open DevTools' Network tab to compare behaviour.

### Transient network loss (offline -> back online)

| | Before (`@latest`) | After (this PR) |
| --- | --- | --- |
| URL | https://next.sanity.dev/ | https://next-sanity-git-test-no-cors.sanity.dev/ |
| When you toggle offline | Reports a **false-positive** ``next.sanity.dev is blocked by CORS policy`` error. The failing OPTIONS preflight is interpreted as a CORS rejection. | No CORS error: `/check/cors` is unreachable too, so CORS is treated as unknown and the EventSource's own error is allowed to propagate. |
| When you go back online | Stays broken - the client believes CORS is denied, so it never reconnects. | Auto-reconnects: console logs a few ``<SanityLive> is attempting to reconnect`` lines followed by ``<SanityLive> is connected and listening for live events to published content.`` |

### Origin not in the project's CORS allow-list (actual CORS rejection)

| | Before (`@latest`) | After (this PR) |
| --- | --- | --- |
| URL | https://next-sanity-no-cors.vercel.app/ | https://next-sanity-no-cors-preview.vercel.app/ |
| Failing requests | ~5: the EventSource itself, then the OPTIONS preflight, then the preflighted request behind it, etc. | 2: one failing EventSource request, then one successful `/check/cors` request that returns `{result: {allowed: false}}`. |
| Reported error | `CorsOriginError` (correct, but reached via the noisy path above). | `CorsOriginError`, confirmed by the API itself - so the diagnosis is now actually trustworthy. |

## Test plan

- `test/live.test.ts` updated: existing CORS-related tests rewired to mock `GET /check/cors` instead of the OPTIONS preflight, plus new regression tests:
  - `does not report CorsOriginError when /check/cors returns a non-2xx response` (covers the `!response.ok` short-circuit)
  - `does not report CorsOriginError when /check/cors returns invalid JSON` (covers the JSON-parse / `.catch` branch)
  - `uses non-project hostname for /check/cors when useProjectHostname is false`
  - `reports CorsOriginError when EventSource needs credentials but /check/cors reports withCredentials: false` - asserts both the `CorsOriginError` and that `addOriginUrl.searchParams.get('credentials') === ''`
  - `does not report CorsOriginError when /check/cors reports allowed: true, withCredentials: true and the EventSource needs credentials`
- `npm test -- test/live.test.ts` (27 passing).
- `npm test` (full suite, 989 passing).
- `npm run lint`.
- Manual verification on the live test deployments linked above.

Made with [Cursor](https://cursor.com)