### PR TITLE
fix: give up when connections are repeatedly dropped right after opening

### DIFF
--- a/src/data/eventsource.ts
+++ b/src/data/eventsource.ts
@@ -104,9 +104,10 @@ export interface ServerSentEvent<Name extends string> {
 const REQUIRED_EVENTS = ['channelError', 'disconnect']
 
 /**
- * A connection that dies within this window of the `open` event is considered "fruitless":
- * the server accepted the request but hung up without keeping the stream alive.
- * Healthy SSE connections are long-lived — surviving past this window resets the counter below.
+ * A connection that dies within this window of the `open` event without delivering any events is
+ * considered "fruitless": the server accepted the request but hung up without serving the stream.
+ * Healthy SSE connections are long-lived — surviving past this window, or delivering an event
+ * (which proves the server can serve the stream), resets the counter below.
  */
 const FRUITLESS_CONNECTION_WINDOW = 1000
 
@@ -218,10 +219,11 @@ function connectWithESInstance<EventTypeName extends string>(
         return
       }
 
-      // The connection was established (`open` fired) but died again — classify it.
-      // A connection that survived the window is healthy and resets the counter; one that died
-      // right away is fruitless, and too many in a row means the server keeps accepting the
-      // request only to drop it (eg an error payload served as 200 `text/event-stream`).
+      // The connection was established (`open` fired) but died again without delivering any
+      // events — classify it. A connection that survived the window is healthy and resets the
+      // counter (so does delivering an event, see `onMessage`); one that died right away is
+      // fruitless, and too many in a row means the server keeps accepting the request only to
+      // drop it (eg an error payload served as 200 `text/event-stream`).
       // The EventSource reconnects internally — invisible to RxJS retry operators — and resets
       // its retry backoff on every successful open, so without this cap such a server is
       // hammered in a tight, infinite loop that never surfaces an error to consumers.
@@ -258,6 +260,13 @@ function connectWithESInstance<EventTypeName extends string>(
     }
 
     function onMessage(message: MessageEvent) {
+      // The server delivered an event, proving it can serve the stream — the connection is not
+      // fruitless, even if it ends up shorter-lived than the fruitless window (eg a `goaway`
+      // followed by a prompt close). Mirrors `reconnectOnConnectionFailure`, which resets its
+      // backoff on any delivered event.
+      openedAt = undefined
+      consecutiveFruitlessConnections = 0
+
       const [parseError, event] = parseEvent(message)
       if (parseError) {
         observer.error(

--- a/src/data/eventsource.ts
+++ b/src/data/eventsource.ts
@@ -27,6 +27,22 @@ export class ConnectionFailedError extends Error {
 }
 
 /**
+ * @public
+ * Thrown when the EventSource connection repeatedly connects successfully, only for the server
+ * to end the stream right away.
+ *
+ * EventSource implementations treat a 200 response with a `text/event-stream` content-type as a
+ * successful connection — even when the body is not valid SSE (eg an error payload) — and will
+ * reconnect indefinitely when the stream ends. Successful connections also reset the reconnection
+ * backoff, so a server that repeatedly accepts the connection and then drops it creates an
+ * infinite, tight request loop that never surfaces an error. This error breaks that loop:
+ * reconnect handling gives up and the stream errors so consumers can react.
+ */
+export class ConnectionExhaustedError extends Error {
+  readonly name = 'ConnectionExhaustedError'
+}
+
+/**
  * The listener has been told to explicitly disconnect.
  *  This is a rare situation, but may occur if the API knows reconnect attempts will fail,
  *  eg in the case of a deleted dataset, a blocked project or similar events.
@@ -88,6 +104,25 @@ export interface ServerSentEvent<Name extends string> {
 const REQUIRED_EVENTS = ['channelError', 'disconnect']
 
 /**
+ * A connection that dies within this window of the `open` event is considered "fruitless":
+ * the server accepted the request but hung up without keeping the stream alive.
+ * Healthy SSE connections are long-lived — surviving past this window resets the counter below.
+ */
+const FRUITLESS_CONNECTION_WINDOW = 1000
+
+/**
+ * How many consecutive fruitless connections to tolerate before giving up.
+ *
+ * EventSource implementations auto-reconnect internally when an established stream ends, and a
+ * successful `open` resets their retry backoff — so a server that repeatedly accepts the
+ * connection and immediately drops it (eg a 200 `text/event-stream` response carrying an error
+ * payload instead of SSE frames) causes an infinite reconnect loop at a constant, tight cadence
+ * that never errors. Those internal reconnects never reach RxJS-level retry logic, so the cap
+ * must live here, at the EventSource event handlers themselves.
+ */
+const MAX_CONSECUTIVE_FRUITLESS_CONNECTIONS = 5
+
+/**
  * @internal
  */
 export type EventSourceEvent<Name extends string> = ServerSentEvent<Name>
@@ -110,6 +145,7 @@ export type EventSourceInstance = InstanceType<typeof globalThis.EventSource>
  * - {@link ChannelError}
  * - {@link DisconnectError}
  * - {@link ConnectionFailedError}
+ * - {@link ConnectionExhaustedError}
  *
  * @param initEventSource - A function that returns an EventSource instance or an Observable that resolves to an EventSource instance
  * @param events - an array of named events from the API to listen for.
@@ -143,6 +179,15 @@ function connectWithESInstance<EventTypeName extends string>(
     const emitOpen = (events as string[]).includes('open')
     const emitReconnect = (events as string[]).includes('reconnect')
 
+    // Tracks when the current connection was established, so that error events can tell a
+    // long-lived connection dropping (fine, reconnect) apart from the server hanging up right
+    // after accepting the request (fruitless — see MAX_CONSECUTIVE_FRUITLESS_CONNECTIONS).
+    // `undefined` means no `open` has happened since the last error, eg the connection attempt
+    // failed at the network level — those are not counted, as backing off while offline and
+    // recovering when the network returns is exactly what the internal reconnects are for.
+    let openedAt: number | undefined
+    let consecutiveFruitlessConnections = 0
+
     // EventSource will emit a regular Event if it fails to connect, however the API may also emit an `error` MessageEvent
     // So we need to handle both cases
     function onError(evt: MessageEvent | Event) {
@@ -173,6 +218,29 @@ function connectWithESInstance<EventTypeName extends string>(
         return
       }
 
+      // The connection was established (`open` fired) but died again — classify it.
+      // A connection that survived the window is healthy and resets the counter; one that died
+      // right away is fruitless, and too many in a row means the server keeps accepting the
+      // request only to drop it (eg an error payload served as 200 `text/event-stream`).
+      // The EventSource reconnects internally — invisible to RxJS retry operators — and resets
+      // its retry backoff on every successful open, so without this cap such a server is
+      // hammered in a tight, infinite loop that never surfaces an error to consumers.
+      if (openedAt !== undefined) {
+        consecutiveFruitlessConnections =
+          Date.now() - openedAt < FRUITLESS_CONNECTION_WINDOW
+            ? consecutiveFruitlessConnections + 1
+            : 0
+        openedAt = undefined
+        if (consecutiveFruitlessConnections >= MAX_CONSECUTIVE_FRUITLESS_CONNECTIONS) {
+          observer.error(
+            new ConnectionExhaustedError(
+              `The EventSource connection was repeatedly closed right after being established. Giving up after ${consecutiveFruitlessConnections} consecutive short-lived connections — this usually means the server accepts the request but is unable to serve the event stream.`,
+            ),
+          )
+          return
+        }
+      }
+
       if (es.readyState === es.CLOSED) {
         // In these cases we'll signal to consumers (via the error path) that a retry/reconnect is needed.
         observer.error(new ConnectionFailedError('EventSource connection failed'))
@@ -182,8 +250,11 @@ function connectWithESInstance<EventTypeName extends string>(
     }
 
     function onOpen() {
-      // The open event of the EventSource API is fired when a connection with an event source is opened.
-      observer.next({type: 'open' as EventTypeName})
+      openedAt = Date.now()
+      if (emitOpen) {
+        // The open event of the EventSource API is fired when a connection with an event source is opened.
+        observer.next({type: 'open' as EventTypeName})
+      }
     }
 
     function onMessage(message: MessageEvent) {
@@ -223,10 +294,9 @@ function connectWithESInstance<EventTypeName extends string>(
     }
 
     es.addEventListener('error', onError)
-
-    if (emitOpen) {
-      es.addEventListener('open', onOpen)
-    }
+    // Always observe `open` (not only when the consumer subscribes to it) — the error handler
+    // above needs it to detect connections that are repeatedly dropped right after opening.
+    es.addEventListener('open', onOpen)
 
     // Make sure we have a unique list of events types to avoid listening multiple times,
     const cleanedEvents = [...new Set([...REQUIRED_EVENTS, ...events])]
@@ -237,9 +307,7 @@ function connectWithESInstance<EventTypeName extends string>(
 
     return () => {
       es.removeEventListener('error', onError)
-      if (emitOpen) {
-        es.removeEventListener('open', onOpen)
-      }
+      es.removeEventListener('open', onOpen)
       cleanedEvents.forEach((type: string) => es.removeEventListener(type, onMessage))
       es.close()
     }

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -14,7 +14,7 @@ import type {
 } from '../types'
 import {shareReplayLatest} from '../util/shareReplayLatest'
 import {_getDataUrl} from './dataMethods'
-import {connectEventSource} from './eventsource'
+import {connectEventSource, ConnectionExhaustedError} from './eventsource'
 import {eventSourcePolyfill} from './eventsourcePolyfill'
 import {reconnectOnConnectionFailure} from './reconnectOnConnectionFailure'
 
@@ -143,6 +143,11 @@ export class LiveClient {
           // `CorsOriginError`, just rethrow it instead of calling `/check/cors`
           // a second time only to get the same answer.
           if (err instanceof CorsOriginError) {
+            return throwError(() => err)
+          }
+          // Exhaustion means the server repeatedly *accepted* the connection and then dropped
+          // it — by definition not a CORS rejection, so skip the probe and surface it as-is.
+          if (err instanceof ConnectionExhaustedError) {
             return throwError(() => err)
           }
           return checkCors.pipe(

--- a/src/data/reconnectOnConnectionFailure.ts
+++ b/src/data/reconnectOnConnectionFailure.ts
@@ -1,10 +1,12 @@
 import {
   catchError,
   concat,
+  defer,
   mergeMap,
   Observable,
   of,
   type OperatorFunction,
+  tap,
   throwError,
   timer,
 } from 'rxjs'
@@ -13,32 +15,58 @@ import {ConnectionFailedError} from './eventsource'
 
 const RETRYABLE_STATUSES = new Set([408, 429])
 
+const INITIAL_RECONNECT_DELAY = 1000
+const MAX_RECONNECT_DELAY = 30_000
+
 /**
  * Note: connection failure is not the same as network disconnect which may happen more frequent.
  * The EventSource instance will automatically reconnect in case of a network disconnect, however,
  * in some rare cases a ConnectionFailed Error will be thrown and this operator explicitly retries these
+ *
+ * Retries use exponential backoff (1s, 2s, 4s, … capped at 30s) so that a server that keeps
+ * rejecting the connection isn't hammered at a constant, tight cadence. The backoff resets once
+ * the connection recovers and delivers an event.
  */
 export function reconnectOnConnectionFailure<T>(): OperatorFunction<T, T | {type: 'reconnect'}> {
   return function (source: Observable<T>) {
-    return source.pipe(
-      catchError((err, caught) => {
-        // Only reconnect on transient connection failures. A 4xx response is a
-        // rejection, not a transient failure — the server will keep rejecting
-        // (eg an expired token), so reconnecting would loop forever. The named
-        // exceptions are the explicitly transient 4xx statuses: 408 (request
-        // timeout) and 429 (rate limited). Anything else surfaces to the
-        // consumer instead.
-        if (
-          err instanceof ConnectionFailedError &&
-          (typeof err.status !== 'number' ||
-            err.status < 400 ||
-            err.status >= 500 ||
-            RETRYABLE_STATUSES.has(err.status))
-        ) {
-          return concat(of({type: 'reconnect' as const}), timer(1000).pipe(mergeMap(() => caught)))
-        }
-        return throwError(() => err)
-      }),
-    )
+    // `defer` scopes the failure count per subscription, not per operator instance.
+    return defer(() => {
+      let consecutiveFailures = 0
+      return source.pipe(
+        tap((event) => {
+          // Any real event means the connection recovered — reset the backoff. Emitted
+          // `reconnect` values are the failures being counted, so they don't reset it.
+          if ((event as {type?: unknown} | null)?.type !== 'reconnect') {
+            consecutiveFailures = 0
+          }
+        }),
+        catchError((err, caught) => {
+          // Only reconnect on transient connection failures. A 4xx response is a
+          // rejection, not a transient failure — the server will keep rejecting
+          // (eg an expired token), so reconnecting would loop forever. The named
+          // exceptions are the explicitly transient 4xx statuses: 408 (request
+          // timeout) and 429 (rate limited). Anything else surfaces to the
+          // consumer instead.
+          if (
+            err instanceof ConnectionFailedError &&
+            (typeof err.status !== 'number' ||
+              err.status < 400 ||
+              err.status >= 500 ||
+              RETRYABLE_STATUSES.has(err.status))
+          ) {
+            consecutiveFailures++
+            const delay = Math.min(
+              INITIAL_RECONNECT_DELAY * 2 ** (consecutiveFailures - 1),
+              MAX_RECONNECT_DELAY,
+            )
+            return concat(
+              of({type: 'reconnect' as const}),
+              timer(delay).pipe(mergeMap(() => caught)),
+            )
+          }
+          return throwError(() => err)
+        }),
+      )
+    })
   }
 }

--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -7,6 +7,7 @@ export {validateApiPerspective} from './config'
 export {
   ChannelError,
   connectEventSource,
+  ConnectionExhaustedError,
   ConnectionFailedError,
   DisconnectError,
   type EventSourceEvent,

--- a/test/eventsource.test.ts
+++ b/test/eventsource.test.ts
@@ -1,0 +1,138 @@
+import {afterEach, beforeEach, describe, expect, test, vitest} from 'vitest'
+
+import {
+  connectEventSource,
+  ConnectionExhaustedError,
+  type EventSourceInstance,
+} from '../src/data/eventsource'
+
+/**
+ * A minimal scripted EventSource stand-in that lets tests dispatch `open`/`error`/message
+ * events synchronously, so the fruitless-connection accounting in `connectEventSource` can be
+ * exercised without real timers or sockets.
+ */
+class FakeEventSource {
+  CONNECTING = 0 as const
+  OPEN = 1 as const
+  CLOSED = 2 as const
+
+  url = 'https://abc123.api.sanity.io/vX/data/live/events/fake'
+  readyState: 0 | 1 | 2 = 0
+  closed = false
+
+  #listeners = new Map<string, Set<(evt: unknown) => void>>()
+
+  addEventListener(type: string, listener: (evt: unknown) => void) {
+    if (!this.#listeners.has(type)) this.#listeners.set(type, new Set())
+    this.#listeners.get(type)!.add(listener)
+  }
+
+  removeEventListener(type: string, listener: (evt: unknown) => void) {
+    this.#listeners.get(type)?.delete(listener)
+  }
+
+  close() {
+    this.closed = true
+    this.readyState = this.CLOSED
+  }
+
+  dispatch(type: string, evt: Record<string, unknown> = {}) {
+    for (const listener of this.#listeners.get(type) ?? []) {
+      listener({type, ...evt})
+    }
+  }
+
+  /** Simulates the internal reconnect cycle of a real EventSource: open, then the stream ends. */
+  openThenDrop() {
+    this.readyState = this.OPEN
+    this.dispatch('open')
+    // Native and polyfilled EventSource implementations go back to CONNECTING and retry
+    // internally when an established stream ends — the error event carries no data or status.
+    this.readyState = this.CONNECTING
+    this.dispatch('error')
+  }
+}
+
+describe('connectEventSource - fruitless connections', () => {
+  beforeEach(() => {
+    vitest.useFakeTimers()
+  })
+  afterEach(() => {
+    vitest.useRealTimers()
+  })
+
+  const subscribe = (es: FakeEventSource) => {
+    const events: unknown[] = []
+    let error: unknown
+    const subscription = connectEventSource(
+      () => es as unknown as EventSourceInstance,
+      ['message', 'welcome', 'reconnect'],
+    ).subscribe({
+      next: (event) => events.push(event),
+      error: (err) => (error = err),
+    })
+    return {events, getError: () => error, subscription}
+  }
+
+  test('gives up with ConnectionExhaustedError when connections are repeatedly dropped right after opening', () => {
+    const es = new FakeEventSource()
+    const {events, getError} = subscribe(es)
+
+    // First four short-lived connections emit `reconnect` and keep going
+    for (let i = 0; i < 4; i++) {
+      es.openThenDrop()
+    }
+    expect(events).toEqual(new Array(4).fill({type: 'reconnect'}))
+    expect(getError()).toBeUndefined()
+
+    // The fifth consecutive short-lived connection exhausts the attempts
+    es.openThenDrop()
+    expect(getError()).toBeInstanceOf(ConnectionExhaustedError)
+    expect(es.closed, 'the EventSource must be closed so it stops reconnecting internally').toBe(
+      true,
+    )
+  })
+
+  test('a long-lived connection resets the counter', () => {
+    const es = new FakeEventSource()
+    const {getError} = subscribe(es)
+
+    for (let i = 0; i < 4; i++) {
+      es.openThenDrop()
+    }
+
+    // This connection survives well past the fruitless window before dropping
+    es.readyState = es.OPEN
+    es.dispatch('open')
+    vitest.advanceTimersByTime(60_000)
+    es.readyState = es.CONNECTING
+    es.dispatch('error')
+    expect(getError()).toBeUndefined()
+
+    // A fresh run of short-lived connections is tolerated again up to the limit
+    for (let i = 0; i < 4; i++) {
+      es.openThenDrop()
+    }
+    expect(getError()).toBeUndefined()
+
+    es.openThenDrop()
+    expect(getError()).toBeInstanceOf(ConnectionExhaustedError)
+  })
+
+  test('network-level failures without a successful open are not counted', () => {
+    const es = new FakeEventSource()
+    const {getError} = subscribe(es)
+
+    // Repeated connection attempts that never open, eg while offline. The EventSource keeps
+    // retrying internally (readyState CONNECTING) and these must never exhaust the connection.
+    for (let i = 0; i < 25; i++) {
+      es.dispatch('error')
+    }
+    expect(getError()).toBeUndefined()
+
+    // Once the network is back a healthy connection proceeds as usual
+    es.readyState = es.OPEN
+    es.dispatch('open')
+    expect(getError()).toBeUndefined()
+  })
+})

--- a/test/eventsource.test.ts
+++ b/test/eventsource.test.ts
@@ -93,6 +93,34 @@ describe('connectEventSource - fruitless connections', () => {
     )
   })
 
+  test('a short-lived connection that delivers an event resets the counter', () => {
+    const es = new FakeEventSource()
+    const {events, getError} = subscribe(es)
+
+    for (let i = 0; i < 4; i++) {
+      es.openThenDrop()
+    }
+
+    // This connection also dies within the fruitless window, but the server delivered an event
+    // first — proving it can serve the stream — so it must not count towards exhaustion.
+    es.readyState = es.OPEN
+    es.dispatch('open')
+    es.dispatch('welcome', {data: '{}'})
+    es.readyState = es.CONNECTING
+    es.dispatch('error')
+    expect(getError()).toBeUndefined()
+    expect(events).toContainEqual({type: 'welcome', id: undefined})
+
+    // The counter was reset: a fresh run of fruitless connections is tolerated up to the limit
+    for (let i = 0; i < 4; i++) {
+      es.openThenDrop()
+    }
+    expect(getError()).toBeUndefined()
+
+    es.openThenDrop()
+    expect(getError()).toBeInstanceOf(ConnectionExhaustedError)
+  })
+
   test('a long-lived connection resets the counter', () => {
     const es = new FakeEventSource()
     const {getError} = subscribe(es)

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -3,6 +3,7 @@ import type {AddressInfo} from 'node:net'
 
 import {
   type ClientConfig,
+  ConnectionExhaustedError,
   ConnectionFailedError,
   CorsOriginError,
   createClient,
@@ -312,6 +313,65 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
           client.live.events({includeDrafts: true}).pipe(catchError((err) => of(err))),
         )
         expect(event).toEqual({type: 'reconnect'})
+      } finally {
+        nock.cleanAll()
+      }
+    })
+
+    test('stops reconnecting when the server repeatedly accepts the connection but immediately drops it', async () => {
+      // Regression for an infinite request loop observed in production: the API responded to
+      // /data/live/events with HTTP 200 and `content-type: text/event-stream`, but the body was
+      // a JSON error (`{"message":"Internal error"}`) instead of SSE frames, and the connection
+      // closed right away. EventSource treats such a response as a *successful* connection, so it
+      // reconnects internally forever — resetting its retry backoff on every attempt — without
+      // ever erroring. The client must detect the fruitless connection cycle, give up, and
+      // surface an error to subscribers.
+      expect.assertions(3)
+
+      const {default: nock} = await import('nock')
+
+      server.use(
+        http.get('https://abc123.api.sanity.io/vX/check/cors', () =>
+          HttpResponse.json({result: {allowed: true, withCredentials: true}}),
+        ),
+      )
+
+      let connectionAttempts = 0
+      nock('https://abc123.api.sanity.io')
+        .persist()
+        .get('/vX/data/live/events/internal-error')
+        .query(true)
+        .reply(() => {
+          connectionAttempts++
+          return [
+            200,
+            // `retry: 1` is valid SSE and speeds up the EventSource's internal reconnect delay
+            // so the test doesn't take multiple seconds — it dispatches no events, keeping the
+            // connection fruitless just like the raw JSON error body observed in production.
+            'retry: 1\n\n{"message":"Internal error"}\n',
+            {'Content-Type': 'text/event-stream'},
+          ]
+        })
+
+      const client = createClient({
+        projectId: 'abc123',
+        dataset: 'internal-error',
+        useCdn: false,
+        apiVersion: 'X',
+        token: 'valid-token',
+      })
+
+      try {
+        // The stream emits a `reconnect` event per fruitless cycle before giving up, so the
+        // error (mapped to a value by `catchError`) is the final emission.
+        const error = await lastValueFrom(
+          client.live.events({includeDrafts: true}).pipe(catchError((err) => of(err))),
+        )
+        expect(error).toBeInstanceOf(ConnectionExhaustedError)
+        expect(error.message).toMatchInlineSnapshot(
+          `"The EventSource connection was repeatedly closed right after being established. Giving up after 5 consecutive short-lived connections — this usually means the server accepts the request but is unable to serve the event stream."`,
+        )
+        expect(connectionAttempts, 'must not keep reconnecting forever').toBe(5)
       } finally {
         nock.cleanAll()
       }

--- a/test/reconnectOnConnectionFailure.test.ts
+++ b/test/reconnectOnConnectionFailure.test.ts
@@ -1,5 +1,5 @@
-import {catchError, firstValueFrom, of, throwError} from 'rxjs'
-import {describe, expect, test} from 'vitest'
+import {catchError, concat, defer, firstValueFrom, of, throwError} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, test, vitest} from 'vitest'
 
 import {ConnectionFailedError} from '../src/data/eventsource'
 import {reconnectOnConnectionFailure} from '../src/data/reconnectOnConnectionFailure'
@@ -48,5 +48,80 @@ describe('reconnectOnConnectionFailure()', () => {
   test('rethrows errors that are not connection failures', async () => {
     const error = new Error('unrelated')
     await expect(firstEmission(error)).resolves.toBe(error)
+  })
+
+  describe('backoff', () => {
+    beforeEach(() => {
+      vitest.useFakeTimers()
+    })
+    afterEach(() => {
+      vitest.useRealTimers()
+    })
+
+    test('reconnects with exponential backoff instead of a constant cadence', () => {
+      let attempts = 0
+      const source = defer(() => {
+        attempts++
+        return throwError(() => new ConnectionFailedError('failed'))
+      })
+
+      const subscription = source.pipe(reconnectOnConnectionFailure()).subscribe({
+        // Swallow emissions; this test only cares about the resubscription timing
+        error: () => {},
+      })
+
+      // Subscribing consumes the first attempt right away
+      expect(attempts).toBe(1)
+
+      // 1s, 2s, 4s, 8s...
+      vitest.advanceTimersByTime(1000)
+      expect(attempts).toBe(2)
+      vitest.advanceTimersByTime(1000)
+      expect(attempts, 'second retry waits 2s, not 1s').toBe(2)
+      vitest.advanceTimersByTime(1000)
+      expect(attempts).toBe(3)
+      vitest.advanceTimersByTime(4000)
+      expect(attempts).toBe(4)
+
+      // ...capped at 30s
+      vitest.advanceTimersByTime(8000)
+      expect(attempts).toBe(5)
+      vitest.advanceTimersByTime(16_000)
+      expect(attempts).toBe(6)
+      vitest.advanceTimersByTime(30_000)
+      expect(attempts).toBe(7)
+      vitest.advanceTimersByTime(30_000)
+      expect(attempts).toBe(8)
+
+      subscription.unsubscribe()
+    })
+
+    test('an emitted event resets the backoff', () => {
+      let attempts = 0
+      const source = defer(() => {
+        attempts++
+        // The second attempt recovers and delivers an event before failing again
+        return attempts === 2
+          ? concat(
+              of({type: 'welcome'}),
+              throwError(() => new ConnectionFailedError('failed')),
+            )
+          : throwError(() => new ConnectionFailedError('failed'))
+      })
+
+      const subscription = source.pipe(reconnectOnConnectionFailure()).subscribe({
+        error: () => {},
+      })
+
+      expect(attempts).toBe(1)
+      // First retry after 1s: emits a welcome event (resetting the backoff), then fails again
+      vitest.advanceTimersByTime(1000)
+      expect(attempts).toBe(2)
+      // The failure after the reset is treated as the first failure again: 1s, not 2s
+      vitest.advanceTimersByTime(1000)
+      expect(attempts).toBe(3)
+
+      subscription.unsubscribe()
+    })
   })
 })


### PR DESCRIPTION
## Problem

Visiting [the personal-website template's Presentation preview](https://nextjs-personal-website.sanity.dev/studio/presentation///?preview=https%3A//nextjs-personal-website.sanity.dev/%3Fsanity-preview-perspective%3Ddrafts) produced an infinite request loop: `GET /data/live/events/…` + a `GET /check/cors` probe every ~1.1s, per live connection, forever — with `<SanityLive>`'s `onError` never firing.

A HAR capture shows the API responding to `/data/live/events` with **HTTP 200** and `content-type: text/event-stream`, but the body is a JSON error (`{"message":"Internal error"}`) instead of SSE frames, and the connection closes ~100ms later.

## Root cause

EventSource implementations (native and both polyfills) treat a 200 + `text/event-stream` response as a **successful connection**, even when the body isn't valid SSE. When the stream then ends, they reconnect *internally* per the SSE spec — and since every attempt "succeeds", the reconnection backoff is reset on every cycle, producing a constant ~1s hammer. The HAR initiator stacks confirm the retries originate from the polyfill's internal `setTimeout`, not from RxJS resubscription.

Because these internal reconnects never error the stream, `connectWithESInstance` just emits `reconnect` values each cycle:

- `reconnectOnConnectionFailure()`'s 4xx-fatal classification (#1226) never runs — there's no error to classify.
- `live.events()` runs the `/check/cors` probe on every `reconnect`, amplifying the loop.
- Subscriber error callbacks (`<SanityLive onError>`) never trigger, so apps can't react.

## Upstream issue for Content Lake

> [!IMPORTANT]
> The client-side loop was triggered by the API serving an **error response with HTTP 200 + `content-type: text/event-stream`** on the live events endpoint. This needs a server-side fix regardless of this PR: a 200 + `text/event-stream` response is a *successful* connection per the SSE spec, so every status-code-based error path (client and browser alike) is bypassed, and spec-compliant EventSource clients will reconnect indefinitely with their backoff reset on each attempt. Older `@sanity/client` versions in the wild will keep hammering the API at ~1 req/s per subscriber (~2/s including the `/check/cors` probe each cycle) for as long as the condition persists.

Observed in the HAR (captured 2026-07-22T17:09:50Z, `sanity-gateway: k8s-gcp-eu-w1-prod-ing-01`, project `r0z1eifg`, dataset `personal-website-dev`):

```
GET https://r0z1eifg.api.sanity.io/v2025-02-27/data/live/events/personal-website-dev?tag=next-loader.live.cache-components&includeDrafts=true
HTTP 200
content-type: text/event-stream
traceparent: 00-892a88d324d04297c201c51d8ab8099a-dfd15a77f76094ed-01

{"message":"Internal error"}
```

The connection closes ~100ms after opening. Same behavior on `v2025-02-19` (tag `sanity.studio.presentation-loader`, `traceparent: 00-53373a38aacab1170f47f36421863637-f2df687cd5a123d5-01`) — 74 identical looping requests over the 40s capture. The traceparents should locate the underlying internal error.

What the endpoint should do instead:

- If the failure happens **before headers are sent**: respond with a real `5xx` status. The client classifies those as transient and retries with backoff (and, after this PR, capped attempts).
- If the failure happens **after the stream is established**: emit an SSE error frame (`event: error` + `data: {"message": …}`) before closing — the client already surfaces those as `MessageError` to subscribers.

## Fix

- `connectWithESInstance` now tracks connection lifetimes: a connection that dies within 1s of `open` is *fruitless*, and 5 consecutive fruitless connections tear down the EventSource and error the stream with the new **`ConnectionExhaustedError`** (exported). Attempts that never reach `open` (offline/network failures) are deliberately not counted, and a connection surviving past the window resets the counter — so ordinary flaky-network reconnects behave exactly as before.
- `ConnectionExhaustedError` is not retried by `reconnectOnConnectionFailure()` and skips the `/check/cors` probe in `live.events()` (the server demonstrably accepted the connection, so it can't be a CORS rejection), propagating straight to subscribers.
- `reconnectOnConnectionFailure()` now retries with exponential backoff (1s doubling to a 30s cap, reset once an event is delivered) instead of a fixed 1s cadence — the RxJS-level retry loop (eg repeated 5xx rejections) had the same constant-hammer problem.

With the fix, the reproduced scenario stops after 5 attempts (~4s) and surfaces the error to `onError`:

```
events emitted: ["reconnect","reconnect","reconnect","reconnect"]
errored after 4.0s with ConnectionExhaustedError: The EventSource connection was repeatedly closed right after being established. Giving up after 5 consecutive short-lived connections — this usually means the server accepts the request but is unable to serve the event stream.
live/events connection attempts: 5 | check/cors probes: 4
```

## Test plan

- [x] New `test/eventsource.test.ts`: exhaustion after 5 fruitless connections, counter reset by long-lived connections, network-level failures (no `open`) never counted — deterministic via a scripted EventSource fake, passes in node/browser/edge configs
- [x] New regression test in `test/live.test.ts` reproducing the HAR scenario end-to-end (200 + `text/event-stream` + JSON error body via nock): asserts `ConnectionExhaustedError` and exactly 5 connection attempts
- [x] New backoff tests in `test/reconnectOnConnectionFailure.test.ts` (exponential growth, 30s cap, reset on delivered event)
- [x] Full suite: 1022 passed; the single `test/client.test.ts` stack-trace failure is pre-existing on `main` (verified via stash)
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, and `npm run build` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live EventSource reconnect and error surfacing behavior; apps may now see ConnectionExhaustedError where streams previously looped silently, but normal flaky-network reconnects are intentionally preserved.
> 
> **Overview**
> Fixes an **infinite `/data/live/events` loop** when the API returns HTTP 200 with `text/event-stream` but closes right away without real SSE (e.g. a JSON error body). EventSource treats that as success and reconnects forever without erroring, so subscribers never see failures and CORS probes run on every cycle.
> 
> **`connectEventSource`** now tracks **fruitless** connections (opened then closed within 1s with no events). After **5 in a row**, it closes the EventSource and errors with the new exported **`ConnectionExhaustedError`**. Delivering any event or keeping the connection open past the window resets the counter; errors before `open` (offline) are not counted.
> 
> **`live.events()`** passes **`ConnectionExhaustedError`** through without the `/check/cors` probe. **`reconnectOnConnectionFailure()`** uses **exponential backoff** (1s → 30s cap, reset on a real event) instead of a fixed 1s retry.
> 
> Tests cover fruitless-connection logic, the production regression scenario, and backoff behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6eb98ce9ed9dd77d1f750a747ff241ac808c91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->