### PR TITLE
fix: stop reconnecting live/listen connections rejected with a 4xx

### DIFF
--- a/src/data/eventsource.ts
+++ b/src/data/eventsource.ts
@@ -5,11 +5,25 @@ import {type Any} from '../types'
 
 /**
  * @public
- * Thrown if the EventSource connection could not be established.
- * Note that ConnectionFailedErrors are rare, and disconnects will normally be handled by the EventSource instance itself and emitted as `reconnect` events.
+ * Thrown when the EventSource connection could not be established, or was rejected by the server.
+ * Transient failures (network drops, 5xx, 408, 429) are reconnected internally and emitted as
+ * `reconnect` events; a permanent rejection (any other 4xx, eg an expired token) errors the
+ * stream with this class so consumers can react — check `status` for the rejection code.
  */
 export class ConnectionFailedError extends Error {
   readonly name = 'ConnectionFailedError'
+  /**
+   * HTTP status code of the rejected connection attempt, if known.
+   * Only set when the EventSource implementation exposes it — the polyfill used in
+   * Node.js and when custom headers (eg authorization) are required does, while
+   * native EventSource implementations (browser and Node.js) do not.
+   */
+  readonly status?: number
+  constructor(message?: string, options: ErrorOptions & {status?: number} = {}) {
+    const {status, ...errorOptions} = options
+    super(message, errorOptions)
+    this.status = status
+  }
 }
 
 /**
@@ -147,6 +161,18 @@ function connectWithESInstance<EventTypeName extends string>(
       // automatically, but in some cases (like when a laptop lid is closed), it will trigger onError
       // if it can't reconnect.
       // see https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model
+      // The polyfills expose the HTTP status of a rejected connection on the error event
+      // (native EventSource implementations do not). A status means the server rejected the
+      // connection attempt, so error out regardless of readyState — the polyfills disagree
+      // on whether the connection closes before or after the error event is dispatched —
+      // and let `reconnectOnConnectionFailure` classify it (4xx fatal, otherwise retried).
+      const rawStatus = (evt as {status?: unknown}).status
+      const status = typeof rawStatus === 'number' ? rawStatus : undefined
+      if (status !== undefined) {
+        observer.error(new ConnectionFailedError('EventSource connection failed', {status}))
+        return
+      }
+
       if (es.readyState === es.CLOSED) {
         // In these cases we'll signal to consumers (via the error path) that a retry/reconnect is needed.
         observer.error(new ConnectionFailedError('EventSource connection failed'))

--- a/src/data/reconnectOnConnectionFailure.ts
+++ b/src/data/reconnectOnConnectionFailure.ts
@@ -11,6 +11,8 @@ import {
 
 import {ConnectionFailedError} from './eventsource'
 
+const RETRYABLE_STATUSES = new Set([408, 429])
+
 /**
  * Note: connection failure is not the same as network disconnect which may happen more frequent.
  * The EventSource instance will automatically reconnect in case of a network disconnect, however,
@@ -20,7 +22,19 @@ export function reconnectOnConnectionFailure<T>(): OperatorFunction<T, T | {type
   return function (source: Observable<T>) {
     return source.pipe(
       catchError((err, caught) => {
-        if (err instanceof ConnectionFailedError) {
+        // Only reconnect on transient connection failures. A 4xx response is a
+        // rejection, not a transient failure — the server will keep rejecting
+        // (eg an expired token), so reconnecting would loop forever. The named
+        // exceptions are the explicitly transient 4xx statuses: 408 (request
+        // timeout) and 429 (rate limited). Anything else surfaces to the
+        // consumer instead.
+        if (
+          err instanceof ConnectionFailedError &&
+          (typeof err.status !== 'number' ||
+            err.status < 400 ||
+            err.status >= 500 ||
+            RETRYABLE_STATUSES.has(err.status))
+        ) {
           return concat(of({type: 'reconnect' as const}), timer(1000).pipe(mergeMap(() => caught)))
         }
         return throwError(() => err)

--- a/test/listen.test.ts
+++ b/test/listen.test.ts
@@ -1,6 +1,6 @@
 import type {AddressInfo} from 'node:net'
 
-import {type ClientConfig, createClient} from '@sanity/client'
+import {type ClientConfig, ConnectionFailedError, createClient} from '@sanity/client'
 import {catchError, firstValueFrom, lastValueFrom, of, take, toArray} from 'rxjs'
 import {describe, expect, test, vitest} from 'vitest'
 
@@ -125,6 +125,88 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
         })
       } finally {
         server.close()
+      }
+    })
+
+    test('stops reconnecting and surfaces the error when the connection is rejected with a 4xx', async () => {
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      // Simulate an auth rejection, e.g. an expired or revoked token. Unlike a
+      // transient 5xx, the server will keep rejecting — reconnecting forever
+      // would hammer the API once per second.
+      nock('https://abc123.api.sanity.io')
+        .persist()
+        .get('/v1/data/listen/prod')
+        .query(true)
+        .reply(401, 'Unauthorized')
+
+      // The token sets an auth header, forcing the polyfill — the only
+      // EventSource implementation that exposes the HTTP status of a rejected
+      // connection
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'prod',
+        useCdn: false,
+        apiVersion: '1',
+        token: 'expired-token',
+      })
+
+      try {
+        const event = await firstValueFrom(
+          client
+            .listen('*', {}, {events: ['reconnect', 'mutation']})
+            .pipe(catchError((err) => of(err))),
+        )
+        expect(event).toBeInstanceOf(ConnectionFailedError)
+        expect(event.status).toBe(401)
+      } finally {
+        nock.cleanAll()
+      }
+    })
+
+    test('keeps reconnecting when the connection is rejected with a non-4xx error status', async () => {
+      // The Node polyfill dispatches the error event (with `status`) BEFORE
+      // closing for statuses like 501, so the connection is not yet CLOSED when
+      // `onError` runs. Relying on readyState alone leaves a permanently dead
+      // connection that neither errors nor reconnects — a status present on the
+      // event must always take over, letting `reconnectOnConnectionFailure`
+      // classify it (non-4xx → reconnect).
+      expect.assertions(1)
+
+      const {default: nock} = await import('nock')
+
+      let attempts = 0
+      nock('https://abc123.api.sanity.io')
+        .persist()
+        .get('/v1/data/listen/prod')
+        .query(true)
+        .reply(501, () => {
+          attempts++
+          return 'Not Implemented'
+        })
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'prod',
+        useCdn: false,
+        apiVersion: '1',
+        token: 'some-token',
+      })
+
+      const subscription = client
+        .listen('*', {}, {events: ['reconnect', 'mutation']})
+        .subscribe({error: () => {}})
+
+      try {
+        // The reconnect delay is 1s; two attempts within 2.5s proves the
+        // connection is retried rather than silently dead after the first
+        await new Promise((resolve) => setTimeout(resolve, 2500))
+        expect(attempts).toBeGreaterThanOrEqual(2)
+      } finally {
+        subscription.unsubscribe()
+        nock.cleanAll()
       }
     })
 

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -1,7 +1,12 @@
 /* eslint-disable no-shadow */
 import type {AddressInfo} from 'node:net'
 
