### PR TITLE
fix(deps): update @sanity/eventsource to v5.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.23.1",
       "license": "MIT",
       "dependencies": {
-        "@sanity/eventsource": "^5.0.2",
+        "@sanity/eventsource": "^5.0.4",
         "get-it": "^8.8.0",
         "nanoid": "^3.3.11",
         "rxjs": "^7.0.0"
@@ -3931,9 +3931,9 @@
       }
     },
     "node_modules/@sanity/eventsource": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
-      "integrity": "sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.4.tgz",
+      "integrity": "sha512-NT6XrTJePJd7q1ZdTqB3NsTyNNOe9R2zMkg4Hlkqwb0LL6UmekVamAD46yjSJ+HbRyXAKLl1Rb65xZBdzC1f8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/event-source-polyfill": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@sanity/eventsource": "^5.0.2",
+    "@sanity/eventsource": "^5.0.4",
     "get-it": "^8.8.0",
     "nanoid": "^3.3.11",
     "rxjs": "^7.0.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps `@sanity/eventsource` from `^5.0.2` to `^5.0.4` so the ESM browser entry fix is included.

That patch adds an ESM `browser.mjs` export used for browser `import`/`import()`, which avoids `TypeError: EventSource2 is not a constructor` under Vite 8's experimental bundled dev mode (`unstable_bundledDev: true`).

Upstream: https://github.com/sanity-io/eventsource/pull/78
Release: https://github.com/sanity-io/eventsource/releases/tag/v5.0.4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6583-7e12-724e-b935-ee4fb3d2bfe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6583-7e12-724e-b935-ee4fb3d2bfe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

