### PR TITLE
fix(live): send projectId to /check/cors to prevent false CorsOriginError

### DIFF
--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -122,8 +122,17 @@ export class LiveClient {
       'goaway',
     ])
 
+    // Carry the `projectId` so `/check/cors` can be evaluated against the right
+    // project. Resource-addressed clients talk to the global API host
+    // (`api.sanity.io`), where the path holds no project context - without this
+    // the endpoint reports every origin as disallowed and we raise a false
+    // `CorsOriginError` on reconnect (SDK-1783).
+    const corsCheckUrl = new URL(this.#client.getUrl('/check/cors', false))
+    if (projectId) {
+      corsCheckUrl.searchParams.set('projectId', projectId)
+    }
     const checkCors = checkCorsObservable(
-      new URL(this.#client.getUrl('/check/cors', false)),
+      corsCheckUrl,
       projectId,
       esOptions.withCredentials === true,
     )

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -336,15 +336,21 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect(event.type).toBe('reconnect')
     })
 
-    test('uses non-project hostname for /check/cors when useProjectHostname is false', async () => {
-      expect.assertions(2)
+    test('uses non-project hostname and sends projectId for /check/cors when useProjectHostname is false', async () => {
+      // Regression for SDK-1783: resource/global-host clients reach
+      // `api.sanity.io/.../check/cors`, where the path carries no project
+      // context. The probe must send `?projectId=` so the endpoint can evaluate
+      // the correct project's allow-list instead of rejecting every origin.
+      expect.assertions(3)
 
       const {default: nock} = await import('nock')
 
       let checkCorsHits = 0
+      let checkCorsProjectId: string | null = null
       server.use(
-        http.get('https://api.sanity.io/vX/check/cors', () => {
+        http.get('https://api.sanity.io/vX/check/cors', ({request}) => {
           checkCorsHits++
+          checkCorsProjectId = new URL(request.url).searchParams.get('projectId')
           return HttpResponse.json({result: {allowed: false, withCredentials: false}})
         }),
       )
@@ -362,6 +368,7 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       const error = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
       expect(error).toBeInstanceOf(CorsOriginError)
       expect(checkCorsHits).toBeGreaterThan(0)
+      expect(checkCorsProjectId).toBe('abc123')
     })
 
     test('reports CorsOriginError when EventSource needs credentials but /check/cors reports withCredentials: false', async () => {


### PR DESCRIPTION
Fixes [SDK-1783](https://linear.app/sanity/issue/SDK-1783/intermittent-false-cors-error-in-sdk-apps).

## Problem

SDK apps intermittently throw a false `CorsOriginError` from the Live Content API even when the origin is correctly allow-listed. It surfaces after backgrounding a tab and returning, navigating, or leaving a tab open a long time, and a hard refresh clears it.

## Root cause

After a live-stream reconnect/error the client probes `/check/cors` before raising `CorsOriginError`. That probe URL is built from a raw path and **drops the project context** that the events URL gets via `_getDataUrl`:

```
events URL   →  …/projects/<pid>/datasets/<ds>/live/events   ✅ project in path
check/cors   →  getUrl('/check/cors')  →  api.sanity.io/v…/check/cors   ❌ no project
```

Resource-addressed clients (`useProjectHostname: false`) therefore hit `/check/cors` on the **global** host, which has no project to evaluate and returns `{"result":{"allowed":false}}` for **every** origin. The probe only runs on reconnect, which is why it's intermittent and why a hard refresh (fresh connection) clears it.

Verified against a live project: an allow-listed origin (`localhost:3333`) connects fine to `live/events` (`200`, `access-control-allow-origin` echoed) yet the global `/check/cors` reports `allowed:false` for it.

## Fix

Send `?projectId=` on the `/check/cors` probe so the endpoint can evaluate the correct project's allow-list. `projectId` is already available on the client config (it's what populates the error's management deep-link).

## ⚠️ Requires API support

This relies on `/check/cors` honouring the `projectId` query param. Today the global endpoint **ignores** it. **The API change must be deployed before this releases**, otherwise the global endpoint keeps returning `allowed:false` and the false positives persist.

## Tests

Updated the `useProjectHostname: false` test to assert the probe now carries `?projectId=`. All 27 live tests pass.