### PR TITLE
feat: variant querying

### DIFF
--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -549,6 +549,7 @@ export function _dataRequest(
     tag,
     returnQuery,
     perspective: options.perspective,
+    variant: options.variant,
     resultSourceMap: options.resultSourceMap,
     lastLiveEventId: Array.isArray(lastLiveEventId) ? lastLiveEventId[0] : lastLiveEventId,
     cacheMode: cacheMode,
@@ -700,6 +701,36 @@ export function _requestObservable<R>(
       }
     }
 
+    const variantOption = options.variant || config.variant
+
+    if (typeof variantOption !== 'undefined') {
+      if (typeof variantOption === 'string') {
+        options.query = {
+          variant: variantOption,
+          ...options.query,
+        }
+      }
+
+      if (typeof variantOption === 'object') {
+        const variantConditions = Object.entries(variantOption)
+        const searchParams = variantConditionPairsToSearchParams(variantConditions).slice(0, 1)
+
+        if (variantConditions.length > 1) {
+          const formatter = new Intl.ListFormat('en')
+
+          // eslint-disable-next-line no-console -- will be removed in an upcoming version; it's better this behaviour is noisy and obvious
+          console.warn(
+            `The Sanity client's beta \`variant\` option currently only supports one condition. Dropped: ${formatter.format(variantConditions.slice(1).map(([subject]) => JSON.stringify(subject)))}.`,
+          )
+        }
+
+        options.query = {
+          ...Object.fromEntries(searchParams),
+          ...options.query,
+        }
+      }
+    }
+
     if (options.lastLiveEventId) {
       options.query = {...options.query, lastLiveEventId: options.lastLiveEventId}
     }
@@ -842,4 +873,13 @@ const resourceDataBase = (config: InitializedClientConfig): string => {
       // @ts-expect-error - handle all supported resource types
       throw new Error(`Unsupported resource type: ${type.toString()}`)
   }
