### PR TITLE
feat: RUN-1528 invoke function helper

### DIFF
--- a/.changeset/functions-invoke.md
+++ b/.changeset/functions-invoke.md
@@ -4,7 +4,9 @@
 
 feat: add `client.functions.invoke()` for calling deployed functions on demand
 
-Invoke a Sanity Function by the `name`. 
+Invoke a Sanity Pubsub Function by the `name`. Only `sanity.function.pubsub` functions can be
+invoked on demand.
+
 Available in two forms, `client.functions.invoke()` resolves with the function's return value, `client.observable.functions.invoke()` emits it and accepts an `event.data` payload,
 a per-call `timeout` and an `AbortSignal`.
 

--- a/.changeset/functions-invoke.md
+++ b/.changeset/functions-invoke.md
@@ -11,3 +11,7 @@ a per-call `timeout` and an `AbortSignal`.
 Names are only unique within a stack, so resolving one requires a `stackId`, either from the new
 `stackId` client config option or from the request. That resolution costs one extra request per
 call. A function that returns nothing resolves to `undefined`.
+
+Stacks deployed at organization scope are reached with the new `organizationId` client config
+option, or a per-call `organizationId`. It takes precedence over `projectId`, which becomes
+optional in that case.

--- a/.changeset/functions-invoke.md
+++ b/.changeset/functions-invoke.md
@@ -1,0 +1,13 @@
+---
+'@sanity/client': minor
+---
+
+feat: add `client.functions.invoke()` for calling deployed functions on demand
+
+Invoke a Sanity Function by the `name`. 
+Available in two forms, `client.functions.invoke()` resolves with the function's return value, `client.observable.functions.invoke()` emits it and accepts an `event.data` payload,
+a per-call `timeout` and an `AbortSignal`.
+
+Names are only unique within a stack, so resolving one requires a `stackId`, either from the new
+`stackId` client config option or from the request. That resolution costs one extra request per
+call. A function that returns nothing resolves to `undefined`.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ export async function updateDocumentTitle(_id, title) {
     - [Getting video playback information](#getting-video-playback-information)
     - [Working with signed playback information](#working-with-signed-playback-information)
     - [Downloading MP4 renditions](#downloading-mp4-renditions)
+  - [Invoking functions](#invoking-functions)
+    - [Choosing a stack](#choosing-a-stack)
+    - [Return values and timeouts](#return-values-and-timeouts)
 - [License](#license)
 - [Migrate](#migrate)
 
@@ -2446,6 +2449,69 @@ if (playbackInfo.renditions?.length) {
 ```
 
 Available resolutions depend on the source video but typically include `1080p`, `480p`, and `270p`.
+
+### Invoking functions
+
+Call a Sanity Pubsub Function on demand. These APIs are available on the `client.functions` namespace.
+
+Functions are addressed by the `name` they are declared with in your blueprint. Names are unique within a stack. The client needs a `stackId` in order to resolve. Configure it once on the client, or pass it per call.
+
+
+```js
+import {createClient} from '@sanity/client'
+
+const client = createClient({
+  projectId: 'your-project-id',
+  apiVersion: '2025-02-19',
+  token: 'valid-token',
+  stackId: 'your-stack-id',
+})
+
+const result = await client.functions.invoke('my-function', {
+  event: {data: {hello: 'world'}},
+})
+```
+
+The payload given as `event.data` is what the function receives as `event.data`. It defaults to `{}` when omitted.
+
+Both Promise and Observable forms are available:
+
+- `client.functions.invoke(name, request)` resolves with the function's return value
+- `client.observable.functions.invoke(name, request)` emits it and completes
+
+```ts
+// The return value is typed through the generic; it is not validated at runtime
+const summary = await client.functions.invoke<{words: number}>('summarize', {
+  event: {data: {documentId: 'abc123'}},
+})
+```
+
+#### Choosing a stack
+
+`stackId` on the request wins over `stackId` in the client config, which lets one client reach functions in more than one stack:
+
+```js
+await client.functions.invoke('my-function', {stackId: 'another-stack-id'})
+```
+
+Resolving the name costs one extra request per call: the client reads the stack to find the function, then invokes it. If neither the request nor the config supplies a `stackId`, the call rejects without touching the network. 
+
+Invoking a name the stack doesn't declare rejects.
+
+#### Return values and timeouts
+
+The request stays open until the function finishes, and resolves with whatever it returned. A function that returns nothing resolves to `undefined`.
+
+Requests time out after five minutes by default, so a longer-running function needs an explicit `timeout` (in milliseconds, `0` to disable it). A call can be aborted with an `AbortSignal` like any other request:
+
+```js
+const controller = new AbortController()
+
+const result = await client.functions.invoke('slow-function', {
+  timeout: 0, // or e.g. 600000 for a ten minute deadline
+  signal: controller.signal,
+})
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ export async function updateDocumentTitle(_id, title) {
     - [Downloading MP4 renditions](#downloading-mp4-renditions)
   - [Invoking functions](#invoking-functions)
     - [Choosing a stack](#choosing-a-stack)
+    - [Scoping to an organization](#scoping-to-an-organization)
     - [Return values and timeouts](#return-values-and-timeouts)
 - [License](#license)
 - [Migrate](#migrate)
@@ -2456,7 +2457,6 @@ Call a Sanity Pubsub Function on demand. These APIs are available on the `client
 
 Functions are addressed by the `name` they are declared with in your blueprint. Names are unique within a stack. The client needs a `stackId` in order to resolve. Configure it once on the client, or pass it per call.
 
-
 ```js
 import {createClient} from '@sanity/client'
 
@@ -2494,9 +2494,33 @@ const summary = await client.functions.invoke<{words: number}>('summarize', {
 await client.functions.invoke('my-function', {stackId: 'another-stack-id'})
 ```
 
-Resolving the name costs one extra request per call: the client reads the stack to find the function, then invokes it. If neither the request nor the config supplies a `stackId`, the call rejects without touching the network. 
+Resolving the name takes one extra request per call: the client reads the stack to find the function, then invokes it. If neither the request nor the config supplies a `stackId`, the call rejects without touching the network.
 
 Invoking a name the stack doesn't declare rejects.
+
+#### Scoping to an organization
+
+Project scope is the default. For an organization-scoped stack, set `organizationId`:
+
+```js
+const client = createClient({
+  projectId: 'your-project-id',
+  apiVersion: '2025-02-19',
+  token: 'valid-token',
+  stackId: 'your-stack-id',
+  organizationId: 'your-organization-id',
+})
+```
+
+It can also be passed per call, and wins over the client config:
+
+```js
+await client.functions.invoke('my-function', {organizationId: 'another-organization-id'})
+```
+
+An `organizationId` takes precedence over `projectId`, since a stack is only ever resolvable at one scope. `projectId` becomes optional in that case, provided the client is also configured with `useProjectHostname: false`.
+
+Scope has to match the token. A project-scoped token gets `403` on an organization-scoped stack; mint one that matches with `sanity blueprints mint-deploy-token --organization-id <id>`.
 
 #### Return values and timeouts
 

--- a/README.md
+++ b/README.md
@@ -2455,6 +2455,8 @@ Available resolutions depend on the source video but typically include `1080p`, 
 
 Call a Sanity Pubsub Function on demand. These APIs are available on the `client.functions` namespace.
 
+Only `sanity.function.pubsub` functions can be invoked this way. Every other type is driven by its own trigger.
+
 Functions are addressed by the `name` they are declared with in your blueprint. Names are unique within a stack. The client needs a `stackId` in order to resolve. Configure it once on the client, or pass it per call.
 
 ```js
@@ -2496,7 +2498,7 @@ await client.functions.invoke('my-function', {stackId: 'another-stack-id'})
 
 Resolving the name takes one extra request per call: the client reads the stack to find the function, then invokes it. If neither the request nor the config supplies a `stackId`, the call rejects without touching the network.
 
-Invoking a name the stack doesn't declare rejects.
+Invoking a name the stack doesn't declare or a non-pubsub function rejects.
 
 #### Scoping to an organization
 

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -10,6 +10,7 @@ import {LiveClient} from './data/live'
 import {ObservablePatch, Patch} from './data/patch'
 import {ObservableTransaction, Transaction} from './data/transaction'
 import {DatasetsClient, ObservableDatasetsClient} from './datasets/DatasetsClient'
+import {FunctionsClient, ObservableFunctionsClient} from './functions/FunctionsClient'
 import {
   MediaLibraryVideoClient,
   ObservableMediaLibraryVideoClient,
@@ -81,6 +82,7 @@ export class ObservableSanityClient {
   agent: {
     action: ObservableAgentsActionClient
   }
+  functions: ObservableFunctionsClient
   releases: ObservableReleasesClient
 
   /**
@@ -110,6 +112,7 @@ export class ObservableSanityClient {
     this.agent = {
       action: new ObservableAgentsActionClient(this, this.#httpRequest),
     }
+    this.functions = new ObservableFunctionsClient(this, this.#httpRequest)
     this.releases = new ObservableReleasesClient(this, this.#httpRequest)
   }
 
@@ -1148,6 +1151,7 @@ export class SanityClient {
   agent: {
     action: AgentActionsClient
   }
+  functions: FunctionsClient
   releases: ReleasesClient
 
   /**
@@ -1182,6 +1186,7 @@ export class SanityClient {
     this.agent = {
       action: new AgentActionsClient(this, this.#httpRequest),
     }
+    this.functions = new FunctionsClient(this, this.#httpRequest)
     this.releases = new ReleasesClient(this, this.#httpRequest)
 
     this.observable = new ObservableSanityClient(httpRequest, config)

--- a/src/functions/FunctionsClient.ts
+++ b/src/functions/FunctionsClient.ts
@@ -46,6 +46,9 @@ export class FunctionsClient {
    * the client config, which costs one extra request per call. Rejects if the
    * stack has no function by that name.
    *
+   * The lookup is scoped to `projectId`, or to `organizationId` when one is set
+   * for a stack deployed at organization scope.
+   *
    * The request stays open until the function finishes, and resolves with its
    * return value, or `undefined` if it returns nothing. Long-running functions
    * may need an explicit `timeout`.

--- a/src/functions/FunctionsClient.ts
+++ b/src/functions/FunctionsClient.ts
@@ -1,0 +1,62 @@
+import {lastValueFrom, type Observable} from 'rxjs'
+
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest} from '../types'
+import {_invoke, type InvokeFunctionRequest} from './invoke'
+
+/** @public */
+export class ObservableFunctionsClient {
+  #client: ObservableSanityClient
+  #httpRequest: HttpRequest
+  constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /**
+   * Invoke a deployed function by its blueprint name.
+   *
+   * The name is resolved within the stack given by `stackId` on the request or
+   * the client config. Passes the function's return value once it finishes.
+   *
+   * @param functionName - name of the function, as declared in the blueprint
+   * @param request - payload and request options
+   */
+  invoke<R = unknown>(
+    functionName: string,
+    request?: InvokeFunctionRequest,
+  ): Observable<R | undefined> {
+    return _invoke<R>(this.#client, this.#httpRequest, functionName, request)
+  }
+}
+
+/** @public */
+export class FunctionsClient {
+  #client: SanityClient
+  #httpRequest: HttpRequest
+  constructor(client: SanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /**
+   * Invoke a deployed function by its blueprint name.
+   *
+   * The name is resolved within the stack given by `stackId` on the request or
+   * the client config, which costs one extra request per call. Rejects if the
+   * stack has no function by that name.
+   *
+   * The request stays open until the function finishes, and resolves with its
+   * return value, or `undefined` if it returns nothing. Long-running functions
+   * may need an explicit `timeout`.
+   *
+   * @param functionName - name of the function, as declared in the blueprint
+   * @param request - payload and request options
+   */
+  invoke<R = unknown>(
+    functionName: string,
+    request?: InvokeFunctionRequest,
+  ): Promise<R | undefined> {
+    return lastValueFrom(_invoke<R>(this.#client, this.#httpRequest, functionName, request))
+  }
+}

--- a/src/functions/FunctionsClient.ts
+++ b/src/functions/FunctionsClient.ts
@@ -44,7 +44,8 @@ export class FunctionsClient {
    *
    * The name is resolved within the stack given by `stackId` on the request or
    * the client config, which costs one extra request per call. Rejects if the
-   * stack has no function by that name.
+   * stack has no function by that name, or if the name resolves to anything
+   * other than a `sanity.function.pubsub` function.
    *
    * The lookup is scoped to `projectId`, or to `organizationId` when one is set
    * for a stack deployed at organization scope.

--- a/src/functions/invoke.ts
+++ b/src/functions/invoke.ts
@@ -6,6 +6,7 @@ import type {HttpRequest, InitializedClientConfig} from '../types'
 
 /** Function resource types in a blueprint are namespaced under this prefix. */
 const FUNCTION_RESOURCE_PREFIX = 'sanity.function.'
+const INVOKABLE_FUNCTION_TYPE = 'sanity.function.pubsub'
 
 /** @public */
 export interface InvokeFunctionEvent {
@@ -129,6 +130,10 @@ function _resolveFunctionId(
         throw new Error(
           `Function "${functionName}" is declared in stack "${stackId}" but is not deployed`,
         )
+      }
+
+      if (match.type !== INVOKABLE_FUNCTION_TYPE) {
+        throw new Error(`Function invocation is not supported for ${match.type}`)
       }
 
       return match.externalId

--- a/src/functions/invoke.ts
+++ b/src/functions/invoke.ts
@@ -25,6 +25,10 @@ export interface InvokeFunctionRequest {
    */
   stackId?: string
   /**
+   * Organization owning the stack.
+   */
+  organizationId?: string
+  /**
    * Milliseconds to wait for the function to return.
    */
   timeout?: number
@@ -46,10 +50,24 @@ interface StackResource {
 
 type Client = SanityClient | ObservableSanityClient
 
-const scopeHeaders = (config: InitializedClientConfig): Record<string, string> => {
+const scopeHeaders = (
+  config: InitializedClientConfig,
+  request: InvokeFunctionRequest | undefined,
+): Record<string, string> => {
+  const organizationId = request?.organizationId || config.organizationId
+  if (organizationId) {
+    return {
+      'X-Sanity-Scope-Type': 'organization',
+      'X-Sanity-Scope-Id': organizationId,
+    }
+  }
+
   const {projectId} = config
   if (!projectId) {
-    throw new Error('`functions.invoke()` requires a `projectId` to be set in the client config')
+    throw new Error(
+      '`functions.invoke()` requires a `projectId` to be set in the client config, or an ' +
+        '`organizationId` for a stack deployed at organization scope',
+    )
   }
 
   return {
@@ -93,7 +111,7 @@ function _resolveFunctionId(
 ): Observable<string> {
   return _requestObservable<{resources?: StackResource[]}>(client, httpRequest, {
     method: 'GET',
-    uri: `/blueprints/stacks/${stackId}`,
+    url: `/blueprints/stacks/${stackId}`,
     headers,
     signal: request?.signal,
   }).pipe(
@@ -129,7 +147,7 @@ export function _invoke<R = unknown>(
   // (and so a rejected promise) rather than throwing at the call site.
   return defer(() => {
     const config = client.config()
-    const headers = scopeHeaders(config)
+    const headers = scopeHeaders(config, request)
     const stackId = resolveStackId(config, request)
 
     return _resolveFunctionId(client, httpRequest, functionName, stackId, headers, request).pipe(
@@ -141,7 +159,7 @@ export function _invoke<R = unknown>(
       mergeMap((functionId) =>
         _requestObservable<R | undefined>(client, httpRequest, {
           method: 'POST',
-          uri: `/functions/${functionId}/invoke`,
+          url: `/functions/${functionId}/invoke`,
           headers,
           body: {event: {data: request?.event?.data ?? {}}},
           timeout: request?.timeout,

--- a/src/functions/invoke.ts
+++ b/src/functions/invoke.ts
@@ -1,0 +1,153 @@
+import {defer, map, mergeMap, type Observable} from 'rxjs'
+
+import {_requestObservable} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest, InitializedClientConfig} from '../types'
+
+/** Function resource types in a blueprint are namespaced under this prefix. */
+const FUNCTION_RESOURCE_PREFIX = 'sanity.function.'
+
+/** @public */
+export interface InvokeFunctionEvent {
+  /**
+   * Payload handed to the function.
+   * The function receives it as `event.data`.
+   */
+  data?: unknown
+}
+
+/** @public */
+export interface InvokeFunctionRequest {
+  event?: InvokeFunctionEvent
+  /**
+   * Stack to resolve the function name against.
+   * Overrides `stackId` from the client config.
+   */
+  stackId?: string
+  /**
+   * Milliseconds to wait for the function to return.
+   */
+  timeout?: number
+  /** Abort the invocation. */
+  signal?: AbortSignal
+}
+
+/**
+ * Subset of a stack resource the client needs in order to resolve a name.
+ *
+ * @internal
+ */
+interface StackResource {
+  name: string
+  type: string
+  /** Provider-side id. For a function resource, the function id. */
+  externalId?: string
+}
+
+type Client = SanityClient | ObservableSanityClient
+
+const scopeHeaders = (config: InitializedClientConfig): Record<string, string> => {
+  const {projectId} = config
+  if (!projectId) {
+    throw new Error('`functions.invoke()` requires a `projectId` to be set in the client config')
+  }
+
+  return {
+    'X-Sanity-Scope-Type': 'project',
+    'X-Sanity-Scope-Id': projectId,
+  }
+}
+
+/**
+ * A per-call `stackId` overrides the one in the client config.
+ */
+const resolveStackId = (
+  config: InitializedClientConfig,
+  request: InvokeFunctionRequest | undefined,
+): string => {
+  const stackId = request?.stackId || config.stackId
+  if (!stackId) {
+    throw new Error(
+      '`functions.invoke()` requires a `stackId`, either in the client config or on the request. ' +
+        'Function names are only unique within a stack.',
+    )
+  }
+
+  return stackId
+}
+
+/**
+ * The invoke route is keyed by function id, but callers know functions by the
+ * name declared in the blueprint. Names are unique within a stack, so the stack
+ * both makes the name resolvable and confines the call to its own functions.
+ *
+ * @internal
+ */
+function _resolveFunctionId(
+  client: Client,
+  httpRequest: HttpRequest,
+  functionName: string,
+  stackId: string,
+  headers: Record<string, string>,
+  request: InvokeFunctionRequest | undefined,
+): Observable<string> {
+  return _requestObservable<{resources?: StackResource[]}>(client, httpRequest, {
+    method: 'GET',
+    uri: `/blueprints/stacks/${stackId}`,
+    headers,
+    signal: request?.signal,
+  }).pipe(
+    map((stack) => {
+      const match = (stack?.resources || []).find(
+        (resource) =>
+          resource.type?.startsWith(FUNCTION_RESOURCE_PREFIX) && resource.name === functionName,
+      )
+
+      if (!match) {
+        throw new Error(`Function "${functionName}" not found in stack "${stackId}"`)
+      }
+
+      if (!match.externalId) {
+        throw new Error(
+          `Function "${functionName}" is declared in stack "${stackId}" but is not deployed`,
+        )
+      }
+
+      return match.externalId
+    }),
+  )
+}
+
+/** @internal */
+export function _invoke<R = unknown>(
+  client: Client,
+  httpRequest: HttpRequest,
+  functionName: string,
+  request?: InvokeFunctionRequest,
+): Observable<R | undefined> {
+  // Deferred so a bad config surfaces as an error on the returned observable
+  // (and so a rejected promise) rather than throwing at the call site.
+  return defer(() => {
+    const config = client.config()
+    const headers = scopeHeaders(config)
+    const stackId = resolveStackId(config, request)
+
+    return _resolveFunctionId(client, httpRequest, functionName, stackId, headers, request).pipe(
+      // A function that returns nothing answers 204, which the transport parses
+      // to an `undefined` body. The status code is not observable from here —
+      // the `HttpRequest` boundary resolves to the body alone — so an empty
+      // response and a function that returned nothing both surface as
+      // `undefined`.
+      mergeMap((functionId) =>
+        _requestObservable<R | undefined>(client, httpRequest, {
+          method: 'POST',
+          uri: `/functions/${functionId}/invoke`,
+          headers,
+          body: {event: {data: request?.event?.data ?? {}}},
+          timeout: request?.timeout,
+          signal: request?.signal,
+        }),
+      ),
+    )
+  })
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -256,6 +256,11 @@ export interface ClientConfig {
    * Lineage token for recursion control
    */
   lineage?: string
+  /**
+   * ID of the blueprints stack that `functions.invoke()` resolves function
+   * names against. Function names are unique within a stack
+   */
+  stackId?: string
 }
 
 /** @public */
@@ -1938,6 +1943,7 @@ export type {
   TranslateTarget,
   TranslateTargetInclude,
 } from './agent/actions/translate'
+export type {InvokeFunctionEvent, InvokeFunctionRequest} from './functions/invoke'
 export type {
   ContentSourceMapParsedPath,
   ContentSourceMapParsedPathKeyedSegment,

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,6 +261,10 @@ export interface ClientConfig {
    * names against. Function names are unique within a stack
    */
   stackId?: string
+  /**
+   * ID of the organization owning the blueprints stack
+   */
+  organizationId?: string
 }
 
 /** @public */

--- a/test/functions/invoke.test.ts
+++ b/test/functions/invoke.test.ts
@@ -1,0 +1,235 @@
+import {createClient as createCoreClient} from '@sanity/client'
+import {describe, expect, test} from 'vitest'
+
+import {getActiveMock, testResolveFetch} from '../helpers/mockFetch'
+
+const PROJECT_ID = 'test123'
+const HOST = `https://${PROJECT_ID}.api.sanity.io`
+const API_VERSION = '2025-02-19'
+const BASE = `/v${API_VERSION}`
+const STACK_ID = 'ST-1234567890'
+const OTHER_STACK_ID = 'ST-9876543210'
+
+// Clients in this suite go through the per-test mock, injected via the
+// public `resolveFetch` config option.
+const createClient: typeof createCoreClient = (config) =>
+  createCoreClient({resolveFetch: testResolveFetch, ...config})
+
+const getClient = (overrides: {stackId?: string} = {stackId: STACK_ID}) =>
+  createClient({
+    projectId: PROJECT_ID,
+    dataset: 'prod',
+    apiVersion: API_VERSION,
+    useCdn: false,
+    token: 'my-token',
+    ...overrides,
+  })
+
+const stackUri = (stackId: string) => `${BASE}/blueprints/stacks/${stackId}`
+const invokeUri = (functionId: string) => `${BASE}/functions/${functionId}/invoke`
+
+const STACK = {
+  id: STACK_ID,
+  name: 'my-stack',
+  resources: [
+    {name: 'my-func', type: 'sanity.function.document', externalId: 'fn-abc123'},
+    {name: 'other-func', type: 'sanity.function.queue', externalId: 'fn-def456'},
+    // A non-function resource sharing a name must not be picked up.
+    {name: 'my-func', type: 'sanity.cors.origin', externalId: 'co-000000'},
+  ],
+}
+
+describe('client.functions.invoke', () => {
+  test('resolves the name within the stack and posts the event payload', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'), {body: {event: {data: {hello: 'world'}}}})
+      .respond({status: 200, body: {ok: true}})
+
+    const result = await getClient().functions.invoke('my-func', {
+      event: {data: {hello: 'world'}},
+    })
+
+    expect(result).toEqual({ok: true})
+    expect(mock).toHaveReceivedRequest('GET', stackUri(STACK_ID))
+    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'))
+  })
+
+  test('matches only resources of a function type', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'))
+      .respond({status: 200, body: {ok: true}})
+
+    await getClient().functions.invoke('my-func')
+
+    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'))
+  })
+
+  test('rejects when the stack has no function by that name', async () => {
+    getActiveMock().scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+
+    await expect(getClient().functions.invoke('not-in-stack')).rejects.toThrow(
+      `Function "not-in-stack" not found in stack "${STACK_ID}"`,
+    )
+  })
+
+  test('rejects when the function is declared but not yet deployed', async () => {
+    getActiveMock()
+      .scope(HOST)
+      .on('GET', stackUri(STACK_ID))
+      .respond({
+        status: 200,
+        body: {...STACK, resources: [{name: 'pending-func', type: 'sanity.function.document'}]},
+      })
+
+    await expect(getClient().functions.invoke('pending-func')).rejects.toThrow('is not deployed')
+  })
+
+  test('a per-call stackId overrides the client config', async () => {
+    const mock = getActiveMock()
+    mock
+      .scope(HOST)
+      .on('GET', stackUri(OTHER_STACK_ID))
+      .respond({
+        status: 200,
+        body: {
+          id: OTHER_STACK_ID,
+          resources: [
+            {name: 'my-func', type: 'sanity.function.document', externalId: 'fn-other999'},
+          ],
+        },
+      })
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-other999'))
+      .respond({status: 200, body: {ok: true}})
+
+    await getClient().functions.invoke('my-func', {stackId: OTHER_STACK_ID})
+
+    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-other999'))
+    // The stack from the client config is never consulted.
+    expect(mock).toHaveReceivedRequestTimes('GET', stackUri(STACK_ID), 0)
+  })
+
+  test('rejects when no stackId is configured or passed', async () => {
+    await expect(getClient({}).functions.invoke('my-func')).rejects.toThrow('requires a `stackId`')
+  })
+
+  test('rejects rather than throwing when projectId is missing', async () => {
+    const client = createClient({
+      apiVersion: API_VERSION,
+      useProjectHostname: false,
+      stackId: STACK_ID,
+    })
+
+    await expect(client.functions.invoke('my-func')).rejects.toThrow('requires a `projectId`')
+  })
+
+  test('does not require a dataset', async () => {
+    // Functions are project-scoped: the routes carry no dataset segment and the
+    // scope headers name only the project, so a dataset-less client must work.
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'))
+      .respond({status: 200, body: {ok: true}})
+
+    const client = createClient({
+      projectId: PROJECT_ID,
+      apiVersion: API_VERSION,
+      useCdn: false,
+      token: 'my-token',
+      stackId: STACK_ID,
+    })
+
+    await expect(client.functions.invoke('my-func')).resolves.toEqual({ok: true})
+  })
+
+  test('sends the project scope headers the services require', async () => {
+    const scopeHeaders = {'X-Sanity-Scope-Type': 'project', 'X-Sanity-Scope-Id': PROJECT_ID}
+    const mock = getActiveMock()
+    mock
+      .scope(HOST)
+      .on('GET', stackUri(STACK_ID), {headers: scopeHeaders})
+      .respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'), {headers: scopeHeaders})
+      .respond({status: 200, body: {ok: true}})
+
+    await getClient().functions.invoke('my-func')
+
+    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'), {headers: scopeHeaders})
+  })
+
+  test('defaults the payload to an empty object when no event is given', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'), {body: {event: {data: {}}}})
+      .respond({status: 200, body: {ok: true}})
+
+    await getClient().functions.invoke('my-func')
+
+    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'))
+  })
+
+  test('resolves to undefined when the function returns nothing (204)', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+    mock.scope(HOST).on('POST', invokeUri('fn-abc123')).respond({status: 204})
+
+    await expect(getClient().functions.invoke('my-func')).resolves.toBeUndefined()
+  })
+
+  test('surfaces a function error as a rejection', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'))
+      .respond({status: 500, body: {error: {description: 'Function invoke failed!'}}})
+
+    await expect(getClient().functions.invoke('my-func')).rejects.toThrow()
+  })
+
+  test('does not invoke when the stack request fails', async () => {
+    const mock = getActiveMock()
+    mock
+      .scope(HOST)
+      .on('GET', stackUri(STACK_ID))
+      .respond({status: 404, body: {error: {description: 'Stack not found'}}})
+
+    await expect(getClient().functions.invoke('my-func')).rejects.toThrow()
+    expect(mock).toHaveReceivedRequestTimes('POST', invokeUri('fn-abc123'), 0)
+  })
+
+  test('is available on the observable client', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'))
+      .respond({status: 200, body: {ok: true}})
+
+    const results: unknown[] = []
+    await new Promise<void>((resolve, reject) => {
+      getClient()
+        .observable.functions.invoke('my-func')
+        .subscribe({
+          next: (value) => results.push(value),
+          error: reject,
+          complete: resolve,
+        })
+    })
+
+    expect(results).toEqual([{ok: true}])
+  })
+})

--- a/test/functions/invoke.test.ts
+++ b/test/functions/invoke.test.ts
@@ -34,8 +34,11 @@ const STACK = {
   id: STACK_ID,
   name: 'my-stack',
   resources: [
-    {name: 'my-func', type: 'sanity.function.document', externalId: 'fn-abc123'},
-    {name: 'other-func', type: 'sanity.function.queue', externalId: 'fn-def456'},
+    {name: 'my-func', type: 'sanity.function.pubsub', externalId: 'fn-abc123'},
+    // Only pubsub functions can be invoked on demand.
+    // Other types should be rejected without a request to the Functions service.
+    {name: 'doc-func', type: 'sanity.function.document', externalId: 'fn-def456'},
+    {name: 'cron-func', type: 'sanity.function.cron', externalId: 'fn-ghi789'},
     // A non-function resource sharing a name must not be picked up.
     {name: 'my-func', type: 'sanity.cors.origin', externalId: 'co-000000'},
   ],
@@ -86,10 +89,30 @@ describe('client.functions.invoke', () => {
       .on('GET', stackUri(STACK_ID))
       .respond({
         status: 200,
-        body: {...STACK, resources: [{name: 'pending-func', type: 'sanity.function.document'}]},
+        body: {...STACK, resources: [{name: 'pending-func', type: 'sanity.function.pubsub'}]},
       })
 
     await expect(getClient().functions.invoke('pending-func')).rejects.toThrow('is not deployed')
+  })
+
+  test('rejects a document function without calling the Functions service', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+
+    await expect(getClient().functions.invoke('doc-func')).rejects.toThrow(
+      'Function invocation is not supported for sanity.function.document',
+    )
+    expect(mock).toHaveReceivedRequestTimes('POST', invokeUri('fn-def456'), 0)
+  })
+
+  test('rejects a cron function without calling the Functions service', async () => {
+    const mock = getActiveMock()
+    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+
+    await expect(getClient().functions.invoke('cron-func')).rejects.toThrow(
+      'Function invocation is not supported for sanity.function.cron',
+    )
+    expect(mock).toHaveReceivedRequestTimes('POST', invokeUri('fn-ghi789'), 0)
   })
 
   test('a per-call stackId overrides the client config', async () => {
@@ -101,9 +124,7 @@ describe('client.functions.invoke', () => {
         status: 200,
         body: {
           id: OTHER_STACK_ID,
-          resources: [
-            {name: 'my-func', type: 'sanity.function.document', externalId: 'fn-other999'},
-          ],
+          resources: [{name: 'my-func', type: 'sanity.function.pubsub', externalId: 'fn-other999'}],
         },
       })
     mock

--- a/test/functions/invoke.test.ts
+++ b/test/functions/invoke.test.ts
@@ -9,6 +9,8 @@ const API_VERSION = '2025-02-19'
 const BASE = `/v${API_VERSION}`
 const STACK_ID = 'ST-1234567890'
 const OTHER_STACK_ID = 'ST-9876543210'
+const ORG_ID = 'oOrG12345'
+const OTHER_ORG_ID = 'oOtHeR9999'
 
 // Clients in this suite go through the per-test mock, injected via the
 // public `resolveFetch` config option.
@@ -166,6 +168,85 @@ describe('client.functions.invoke', () => {
     await getClient().functions.invoke('my-func')
 
     expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'), {headers: scopeHeaders})
+  })
+
+  test('scopes to the organization when `organizationId` is configured', async () => {
+    const orgHeaders = {'X-Sanity-Scope-Type': 'organization', 'X-Sanity-Scope-Id': ORG_ID}
+    const mock = getActiveMock()
+    mock
+      .scope(HOST)
+      .on('GET', stackUri(STACK_ID), {headers: orgHeaders})
+      .respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'), {headers: orgHeaders})
+      .respond({status: 200, body: {ok: true}})
+
+    const client = createClient({
+      projectId: PROJECT_ID,
+      apiVersion: API_VERSION,
+      useCdn: false,
+      token: 'my-token',
+      stackId: STACK_ID,
+      organizationId: ORG_ID,
+    })
+
+    await expect(client.functions.invoke('my-func')).resolves.toEqual({ok: true})
+    // Organization scope wins over the configured project.
+    expect(mock).toHaveReceivedRequest('GET', stackUri(STACK_ID), {
+      headers: {'X-Sanity-Scope-Type': 'organization'},
+    })
+  })
+
+  test('a per-call organizationId overrides the client config', async () => {
+    const orgHeaders = {'X-Sanity-Scope-Type': 'organization', 'X-Sanity-Scope-Id': OTHER_ORG_ID}
+    const mock = getActiveMock()
+    mock
+      .scope(HOST)
+      .on('GET', stackUri(STACK_ID), {headers: orgHeaders})
+      .respond({status: 200, body: STACK})
+    mock
+      .scope(HOST)
+      .on('POST', invokeUri('fn-abc123'), {headers: orgHeaders})
+      .respond({status: 200, body: {ok: true}})
+
+    const client = createClient({
+      projectId: PROJECT_ID,
+      apiVersion: API_VERSION,
+      useCdn: false,
+      token: 'my-token',
+      stackId: STACK_ID,
+      organizationId: ORG_ID,
+    })
+
+    await expect(
+      client.functions.invoke('my-func', {organizationId: OTHER_ORG_ID}),
+    ).resolves.toEqual({ok: true})
+  })
+
+  test('organization scope does not require a projectId', async () => {
+    const orgHeaders = {'X-Sanity-Scope-Type': 'organization', 'X-Sanity-Scope-Id': ORG_ID}
+    const mock = getActiveMock()
+    const globalHost = 'https://api.sanity.io'
+    mock
+      .scope(globalHost)
+      .on('GET', stackUri(STACK_ID), {headers: orgHeaders})
+      .respond({status: 200, body: STACK})
+    mock
+      .scope(globalHost)
+      .on('POST', invokeUri('fn-abc123'), {headers: orgHeaders})
+      .respond({status: 200, body: {ok: true}})
+
+    const client = createClient({
+      apiVersion: API_VERSION,
+      useProjectHostname: false,
+      useCdn: false,
+      token: 'my-token',
+      stackId: STACK_ID,
+      organizationId: ORG_ID,
+    })
+
+    await expect(client.functions.invoke('my-func')).resolves.toEqual({ok: true})
   })
 
   test('defaults the payload to an empty object when no event is given', async () => {


### PR DESCRIPTION
## feat: `client.functions.invoke()`

Adds a client method for invoking a deployed Pubsub functions.

```ts
const client = createClient({
  projectId: 'abc123',
  apiVersion: '2025-02-19',
  token: '...',
  stackId: 'ST-1234567890',
})

const result = await client.functions.invoke<{words: number}>('summarize', {
  event: {data: {documentId: 'abc123'}},
})
```

## API
`client.functions.invoke<R>(name, request?): Promise<R | undefined>`
`client.observable.functions.invoke<R>(name, request?): Observable<R | undefined>`

### How name resolution works
The invoke route is keyed by function id, but callers know functions by the name declared in
the blueprint. Names are unique within a stack, so each call is two requests:

`GET /blueprints/stacks/:stackId` to find the resource whose type starts with `sanity.function.` and whose name matches, then read its `externalId`
`POST /functions/:functionId/invoke with {event: {data}}`
A per-call `stackId` overrides the config, so a single client can reach more than one stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API surface and authenticated remote execution paths, but behavior is isolated behind `client.functions` with validation before invoke and broad test coverage.
> 
> **Overview**
> Adds **`client.functions.invoke()`** (and **`client.observable.functions.invoke()`**) so callers can run deployed **`sanity.function.pubsub`** functions by blueprint **name**, with **`event.data`**, optional **`timeout`**, and **`AbortSignal`**.
> 
> Each call is two HTTP steps: **`GET /blueprints/stacks/:stackId`** to map the name to a function id (only pubsub types are allowed), then **`POST /functions/:id/invoke`**. New client config **`stackId`** and **`organizationId`** (per-call overrides supported) drive scope via **`X-Sanity-Scope-*`** headers; org scope can work without **`projectId`** when **`useProjectHostname: false`**.
> 
> README and a minor changeset document the API; vitest coverage exercises resolution, errors, scoping, and observable parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2d3c94a459868cb230399c0116854b21b6270d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->