### PR TITLE
fix(live): stop the infinite reconnect + /check/cors request loop on goaway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,7 +1038,7 @@ The method will emit different types of events:
 - `message`: Regular event messages.
 - `restart`: Emitted when the event stream restarts.
 - `reconnect`: Emitted when the client reconnects to the event stream.
-- `goaway`: Emitted when when the connection is rejected or had to be closed, eg. if connection limits are reached and the client should switch data fetching strategy from live to polling.
+- `goaway`: Emitted when when the connection is rejected or had to be closed, eg. if connection limits are reached and the client should switch data fetching strategy from live to polling. The observable completes after emitting this event — the server is intentionally shutting the connection down, so no reconnect is attempted.
 - `welcome`: Emitted when the client successfully connects to the event stream.
 
 To listen to updates in draft content, set `includeDrafts` to `true`

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -1,4 +1,4 @@
-import {catchError, mergeMap, Observable, of, throwError} from 'rxjs'
+import {catchError, mergeMap, Observable, of, takeWhile, throwError} from 'rxjs'
 import {finalize, map} from 'rxjs/operators'
 
 import {CorsOriginError} from '../http/errors'
@@ -131,6 +131,14 @@ export class LiveClient {
     const observable = events
       .pipe(
         reconnectOnConnectionFailure(),
+        // The server sends `goaway` when it rejects or is about to close the
+        // connection on purpose, eg when connection limits are reached. The
+        // EventSource machinery auto-reconnects — and the server will just
+        // keep rejecting — so deliver the event downstream, then complete,
+        // which tears down the EventSource before it can turn a deliberate
+        // rejection into an infinite reconnect loop. Consumers are expected
+        // to fall back to polling per the Live Content API contract.
+        takeWhile((event) => event.type !== 'goaway', true),
         mergeMap((event) => {
           if (event.type === 'reconnect') {
             // Check for CORS on reconnect events (which happen on 403s)
@@ -158,7 +166,15 @@ export class LiveClient {
             // Splat data properties from the eventsource message onto the returned event
             return {...rest, tags: (data as {tags: SyncTag[]}).tags} as LiveEventMessage
           }
-          return event as LiveEventRestart | LiveEventReconnect | LiveEventWelcome | LiveEventGoAway
+          if (event.type === 'goaway') {
+            const {data, ...rest} = event
+            // Splat the reason from the eventsource message onto the returned event
+            return {
+              ...rest,
+              reason: (data as {reason?: string} | undefined)?.reason,
+            } as LiveEventGoAway
+          }
+          return event as LiveEventRestart | LiveEventReconnect | LiveEventWelcome
         }),
       )
       .pipe(

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -128,6 +128,11 @@ export class LiveClient {
       esOptions.withCredentials === true,
     )
 
+    // Tracks whether the current connection delivered any server event since
+    // the last `reconnect`, so reconnects can tell "an established connection
+    // dropped" apart from "connection attempts keep failing".
+    let connectionEstablished = false
+
     const observable = events
       .pipe(
         reconnectOnConnectionFailure(),
@@ -140,11 +145,22 @@ export class LiveClient {
         // to fall back to polling per the Live Content API contract.
         takeWhile((event) => event.type !== 'goaway', true),
         mergeMap((event) => {
-          if (event.type === 'reconnect') {
-            // Check for CORS on reconnect events (which happen on 403s)
-            return checkCors.pipe(mergeMap(() => of(event)))
+          if (event.type !== 'reconnect') {
+            // Any server-sent event means the connection was established
+            connectionEstablished = true
+            return of(event)
           }
-          return of(event)
+          const wasEstablished = connectionEstablished
+          connectionEstablished = false
+          // An established connection that drops is a transient failure, not
+          // a CORS rejection — CORS is enforced when connecting. Only probe
+          // `/check/cors` while connection attempts fail without ever getting
+          // established (eg a 403 on connect), otherwise every drop of a
+          // healthy connection would fire a probe request per reconnect.
+          if (wasEstablished) {
+            return of(event)
+          }
+          return checkCors.pipe(mergeMap(() => of(event)))
         }),
         catchError((err) => {
           // If a prior `reconnect` already ran the CORS probe and produced a
@@ -178,7 +194,10 @@ export class LiveClient {
         }),
       )
       .pipe(
-        finalize(() => eventsCache.delete(key)),
+        finalize(() => {
+          connectionEstablished = false
+          eventsCache.delete(key)
+        }),
         shareReplayLatest({
           predicate: (event) => event.type === 'welcome',
         }),

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -213,6 +213,37 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       }
     }, 10_000)
 
+    test('does not probe /check/cors when an established connection drops', async () => {
+      // An established connection that drops is a transient failure, not a
+      // CORS rejection — CORS is enforced when connecting. Probing
+      // `/check/cors` on every `reconnect` event meant a flaky (or
+      // deliberately dropped) connection fired a probe request per reconnect,
+      // hammering the API endlessly.
+      expect.assertions(2)
+
+      let corsProbes = 0
+      server.use(
+        http.get('*/check/cors', () => {
+          corsProbes++
+          return HttpResponse.json({result: {allowed: true, withCredentials: false}})
+        }),
+      )
+
+      const {server: sseServer, client} = await testSse(({channel}) => {
+        channel!.send({event: 'welcome'})
+        // Drop the connection shortly after it was established
+        setTimeout(() => channel!.close(), 25)
+      })
+
+      try {
+        const events = await lastValueFrom(client.live.events().pipe(take(2), toArray()))
+        expect(events.map((event) => event.type)).toEqual(['welcome', 'reconnect'])
+        expect(corsProbes, 'must not probe /check/cors after an established connection').toBe(0)
+      } finally {
+        sseServer.close()
+      }
+    }, 10_000)
+
     test('emits errors', async () => {
       expect.assertions(1)
 

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@sanity/client'
 import {http, HttpResponse} from 'msw'
 import {setupServer} from 'msw/node'
-import {catchError, firstValueFrom, lastValueFrom, of, take} from 'rxjs'
+import {catchError, firstValueFrom, lastValueFrom, of, take, toArray} from 'rxjs'
 import {afterAll, afterEach, beforeAll, describe, expect, test, vitest} from 'vitest'
 
 import {createSseServer, type OnRequest} from './helpers/sseServer'
@@ -180,6 +180,38 @@ describe.skipIf(typeof EdgeRuntime === 'string' || typeof document !== 'undefine
       expect(msg.type, 'emits goaway events to tell the client to switch to polling').toBe('goaway')
       server.close()
     })
+
+    test('exposes the goaway reason and stops reconnecting after a goaway event', async () => {
+      // `goaway` means the server rejected or is closing the connection on
+      // purpose (eg connection limits reached) and the client should fall
+      // back to polling. The EventSource machinery auto-reconnects when the
+      // server then closes the connection, which used to turn a deliberate
+      // rejection into an infinite reconnect loop: a new connection attempt
+      // and a `/check/cors` probe every second, forever, without ever
+      // surfacing anything to the subscriber.
+      expect.assertions(3)
+
+      let connectAttempts = 0
+      const {server, client} = await testSse(({channel}) => {
+        connectAttempts++
+        channel!.send({event: 'welcome'})
+        channel!.send({event: 'goaway', id: '123', data: {reason: 'connection limit reached'}})
+        process.nextTick(() => channel!.close())
+      })
+
+      try {
+        // `toArray` only resolves if the stream completes on its own
+        const events = await lastValueFrom(client.live.events().pipe(toArray()))
+        expect(events.map((event) => event.type)).toEqual(['welcome', 'goaway'])
+        expect(events[1]).toEqual({type: 'goaway', id: '123', reason: 'connection limit reached'})
+
+        // Give a (buggy) auto-reconnect a chance to fire before asserting
+        await new Promise((resolve) => setTimeout(resolve, 1500))
+        expect(connectAttempts, 'must not reconnect after a goaway event').toBe(1)
+      } finally {
+        server.close()
+      }
+    }, 10_000)
 
     test('emits errors', async () => {
       expect.assertions(1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Visiting a Presentation preview (eg `https://nextjs-personal-website.sanity.dev/studio/presentation/…?preview=…`) can put `client.live.events()` into an endless request loop — a new `live/events` connection attempt, a `/check/cors` probe, and (via the studio's loaders) a full query refetch storm roughly every second, dozens of times per minute — without `onError` on `<SanityLive>` ever firing.

## Root cause

Reproduced with the built browser bundle in headless Chrome against a mock Live API (polyfilled `EventSource` path, ie `includeDrafts` + token, exactly like production draft mode):

1. **`goaway` is not honored.** The Live Content API sends `goaway` when it rejects/closes a connection on purpose (eg `"connection limit reached"`) and then closes the stream. `live.events()` just forwards the event; nothing closes the `EventSource`. The `EventSource` machinery treats the close as a transient drop and auto-reconnects. Because each attempt *succeeds* before being closed again (welcome → goaway → close), the polyfill's retry backoff **resets to 1s on every cycle**, so a server that keeps rejecting produces a steady ~1s loop, forever.
2. **A `/check/cors` probe fires on every `reconnect` event.** Reconnect events are emitted for *any* dropped connection, not just rejected connection attempts, so the loop above (or any repeatedly-dropped connection) hammers `/check/cors` once per cycle — the "cors happens dozens of times per minute" signature in the network tab.
3. Since each cycle ends in an internal reconnect rather than a stream error, **no error ever reaches the subscriber** — `onError` never triggers, and the loop is invisible to the app.

Repro trace (before, mock server sends welcome + goaway then closes; repeats forever):

```
0.0s GET /vX/data/live/events/… → 200, welcome
0.2s goaway
0.3s GET /vX/check/cors → reconnect
1.3s GET /vX/data/live/events/…&lastEventId=… → 200, welcome
1.5s goaway
1.6s GET /vX/check/cors → reconnect
… (forever, ~1s cadence)
```

Bonus bug found along the way: `LiveEventGoAway` declares a `reason` property, but consumers actually received it nested under `data.reason` — so eg `next-sanity`'s default `onGoAway` handler logged `undefined`.

## Fix

- **`goaway` now terminates the stream**: the event is delivered downstream (so consumers can switch to polling, which is what `next-sanity`'s default `onGoAway` handler already does), then the observable completes, tearing down the `EventSource` before it can auto-reconnect into the loop.
- **`/check/cors` is only probed while connection attempts fail without ever establishing** (eg a 403 on connect). An established connection that drops was, by definition, not rejected by CORS — CORS is enforced at connect time — so those reconnects no longer probe. `CorsOriginError` detection for misconfigured origins is preserved (covered by the existing `handles CORS errors` test, which exercises the never-established probe path).
- `goaway` events now expose `reason` as typed.

After the fix, the same goaway repro:

```
0.0s GET /vX/data/live/events/… → 200, welcome
0.2s goaway (reason="connection limit reached")
0.2s complete   ← stream ends, EventSource closed, no further requests
```

And a transient drop (no goaway) still reconnects per SSE semantics, but with zero `/check/cors` probes.

## Notes

- Transient failure retries (network drops, 5xx, 408/429) are unchanged.
- `listen()` is unchanged (it never subscribes to `goaway`).

## Testing

- New regression tests: goaway completes the stream + exposes `reason` + no reconnect attempt afterwards; established-then-dropped connections emit `reconnect` without probing `/check/cors` (both fail against the previous implementation).
- Full suites pass: node (1019), browser (889), edge (473), lint, build.
- Verified end-to-end in headless Chrome with the bundled browser build against a mock Live API for the goaway, clean-drop, abrupt-drop, and 4xx-rejection scenarios.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdf57f10-93b4-43dc-99e3-31fd42278417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdf57f10-93b4-43dc-99e3-31fd42278417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

