### PR TITLE
chore(deps): update happy-dom to v20 + fix browser tests (rebased #1152)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-tsdoc": "^0.5.2",
         "eslint-plugin-unused-imports": "^4.4.1",
         "globals": "^16.5.0",
-        "happy-dom": "^12.10.3",
+        "happy-dom": "^20.0.0",
         "json-diff": "^1.0.6",
         "ls-engines": "^0.10.1",
         "msw": "^2.15.0",
@@ -4452,6 +4452,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
@@ -5452,6 +5469,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -5951,13 +5981,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -6279,9 +6302,9 @@
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -7829,18 +7852,22 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "12.10.3",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-12.10.3.tgz",
-      "integrity": "sha512-JzUXOh0wdNGY54oKng5hliuBkq/+aT1V3YpTM+lrN/GoLQTANZsMaIvmHiHe612rauHvPJnDZkZ+5GZR++1Abg==",
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "css.escape": "^1.5.1",
-        "entities": "^4.5.0",
-        "iconv-lite": "^0.6.3",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0"
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -8018,19 +8045,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -11415,7 +11429,8 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/scheduler": {
       "version": "0.25.0",
@@ -13534,29 +13549,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -13812,6 +13804,28 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-tsdoc": "^0.5.2",
         "eslint-plugin-unused-imports": "^4.4.1",
         "globals": "^16.5.0",
-        "happy-dom": "^20.0.0",
+        "happy-dom": "^20.11.1",
         "json-diff": "^1.0.6",
         "ls-engines": "^0.10.1",
         "msw": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "eslint-plugin-tsdoc": "^0.5.2",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^16.5.0",
-    "happy-dom": "^12.10.3",
+    "happy-dom": "^20.0.0",
     "json-diff": "^1.0.6",
     "ls-engines": "^0.10.1",
     "msw": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "eslint-plugin-tsdoc": "^0.5.2",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^16.5.0",
-    "happy-dom": "^20.0.0",
+    "happy-dom": "^20.11.1",
     "json-diff": "^1.0.6",
     "ls-engines": "^0.10.1",
     "msw": "^2.15.0",

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -11,6 +11,20 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'happy-dom',
+      environmentOptions: {
+        happyDOM: {
+          // happy-dom v20 enforces the CORS same-origin policy and issues preflight
+          // `OPTIONS` requests for cross-origin fetches. The test suite mocks the API
+          // with nock (which only intercepts the real requests, not the preflights),
+          // so disable the same-origin policy to keep the simulated browser behavior
+          // aligned with what these tests expect.
+          settings: {
+            fetch: {
+              disableSameOriginPolicy: true,
+            },
+          },
+        },
+      },
       alias: {
         '@sanity/client/csm': new URL(pkg.exports['./csm'].source, import.meta.url).pathname,
         '@sanity/client/stega': new URL(pkg.exports['./stega'].browser.source, import.meta.url)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Rebases the Renovate `happy-dom` v20 security upgrade ([#1152](https://github.com/sanity-io/client/pull/1152)) onto the latest `main`, and fixes the browser test suite that breaks under happy-dom v20.

- Bumps `happy-dom` `^12.10.3` → `^20.11.1` (latest, resolves to `20.11.1`)
- Configures the browser Vitest environment to disable happy-dom's same-origin policy

## Why the tests were failing

The visible CI failure on [#1152](https://github.com/sanity-io/client/pull/1152) was the `browser-runtime` job erroring with:

```
##[error]Unable to download artifact(s): Artifact not found for name: build-output-<run_id>
```

That failure is **spurious**: the original run was from Jul 30, but the failing `browser-runtime` log is a *re-run from Aug 4*. The build artifact uses `retention-days: 1`, so it had long expired — the job failed at the download step, before ever running the tests. A rebase (fresh CI run) resolves that.

However, the artifact failure **masked a real regression**. Running the browser suite locally against happy-dom v20 revealed that it now enforces the CORS same-origin policy and issues preflight `OPTIONS` requests for cross-origin fetches. The suite mocks the API with `nock`, which only intercepts the real requests (not the preflight `OPTIONS`), so cross-origin requests fail.

Comparing the same sandbox:

| | happy-dom | preflight `OPTIONS` requests | browser tests |
|---|---|---|---|
| `main` | v12 | 0 | pass (892) |
| rebased upgrade (before fix) | v20 | 898 | fail (25 failures across 4 files) |
| rebased upgrade (with fix) | v20 | 0 | pass (892) |

## The fix

happy-dom exposes `settings.fetch.disableSameOriginPolicy`. Setting it in the browser Vitest config restores the pre-v20 behavior these nock-mocked tests rely on:

```ts
environmentOptions: {
  happyDOM: {
    settings: {
      fetch: {
        disableSameOriginPolicy: true,
      },
    },
  },
}
```

## Verification

- `npm run test:browser` → **892 passed | 102 skipped**, 0 preflight `OPTIONS` requests (matches `main` exactly)
- `eslint vitest.browser.config.ts` passes

## Note

This branch supersedes the Renovate PR [#1152](https://github.com/sanity-io/client/pull/1152), which cannot merge as-is because the happy-dom v20 upgrade breaks the browser tests without the accompanying config change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6410483-6ca8-40cb-8633-faa62f298e77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6410483-6ca8-40cb-8633-faa62f298e77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