-import {type ClientConfig, CorsOriginError, createClient} from '@sanity/client'
+import {
+  type ClientConfig,
+  ConnectionFailedError,
+  CorsOriginError,
+  createClient,
+} from '@sanity/client'
 import {http, HttpResponse} from 'msw'
 import {setupServer} from 'msw/node'
 import {catchError, firstValueFrom, lastValueFrom, of, take} from 'rxjs'
@@ -273,6 +278,85 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       // Since CORS check reports allowed: true, should get a reconnect event (not CorsOriginError)
       const event = await firstValueFrom(client.live.events().pipe(catchError((err) => of(err))))
       expect(event.type).toBe('reconnect')
+    })
+
+    test('keeps reconnecting when the connection is rejected with a 429 (rate limited)', async () => {
+      expect.assertions(1)
+
+      const {default: nock} = await import('nock')
+
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: false}}),
+        ),
+      )
+
+      // Rate limiting is transient — unlike other 4xx rejections it must keep
+      // the reconnect behavior so listeners recover when the throttle lifts
+      nock('https://abc123.api.sanity.io')
+        .persist()
+        .get('/vX/data/live/events/rate-limited-dataset')
+        .query(true)
+        .reply(429, 'Too Many Requests')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'rate-limited-dataset',
+        useCdn: false,
+        apiVersion: 'X',
+        token: 'valid-but-throttled-token',
+      })
+
+      try {
+        const event = await firstValueFrom(
+          client.live.events({includeDrafts: true}).pipe(catchError((err) => of(err))),
+        )
+        expect(event).toEqual({type: 'reconnect'})
+      } finally {
+        nock.cleanAll()
+      }
+    })
+
+    test('stops reconnecting and surfaces the error when the connection is rejected with a 4xx', async () => {
+      expect.assertions(2)
+
+      const {default: nock} = await import('nock')
+
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: false}}),
+        ),
+      )
+
+      // Simulate an auth rejection, e.g. an expired or revoked token. Unlike a
+      // transient 5xx, the server will keep rejecting — reconnecting forever
+      // would hammer the API once per second.
+      nock('https://abc123.api.sanity.io')
+        .persist()
+        .get('/vX/data/live/events/unauthorized-dataset')
+        .query(true)
+        .reply(401, 'Unauthorized')
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'unauthorized-dataset',
+        useCdn: false,
+        apiVersion: 'X',
+        token: 'expired-token',
+      })
+
+      try {
+        // `includeDrafts` sets an auth header, forcing the polyfill — the only
+        // EventSource implementation that exposes the HTTP status of a
+        // rejected connection
+        const event = await firstValueFrom(
+          client.live.events({includeDrafts: true}).pipe(catchError((err) => of(err))),
+        )
+        expect(event).toBeInstanceOf(ConnectionFailedError)
+        expect(event.status).toBe(401)
+      } finally {
+        nock.cleanAll()
+      }
     })
 
     test('does not report CorsOriginError when /check/cors returns a non-2xx response', async () => {

--- a/test/reconnectOnConnectionFailure.test.ts
+++ b/test/reconnectOnConnectionFailure.test.ts
@@ -1,0 +1,52 @@
+import {catchError, firstValueFrom, of, throwError} from 'rxjs'
+import {describe, expect, test} from 'vitest'
+
+import {ConnectionFailedError} from '../src/data/eventsource'
+import {reconnectOnConnectionFailure} from '../src/data/reconnectOnConnectionFailure'
+
+const failingSource = (error: unknown) =>
+  throwError(() => error).pipe(reconnectOnConnectionFailure())
+
+const firstEmission = (error: unknown) =>
+  firstValueFrom(failingSource(error).pipe(catchError((err) => of(err))))
+
+describe('reconnectOnConnectionFailure()', () => {
+  test('reconnects when the failure has no status (native EventSource, network drop)', async () => {
+    await expect(firstEmission(new ConnectionFailedError('failed'))).resolves.toEqual({
+      type: 'reconnect',
+    })
+  })
+
+  test('reconnects on a 5xx (transient server error)', async () => {
+    await expect(
+      firstEmission(new ConnectionFailedError('failed', {status: 503})),
+    ).resolves.toEqual({type: 'reconnect'})
+  })
+
+  test('reconnects on 429 (rate limited — transient by definition)', async () => {
+    await expect(
+      firstEmission(new ConnectionFailedError('failed', {status: 429})),
+    ).resolves.toEqual({type: 'reconnect'})
+  })
+
+  test('reconnects on 408 (request timeout — explicitly retryable)', async () => {
+    await expect(
+      firstEmission(new ConnectionFailedError('failed', {status: 408})),
+    ).resolves.toEqual({type: 'reconnect'})
+  })
+
+  test('rethrows on a 401 (permanent rejection)', async () => {
+    const error = new ConnectionFailedError('failed', {status: 401})
+    await expect(firstEmission(error)).resolves.toBe(error)
+  })
+
+  test('rethrows on a 404 (permanent rejection)', async () => {
+    const error = new ConnectionFailedError('failed', {status: 404})
+    await expect(firstEmission(error)).resolves.toBe(error)
+  })
+
+  test('rethrows errors that are not connection failures', async () => {
+    const error = new Error('unrelated')
+    await expect(firstEmission(error)).resolves.toBe(error)
+  })
+})


### PR DESCRIPTION
When an SSE connection (`live.events()` or `listen()`) is rejected with a 4xx — most commonly a 401 from an expired or revoked token — the client reconnects every second, forever. The server keeps rejecting, so the loop never resolves. Request logs show individual apps stuck in this state generating ~86K requests per day each.

- `ConnectionFailedError` now carries the HTTP `status` of the rejected connection when the EventSource implementation exposes it (the Node/headers polyfills do; native `EventSource` does not).
- `onError` errors the stream whenever the error event carries a status, regardless of `readyState` — the polyfills disagree on whether the connection closes before or after the error event is dispatched. This also fixes a pre-existing zombie: statuses the Node polyfill dispatches before closing (eg 501, proxy 52x) previously left a silently dead connection that neither errored nor reconnected.
- `reconnectOnConnectionFailure()` rethrows 4xx failures to the consumer instead of retrying, with 408 (request timeout) and 429 (rate limited) carved out as transient — consistent with the HTTP layer, which retries 429 with backoff. 5xx and status-less failures reconnect as before.

Behavior change: consumers of `live.events()` and `listen()` that previously saw silent `reconnect` events on a 4xx now get an error with `status` set — check it to react (eg refresh auth and resubscribe). Known limitation: native `EventSource` connections (no custom headers, eg cookie auth) expose no status, so 4xx rejections there keep the old reconnect behavior; a backoff/cap for status-less failures is a candidate follow-up.

FIXES SDK-1891

🤖 Generated with [Claude Code](https://claude.com/claude-code)