### PR TITLE
feat: support querying by multiple variant conditions

### DIFF
--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -13,6 +13,7 @@ import type {
   Any,
   BaseActionOptions,
   BaseMutationOptions,
+  ClientVariantConditions,
   CreateVersionAction,
   DiscardVersionAction,
   FirstDocumentIdMutationOptions,
@@ -703,31 +704,17 @@ export function _requestObservable<R>(
 
     const variantOption = options.variant || config.variant
 
-    if (typeof variantOption !== 'undefined') {
-      if (typeof variantOption === 'string') {
-        options.query = {
-          variant: variantOption,
-          ...options.query,
-        }
+    if (typeof variantOption === 'string') {
+      options.query = {
+        variant: variantOption,
+        ...options.query,
       }
+    }
 
-      if (typeof variantOption === 'object') {
-        const variantConditions = Object.entries(variantOption)
-        const searchParams = variantConditionPairsToSearchParams(variantConditions).slice(0, 1)
-
-        if (variantConditions.length > 1) {
-          const formatter = new Intl.ListFormat('en')
-
-          // eslint-disable-next-line no-console -- will be removed in an upcoming version; it's better this behaviour is noisy and obvious
-          console.warn(
-            `The Sanity client's beta \`variant\` option currently only supports one condition. Dropped: ${formatter.format(variantConditions.slice(1).map(([subject]) => JSON.stringify(subject)))}.`,
-          )
-        }
-
-        options.query = {
-          ...Object.fromEntries(searchParams),
-          ...options.query,
-        }
+    if (typeof variantOption === 'object') {
+      options.query = {
+        variantCondition: variantConditionsToQueryArray(variantOption),
+        ...options.query,
       }
     }
 
@@ -875,11 +862,10 @@ const resourceDataBase = (config: InitializedClientConfig): string => {
   }
 }
 
-function variantConditionPairsToSearchParams(
-  variantConditionPairs: string[][],
-): ['variantCondition', `${string}:${string}`][] {
-  return variantConditionPairs.map(([condition, value]) => [
-    'variantCondition',
-    `${condition}:${value}`,
-  ])
+function variantConditionsToQueryArray(
+  variantConditions: ClientVariantConditions,
+): `${string}:${string}`[] {
+  return Object.entries(variantConditions)
+    .map<`${string}:${string}`>(([condition, value]) => `${condition}:${value}`)
+    .toSorted()
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1463,45 +1463,63 @@ describe('client', async () => {
       'setting a variant condition on client.fetch supersedes the config',
       async () => {
         nock(projectHost())
-          .get(`/vX/data/query/foo?query=*&returnQuery=false&variantCondition=market%3Aeu`)
+          .get(
+            `/vX/data/query/foo?query=*&returnQuery=false&variantCondition=audience%3Amusicians&variantCondition=currency%3Agbp&variantCondition=market%3Aeu`,
+          )
           .reply(200, {
             ms: 123,
             result,
           })
 
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const client = getClient({
+          apiVersion: 'X',
+          variant: {
+            market: 'us',
+          },
+        })
 
-        try {
-          const client = getClient({
-            apiVersion: 'X',
+        const res = await client.fetch(
+          '*',
+          {},
+          {
             variant: {
-              market: 'us',
+              market: 'eu',
+              currency: 'gbp',
+              audience: 'musicians',
             },
-          })
+          },
+        )
 
-          const res = await client.fetch(
-            '*',
-            {},
-            {
-              variant: {
-                market: 'eu',
-                currency: 'gbp',
-                audience: 'musicians',
-              },
-            },
-          )
-
-          expect(res.length, 'length should match').toBe(1)
-          expect(res[0].rating, 'data should match').toBe(5)
-
-          expect(warn).toHaveBeenCalledWith(
-            expect.stringContaining('Dropped: "currency" and "audience"'),
-          )
-        } finally {
-          warn.mockRestore()
-        }
+        expect(res.length, 'length should match').toBe(1)
+        expect(res[0].rating, 'data should match').toBe(5)
       },
     )
+
+    test.skipIf(isEdge)('sends multiple variant conditions ordered lexicographically', async () => {
+      const scope = nock(projectHost())
+        .get(
+          `/vX/data/query/foo?query=*&returnQuery=false&variantCondition=audience%3Amusicians&variantCondition=currency%3Agbp&variantCondition=market%3Aeu`,
+        )
+        .reply(200, {
+          ms: 123,
+          result,
+        })
+
+      const client = getClient({
+        apiVersion: 'X',
+        variant: {
+          market: 'eu',
+          audience: 'musicians',
+          currency: 'gbp',
+        },
+      })
+
+      const res = await client.fetch('*', {})
+
+      expect(res.length, 'length should match').toBe(1)
+      expect(res[0].rating, 'data should match').toBe(5)
+      expect(scope.isDone(), 'expected sorted variantCondition params').toBe(true)
+    })
 
     test.skipIf(isEdge)(
       'setting a variant id on client.fetch supersedes a variant condition from the config',


### PR DESCRIPTION
### Description

This branch expands variant querying to support multiple variant conditions.

### What to review

Query URL generated when providing a record of variant conditions to the `variant` option.

### Testing

Updated unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes beta query URL encoding for multi-key `variant` objects; callers relying on the old single-condition behavior will see different API requests.
> 
> **Overview**
> **Object-style `variant` options now send every condition**, not just the first. The client no longer logs a console warning when more than one key is provided.
> 
> For record `variant` values, query building sets `variantCondition` to an array of `subject:value` strings **sorted lexicographically** (via `variantConditionsToQueryArray`), so repeated params like `variantCondition=audience:musicians&variantCondition=currency:gbp&variantCondition=market:eu` are emitted. String `variant` IDs are unchanged.
> 
> Tests were updated to assert the full multi-condition URL and to add coverage for sorted ordering from client config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7946085d2682b6a775f9d0ace3fe64b60f1dda30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->