+}
+
+function variantConditionPairsToSearchParams(
+  variantConditionPairs: string[][],
+): ['variantCondition', `${string}:${string}`][] {
+  return variantConditionPairs.map(([condition, value]) => [
+    'variantCondition',
+    `${condition}:${value}`,
+  ])
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,18 @@ export type ClientPerspective =
   | 'raw'
   | StackablePerspective[]
 
+/**
+ * @public
+ * @beta
+ */
+export type ClientVariantConditions = Record<string, string>
+
+/**
+ * @public
+ * @beta
+ */
+export type ClientVariant = ClientVariantConditions | string
+
 type ClientConfigResource =
   | {
       type: 'canvas'
@@ -111,6 +123,10 @@ export interface ClientConfig {
    * @defaultValue 'published'
    */
   perspective?: ClientPerspective
+  /**
+   * @beta
+   */
+  variant?: ClientVariant
   apiHost?: string
 
   /**
@@ -484,6 +500,10 @@ export interface RequestObservableOptions extends Omit<RequestOptions, 'url'> {
   returnQuery?: boolean
   resultSourceMap?: boolean | 'withKeyArraySelector'
   perspective?: ClientPerspective
+  /**
+   * @beta
+   */
+  variant?: ClientVariant
   lastLiveEventId?: string
   cacheMode?: 'noStale'
 }
@@ -678,6 +698,8 @@ export interface QueryParams {
   next?: 'next' extends keyof RequestInit ? never : any
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
   perspective?: never
+  /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
+  variant?: never
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
   query?: never
   /** @deprecated you're using a fetch option as a GROQ parameter, this is likely a mistake */
@@ -1424,6 +1446,10 @@ export interface ResumableListenOptions extends Omit<ListenOptions, 'events' | '
 /** @public */
 export interface ResponseQueryOptions extends RequestOptions {
   perspective?: ClientPerspective
+  /**
+   * @beta
+   */
+  variant?: ClientVariant
   resultSourceMap?: boolean | 'withKeyArraySelector'
   returnQuery?: boolean
   useCdn?: boolean

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1410,6 +1410,119 @@ describe('client', async () => {
       },
     )
 
+    test.skipIf(isEdge)('can query with a variant id set in the client config', async () => {
+      nock(projectHost())
+        .get(`/vX/data/query/foo?query=*&returnQuery=false&variant=abc`)
+        .reply(200, {
+          ms: 123,
+          result,
+        })
+
+      const client = getClient({apiVersion: 'X', variant: 'abc'})
+      const res = await client.fetch('*', {})
+
+      expect(res.length, 'length should match').toBe(1)
+      expect(res[0].rating, 'data should match').toBe(5)
+    })
+
+    test.skipIf(isEdge)('can query with a variant condition set in the client config', async () => {
+      nock(projectHost())
+        .get(`/vX/data/query/foo?query=*&returnQuery=false&variantCondition=market%3Aus`)
+        .reply(200, {
+          ms: 123,
+          result,
+        })
+
+      const client = getClient({apiVersion: 'X', variant: {market: 'us'}})
+      const res = await client.fetch('*', {})
+
+      expect(res.length, 'length should match').toBe(1)
+      expect(res[0].rating, 'data should match').toBe(5)
+    })
+
+    test.skipIf(isEdge)('setting a variant id on client.fetch supersedes the config', async () => {
+      nock(projectHost())
+        .get(`/vX/data/query/foo?query=*&returnQuery=false&variant=xyz`)
+        .reply(200, {
+          ms: 123,
+          result,
+        })
+
+      const client = getClient({
+        apiVersion: 'X',
+        variant: 'abc',
+      })
+
+      const res = await client.fetch('*', {}, {variant: 'xyz'})
+
+      expect(res.length, 'length should match').toBe(1)
+      expect(res[0].rating, 'data should match').toBe(5)
+    })
+
+    test.skipIf(isEdge)(
+      'setting a variant condition on client.fetch supersedes the config',
+      async () => {
+        nock(projectHost())
+          .get(`/vX/data/query/foo?query=*&returnQuery=false&variantCondition=market%3Aeu`)
+          .reply(200, {
+            ms: 123,
+            result,
+          })
+
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        try {
+          const client = getClient({
+            apiVersion: 'X',
+            variant: {
+              market: 'us',
+            },
+          })
+
+          const res = await client.fetch(
+            '*',
+            {},
+            {
+              variant: {
+                market: 'eu',
+                currency: 'gbp',
+                audience: 'musicians',
+              },
+            },
+          )
+
+          expect(res.length, 'length should match').toBe(1)
+          expect(res[0].rating, 'data should match').toBe(5)
+
+          expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining('Dropped: "currency" and "audience"'),
+          )
+        } finally {
+          warn.mockRestore()
+        }
+      },
+    )
+
+    test.skipIf(isEdge)(
+      'setting a variant id on client.fetch supersedes a variant condition from the config',
+      async () => {
+        // the fetch-level variant replaces the config value wholesale – no
+        // `variantCondition` param should remain
+        nock(projectHost())
+          .get(`/vX/data/query/foo?query=*&returnQuery=false&variant=xyz`)
+          .reply(200, {
+            ms: 123,
+            result,
+          })
+
+        const client = getClient({apiVersion: 'X', variant: {market: 'us'}})
+        const res = await client.fetch('*', {}, {variant: 'xyz'})
+
+        expect(res.length, 'length should match').toBe(1)
+        expect(res[0].rating, 'data should match').toBe(5)
+      },
+    )
+
     test.skipIf(isEdge)('allow overriding useCdn to false on client.fetch', async () => {
       nock('https://abc123.api.sanity.io')
         .get(`/v1/data/query/foo?query=*&returnQuery=false`)


### PR DESCRIPTION
### Description

This branch adds a `variant` option. It must either be a string representing a variant id, or a set of variant conditions:

```ts
{
  variant: 'someVariantId',
},
```

```ts
{
  variant: {
    market: 'eu',
    currency: 'gbp',
    audience: 'musicians',
  },
},
```

In this initial implementation, only the first variant condition is passed to the request (`market: 'eu'`). We will discuss how the backend handles array values with Content Lake and follow up with a fix. For now, a warning is logged showing which conditions were dropped.

### What to review

New `variant` option and related types.

### Testing

Added unit tests.