### PR TITLE
fix(live): verify CORS via /check/cors before reporting CorsOriginError

### DIFF
--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -122,16 +122,9 @@ export class LiveClient {
       'goaway',
     ])
 
-    const checkCors = fetchObservable(url, {
-      method: 'OPTIONS',
-      mode: 'cors',
-      credentials: esOptions.withCredentials ? 'include' : 'omit',
-      headers: esOptions.headers,
-    }).pipe(
-      catchError(() => {
-        // If the request fails, then we assume it was due to CORS, and we rethrow a special error that allows special handling in userland
-        throw new CorsOriginError({projectId: projectId!})
-      }),
+    const checkCors = checkCorsObservable(
+      new URL(this.#client.getUrl('/check/cors', false)),
+      projectId!,
     )
 
     const observable = events
@@ -172,21 +165,47 @@ export class LiveClient {
   }
 }
 
-function fetchObservable(url: URL, init: RequestInit) {
-  return new Observable((observer) => {
+/**
+ * Probes the `/check/cors` endpoint to verify whether the current
+ * origin is allowed by the project's CORS configuration. The endpoint responds
+ * with `{result: {allowed: boolean, withCredentials: boolean}}`; we only inspect
+ * `result.allowed` (the live events API does not require credentials).
+ *
+ * - Emits `true` and completes when the server reports `allowed: true` (or
+ *   returns an unrecognised shape).
+ * - Emits `true` and completes when the request itself fails (network error,
+ *   non-2xx status, malformed JSON, etc.) so callers don't misreport unrelated
+ *   failures as CORS errors.
+ * - Errors with `CorsOriginError` only when the server explicitly reports
+ *   `allowed: false`.
+ */
+function checkCorsObservable(url: URL, projectId: string): Observable<true> {
+  return new Observable<true>((observer) => {
     const controller = new AbortController()
     const signal = controller.signal
-    fetch(url, {...init, signal: controller.signal}).then(
-      (response) => {
-        observer.next(response)
-        observer.complete()
-      },
-      (err) => {
-        if (!signal.aborted) {
-          observer.error(err)
+    fetch(url, {
+      method: 'GET',
+      mode: 'cors',
+      credentials: 'omit',
+      signal,
+    })
+      .then((response) => response.json() as Promise<{result?: {allowed?: boolean}}>)
+      .then((body) => {
+        if (body?.result?.allowed === false) {
+          throw new CorsOriginError({projectId})
         }
-      },
-    )
+        observer.next(true)
+        observer.complete()
+      })
+      .catch((err) => {
+        if (signal.aborted) return
+        if (err instanceof CorsOriginError) {
+          observer.error(err)
+          return
+        }
+        observer.next(true)
+        observer.complete()
+      })
     return () => controller.abort()
   })
 }

--- a/test/helpers/sseServer.ts
+++ b/test/helpers/sseServer.ts
@@ -11,6 +11,15 @@ export type OnRequest = (options: {
 export const createSseServer = (onRequest: OnRequest): Promise<http.Server> =>
   new Promise((resolve, reject) => {
     const server = http.createServer((request, response) => {
+      // Respond to the CORS-check endpoint with a permissive `allowed: true` so
+      // tests that trigger reconnect/error paths in `live.events()` don't hang
+      // on a missing `/check/cors` handler.
+      if (/\/check\/cors$/.test(request?.url || '')) {
+        response.writeHead(200, {'content-type': 'application/json'})
+        response.end(JSON.stringify({result: {allowed: true, withCredentials: false}}))
+        return
+      }
+
       let channel
       if (
         request?.url?.indexOf('/v1/data/listen/') === 0 ||

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -28,16 +28,7 @@ const testSse = async (onRequest: OnRequest, options: ClientConfig = {}) => {
 describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefined')(
   '.live.events()',
   () => {
-    const server = setupServer(
-      http.options(
-        '/vX/data/live/events/prod',
-        () =>
-          new HttpResponse(null, {
-            status: 204,
-            headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-          }),
-      ),
-    )
+    const server = setupServer()
 
     beforeAll(() => {
       server.listen({onUnhandledRequest: 'bypass'})
@@ -203,59 +194,57 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
 
     test('handles CORS errors', async () => {
       expect.assertions(3)
-      const restoreFetch = global.fetch
-
-      global.fetch = async (info, init) => {
-        const response = await restoreFetch(info, init)
-        if (!response.headers.has('access-control-allow-origin')) {
-          throw new Error('CORS preflight request failed')
-        }
-        return response
-      }
 
       const {default: nock} = await import('nock')
 
-      // The OPTIONS request is done with `global.fetch`, and so nock can't intercept it.
+      // Mock /check/cors via msw (it's hit through `fetch`, which msw intercepts).
+      // Use distinct projectIds so the cors-check URL differs between the two clients.
       server.use(
-        http.options(
-          'https://abc123.api.sanity.io/vX/data/live/events/no-cors',
-          () => new HttpResponse(null, {status: 204, headers: {'Content-Length': '0'}}),
+        http.get('https://no-cors.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: false, withCredentials: false}}),
         ),
-        http.options(
-          'https://abc123.api.sanity.io/vX/data/live/events/cors',
-          () =>
-            new HttpResponse(null, {
-              status: 204,
-              headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-            }),
+        http.get('https://cors.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: false}}),
         ),
       )
 
-      // The EventSource can't be intercepted by msw, so we use nock
-      nock('https://abc123.api.sanity.io')
-        .get('/vX/data/live/events/cors')
+      // The EventSource can't be intercepted by msw, so we use nock.
+      // For the no-cors project, simulate a 403 (the typical CORS-rejection response)
+      // which causes the listener to reconnect and trigger the CORS check.
+      nock('https://no-cors.api.sanity.io').get('/vX/data/live/events/prod').reply(403, '')
+
+      nock('https://cors.api.sanity.io')
+        .get('/vX/data/live/events/prod')
         .reply(200, ['event: welcome', 'data: {}', '', '.', ''].join('\n'), {
           'Access-Control-Allow-Origin': '*',
           'Content-Type': 'text/event-stream',
         })
 
-      const client = createClient({
-        projectId: 'abc123',
-        dataset: 'no-cors',
+      const noCorsClient = createClient({
+        projectId: 'no-cors',
+        dataset: 'prod',
         useCdn: false,
         apiVersion: 'X',
       })
 
-      const error = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
+      const error = await firstValueFrom(
+        noCorsClient.live.events().pipe(catchError((err) => of(err))),
+      )
       expect(error).toBeInstanceOf(CorsOriginError)
       expect(error.message).toMatchInlineSnapshot(
-        `"The current origin is not allowed to connect to the Live Content API. Change your configuration here: https://sanity.io/manage/project/abc123/api"`,
+        `"The current origin is not allowed to connect to the Live Content API. Change your configuration here: https://sanity.io/manage/project/no-cors/api"`,
       )
 
-      const client2 = client.withConfig({dataset: 'cors'})
-      const event = await firstValueFrom(client2.live.events().pipe(catchError((err) => of(err))))
+      const corsClient = createClient({
+        projectId: 'cors',
+        dataset: 'prod',
+        useCdn: false,
+        apiVersion: 'X',
+      })
+      const event = await firstValueFrom(
+        corsClient.live.events().pipe(catchError((err) => of(err))),
+      )
       expect(event.type).toBe('welcome')
-      global.fetch = restoreFetch
     })
 
     test('handles non-CORS reconnect errors correctly', async () => {
@@ -264,13 +253,8 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       const {default: nock} = await import('nock')
 
       server.use(
-        http.options(
-          'https://abc123.api.sanity.io/vX/data/live/events/error-dataset',
-          () =>
-            new HttpResponse(null, {
-              status: 204,
-              headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-            }),
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: false}}),
         ),
       )
 
@@ -286,9 +270,69 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
         apiVersion: 'X',
       })
 
-      // Since CORS check passes, should get reconnect event (not CorsOriginError)
+      // Since CORS check reports allowed: true, should get a reconnect event (not CorsOriginError)
       const event = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
       expect(event.type).toBe('reconnect')
+    })
+
+    test('does not report CorsOriginError when /check/cors fetch fails', async () => {
+      // Regression: a failing /check/cors request (network error, 5xx, malformed
+      // response) must NOT be treated as a CORS failure. The original underlying
+      // error should propagate instead.
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      // Have /check/cors itself fail. msw passes the request through to the network
+      // layer, and nock returns a 500 with a non-JSON body so the JSON parse fails.
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.text('boom', {status: 500}),
+        ),
+      )
+
+      nock('https://abc123.api.sanity.io')
+        .get('/vX/data/live/events/check-cors-fails')
+        .reply(500, 'Internal Server Error')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'check-cors-fails',
+        useCdn: false,
+        apiVersion: 'X',
+      })
+
+      const event = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
+      expect(event).not.toBeInstanceOf(CorsOriginError)
+      expect(event.type).toBe('reconnect')
+    })
+
+    test('uses non-project hostname for /check/cors when useProjectHostname is false', async () => {
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      let checkCorsHits = 0
+      server.use(
+        http.get('https://api.sanity.io/vX/check/cors', () => {
+          checkCorsHits++
+          return HttpResponse.json({result: {allowed: false, withCredentials: false}})
+        }),
+      )
+
+      nock('https://api.sanity.io').get('/vX/data/live/events/global').reply(403, '')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'global',
+        useProjectHostname: false,
+        useCdn: false,
+        apiVersion: 'X',
+      })
+
+      const error = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
+      expect(error).toBeInstanceOf(CorsOriginError)
+      expect(checkCorsHits).toBeGreaterThan(0)
     })
 
     test('can immediately unsubscribe, does not connect to server', async () => {
@@ -352,29 +396,7 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect.assertions(5)
       let instanceCount = 0
 
-      const restoreFetch = global.fetch
-
-      global.fetch = async (info, init) => {
-        const response = await restoreFetch(info, init)
-        if (!response.headers.has('access-control-allow-origin')) {
-          throw new Error('CORS preflight request failed')
-        }
-        return response
-      }
-
       const {default: nock} = await import('nock')
-
-      // The OPTIONS request is done with `global.fetch`, and so nock can't intercept it.
-      server.use(
-        http.options(
-          'https://abc123.api.sanity.io/v2021-03-26/data/live/events/dedupe',
-          () =>
-            new HttpResponse(null, {
-              status: 204,
-              headers: {'Access-Control-Allow-Origin': '*', 'Content-Length': '0'},
-            }),
-        ),
-      )
 
       // The EventSource can't be intercepted by msw, so we use nock
       nock('https://abc123.api.sanity.io')
@@ -422,8 +444,6 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect(msg2a).toEqual(msg2b)
       expect(msg1a).toEqual({id: 'NjA5MDk3MTQ0fFduQzE3KzVTTTBv', type: 'welcome'})
       expect(msg2a).toEqual({id: 'NjI0MTk4MzExfHFkS2twak9CcjRF', type: 'message', tags: []})
-
-      global.fetch = restoreFetch
     })
 
     test('works with global API endpoints', async () => {


### PR DESCRIPTION
## Summary

- Replace the OPTIONS preflight that `live.events()` used to detect CORS issues with an explicit `GET /check/cors` request, so a `CorsOriginError` is only raised when the server actually reports `result.allowed === false`.
- All other outcomes - `allowed: true`, malformed responses, or the `/check/cors` request itself failing (offline, DNS, 5xx, etc.) - now rethrow the original underlying error, eliminating the false-positive CORS detections that today swallow network errors.
- The cors-check URL is built through `client.getUrl('/check/cors')`, so it respects the existing `useProjectHostname`, `apiHost`, `apiVersion`, and `projectId` rules (matching the example `https://api.sanity.io/v<apiVersion>/check/cors`).

## Test plan

- `npm test -- test/live.test.ts` (24 passing, including new tests for `allowed: true`, `allowed: false`, a failing `/check/cors` request, and `useProjectHostname: false`).
- `npm test` (full suite, 986 passing).
- `npm run lint`.

Made with [Cursor](https://cursor.com)