### PR TITLE
build(lint): enable oxlint type-aware rules, fix what they found

### DIFF
--- a/.changeset/literal-union-autocomplete.md
+++ b/.changeset/literal-union-autocomplete.md
@@ -1,0 +1,11 @@
+---
+'@sanity/client': patch
+---
+
+fix: restore editor autocomplete for `StackablePerspective` and `StudioBaseUrl`
+
+Both types applied the `& {}` autocomplete idiom around the whole union rather than around the
+`string` member, as in `('published' | 'drafts' | string) & {}`. That collapses to plain `string`,
+so editors offered no completions for `published` or `drafts`, and the three template literal
+patterns in `StudioBaseUrl` had no effect. Assignability is unchanged, so this only adds
+suggestions that were always intended to be there.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,10 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "import"],
+  "options": {
+    "typeAware": true,
+    "reportUnusedDisableDirectives": "error"
+  },
   "categories": {
     "correctness": "error"
   },
@@ -19,7 +23,16 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
-    "typescript/no-explicit-any": "error"
+    "typescript/no-explicit-any": "error",
+
+    "typescript/await-thenable": "error",
+    "typescript/no-duplicate-type-constituents": "error",
+    "typescript/no-floating-promises": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-unnecessary-type-parameters": "error",
+
+    "typescript/no-base-to-string": "off",
+    "typescript/restrict-template-expressions": "off"
   },
   "overrides": [
     {
@@ -27,6 +40,23 @@
       "rules": {
         "typescript/no-explicit-any": "off",
         "typescript/no-non-null-assertion": "off"
+      }
+    },
+    {
+      // Type-level assertions reference methods without calling them by design.
+      "files": ["**/*.test-d.ts"],
+      "rules": {
+        "typescript/unbound-method": "off"
+      }
+    },
+    {
+      // The `fetch` overloads declare `Q` for callers who pass explicit type arguments
+      // (`fetch<R, Q>(...)`), so it is public API rather than a redundant parameter. An inline
+      // directive cannot suppress it: the diagnostic is reported against the closing `>(...)`
+      // line, and a comment inside a multi-line type parameter list is not picked up.
+      "files": ["src/SanityClient.ts"],
+      "rules": {
+        "typescript/no-unnecessary-type-parameters": "off"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "next": "^16.3.0",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.78.0",
+    "oxlint-tsgolint": "^7.0.2001",
     "pkg-pr-new": "^0.0.86",
     "typescript": "7.0.2",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,10 @@ importers:
         version: 0.63.0
       oxlint:
         specifier: ^1.78.0
-        version: 1.78.0
+        version: 1.78.0(oxlint-tsgolint@7.0.2001)
+      oxlint-tsgolint:
+        specifier: ^7.0.2001
+        version: 7.0.2001
       pkg-pr-new:
         specifier: ^0.0.86
         version: 0.0.86
@@ -1235,6 +1238,36 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.63.0':
     resolution: {integrity: sha512-sgsHCQy432OTQH4Ikk3tZptp3GqwnhwUDuY0loBH41zyHWfMZY9v8Dy78wsnSofHejvFozZGgJgBB1A0LQRwMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    resolution: {integrity: sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    resolution: {integrity: sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    resolution: {integrity: sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    resolution: {integrity: sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    resolution: {integrity: sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    resolution: {integrity: sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==}
     cpu: [x64]
     os: [win32]
 
@@ -3226,6 +3259,10 @@ packages:
       vite-plus:
         optional: true
 
+  oxlint-tsgolint@7.0.2001:
+    resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
+    hasBin: true
+
   oxlint@1.78.0:
     resolution: {integrity: sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5087,6 +5124,24 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.63.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.78.0':
@@ -7000,7 +7055,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.63.0
       '@oxfmt/binding-win32-x64-msvc': 0.63.0
 
-  oxlint@1.78.0:
+  oxlint-tsgolint@7.0.2001:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 7.0.2001
+      '@oxlint-tsgolint/darwin-x64': 7.0.2001
+      '@oxlint-tsgolint/linux-arm64': 7.0.2001
+      '@oxlint-tsgolint/linux-x64': 7.0.2001
+      '@oxlint-tsgolint/win32-arm64': 7.0.2001
+      '@oxlint-tsgolint/win32-x64': 7.0.2001
+
+  oxlint@1.78.0(oxlint-tsgolint@7.0.2001):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.78.0
       '@oxlint/binding-android-arm64': 1.78.0
@@ -7021,6 +7085,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.78.0
       '@oxlint/binding-win32-ia32-msvc': 1.78.0
       '@oxlint/binding-win32-x64-msvc': 1.78.0
+      oxlint-tsgolint: 7.0.2001
 
   p-filter@2.1.0:
     dependencies:

--- a/src/csm/studioPath.ts
+++ b/src/csm/studioPath.ts
@@ -45,6 +45,7 @@ export function isIndexTuple(segment: PathSegment): segment is IndexTuple {
 }
 
 /** @internal */
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- caller-supplied return type; removing it breaks `get<Result>(...)` call sites
 export function get<Result = unknown, Fallback = unknown>(
   obj: unknown,
   path: Path | string,
@@ -55,7 +56,7 @@ export function get<Result = unknown, Fallback = unknown>(
     throw new Error('Path must be an array or a string')
   }
 
-  let acc: unknown | undefined = obj
+  let acc: unknown = obj
   for (let i = 0; i < select.length; i++) {
     const segment = select[i]
     if (isIndexSegment(segment)) {

--- a/src/csm/types.ts
+++ b/src/csm/types.ts
@@ -39,7 +39,11 @@ export type ContentSourceMapParsedPath = (
 )[]
 
 /** @alpha */
-export type StudioBaseUrl = `/${string}` | `${string}.sanity.studio` | `https://${string}` | string
+export type StudioBaseUrl =
+  | `/${string}`
+  | `${string}.sanity.studio`
+  | `https://${string}`
+  | (string & {})
 
 /** @alpha */
 export type StudioBaseRoute = {baseUrl: StudioBaseUrl; workspace?: string; tool?: string}

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export type ReleaseId = `r${string}`
 type DeprecatedPreviewDrafts = 'previewDrafts'
 
 /** @public */
-export type StackablePerspective = ('published' | 'drafts' | string) & {}
+export type StackablePerspective = 'published' | 'drafts' | (string & {})
 
 /** @public */
 export type ClientPerspective =

--- a/src/users/UsersClient.ts
+++ b/src/users/UsersClient.ts
@@ -18,9 +18,7 @@ export class ObservableUsersClient {
    *
    * @param id - User ID of the user to fetch. If `me` is provided, a minimal response including the users role is returned.
    */
-  getById<T extends 'me' | string>(
-    id: T,
-  ): Observable<T extends 'me' ? CurrentSanityUser : SanityUser> {
+  getById<T extends string>(id: T): Observable<T extends 'me' ? CurrentSanityUser : SanityUser> {
     return _requestObservable<T extends 'me' ? CurrentSanityUser : SanityUser>(
       this.#client,
       this.#httpRequest,
@@ -43,9 +41,7 @@ export class UsersClient {
    *
    * @param id - User ID of the user to fetch. If `me` is provided, a minimal response including the users role is returned.
    */
-  getById<T extends 'me' | string>(
-    id: T,
-  ): Promise<T extends 'me' ? CurrentSanityUser : SanityUser> {
+  getById<T extends string>(id: T): Promise<T extends 'me' ? CurrentSanityUser : SanityUser> {
     return _request<T extends 'me' ? CurrentSanityUser : SanityUser>(
       this.#client,
       this.#httpRequest,

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -289,7 +289,7 @@ describe('client', async () => {
       let error: unknown
       try {
         // @ts-expect-error -- `url` is required in the types; this simulates a JS caller omitting it
-        getClient().request({})
+        void getClient().request({})
       } catch (err) {
         error = err
       }
@@ -1946,7 +1946,7 @@ describe('client', async () => {
 
     test.skipIf(isEdge)('throws on invalid request tag on request', () => {
       expect(() => {
-        getClient().fetch('*', {}, {tag: 'mycompany syncjob ok'})
+        void getClient().fetch('*', {}, {tag: 'mycompany syncjob ok'})
       }).toThrow(/tag can only contain alphanumeric/i)
     })
 

--- a/test/dataMethods.test.ts
+++ b/test/dataMethods.test.ts
@@ -127,7 +127,7 @@ const assertObservableError = <T>(
   })
 }
 
-const testTagOption = <T = unknown>(
+const testTagOption = (
   methodName: string,
   methodFn: (typeof dataMethods)[keyof typeof dataMethods],
   args: readonly unknown[] = [],
@@ -140,7 +140,7 @@ const testTagOption = <T = unknown>(
 
     const client = getClient()
     const options = {tag: 'test-tag'}
-    const typedMethodFn = methodFn as unknown as DataMethodFn<T>
+    const typedMethodFn = methodFn as unknown as DataMethodFn<unknown>
     const observable = typedMethodFn(client, mockHttpRequest, ...args, options)
 
     return assertObservable(observable, () => {
@@ -150,7 +150,7 @@ const testTagOption = <T = unknown>(
   })
 }
 
-const testSignalOption = <T = unknown>(
+const testSignalOption = (
   methodName: string,
   methodFn: (typeof dataMethods)[keyof typeof dataMethods],
   args: readonly unknown[] = [],
@@ -164,7 +164,7 @@ const testSignalOption = <T = unknown>(
     const client = getClient()
     const controller = new AbortController()
     const signal = controller.signal
-    const typedMethodFn = methodFn as unknown as DataMethodFn<T>
+    const typedMethodFn = methodFn as unknown as DataMethodFn<unknown>
     const observable = typedMethodFn(client, mockHttpRequest, ...args, {signal})
 
     return assertObservable(observable, () => {

--- a/test/literalUnions.test-d.ts
+++ b/test/literalUnions.test-d.ts
@@ -1,0 +1,23 @@
+import type {StudioBaseUrl} from '../src/csm/types'
+import type {StackablePerspective} from '../src/types'
+
+/**
+ * Guards the `string & {}` idiom that keeps literal members visible to editor autocomplete.
+ *
+ * Writing the intersection around the whole union instead of around the `string` member, as in
+ * `('published' | 'drafts' | string) & {}`, collapses the type to plain `string` and silently
+ * drops every completion. These assertions fail if that regresses.
+ */
+type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never
+
+/** `false` for a plain `string`, `true` for a union whose literal members survived. */
+type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true
+
+type Assert<T extends true> = T
+
+export type PerspectiveIsUnion = Assert<IsUnion<StackablePerspective>>
+export type StudioBaseUrlIsUnion = Assert<IsUnion<StudioBaseUrl>>

--- a/test/stega/client.test.ts
+++ b/test/stega/client.test.ts
@@ -297,7 +297,7 @@ describe('@sanity/client', () => {
     })
 
     test('allows passing stega: undefined', async () => {
-      await expect(
+      expect(
         async () =>
           await client.fetch(
             '*',
@@ -309,7 +309,7 @@ describe('@sanity/client', () => {
       ).not.toThrow()
     })
     test('allows passing stega: false', async () => {
-      await expect(
+      expect(
         async () =>
           await client.fetch(
             '*',


### PR DESCRIPTION
Follow-up to #1260, implementing the oxlint options @stipsan suggested in [review](https://github.com/sanity-io/client/pull/1260#discussion_r3761014138).

Adds `oxlint-tsgolint` and enables `typeAware` plus `reportUnusedDisableDirectives`.

## Rule selection

Enabled, per the review discussion:

- `await-thenable`
- `no-duplicate-type-constituents`
- `no-floating-promises`
- `no-redundant-type-constituents`
- `no-unnecessary-type-parameters`

Explicitly off: `no-base-to-string` and `restrict-template-expressions`. Nearly every hit was `received ${value}` in a validation error message, so the payoff is `[object Object]` reading slightly better in a message the caller only sees once they have already passed the wrong type.

`no-deprecated` is left off as discussed, since `@deprecated` is load-bearing for the internal-API convention here and would fire on intentional usage.

## The bug this caught

```ts
export type StackablePerspective = ('published' | 'drafts' | string) & {}
```

The `& {}` is applied to the whole union, which collapses the type to `string & {}`, i.e. plain `string`. Editors offered no completions for `published` or `drafts`. `StudioBaseUrl` had the same shape, making its three template literal patterns inert.

Both now put the intersection on the `string` member:

```ts
export type StackablePerspective = 'published' | 'drafts' | (string & {})
```

Verified with an A/B rather than by eye. Using a non-distributive `IsUnion` check, both types evaluate to `false` (not a union, so collapsed) before the fix and `true` after. That check is kept as `test/literalUnions.test-d.ts` so the idiom cannot silently regress.

Assignability is unchanged, so this only adds suggestions that were always intended.

## Other fixes

- `UsersClient.getById<T extends 'me' | string>` constrained to a union that collapses to `string`. Literal inference still drives the conditional return type, so `getById('me')` keeps returning `CurrentSanityUser`.
- `let acc: unknown | undefined` in `studioPath`.
- Two unused generics on test helpers, both always defaulted to `unknown` at every call site.
- Two floating promises in tests that assert synchronous throws, now marked `void`.
- Two redundant `await`s on synchronous `expect(...)` assertions.

## Two suppressions rather than changes

Both are public API where the rule is wrong for this codebase, since removing the parameter breaks explicit type arguments at call sites:

- `studioPath.get`'s caller-supplied `Result`, suppressed inline.
- The `fetch` overloads' `Q`, which needs a file-scoped override in `.oxlintrc.json`.

The second is blunter than I would like, and worth knowing why: an inline directive cannot attach inside a multi-line type parameter list. The diagnostic anchors to the closing `>(...)` line, and a comment placed there is not picked up as a directive, so it reports as both unused and unsuppressed. If the file-level override is unwelcome, the alternative is turning `no-unnecessary-type-parameters` off repo-wide.

## Verification

Rebased onto `main` after the pnpm and changesets migration in #1261. `package-lock.json` was deleted there, so `oxlint-tsgolint` lands in `pnpm-lock.yaml` instead.

Worth noting given the `@types/node` hoisting problem that migration hit: pnpm's isolated layout does not hoist, so I confirmed the type-aware rules actually run rather than silently skipping, by reintroducing a `no-redundant-type-constituents` violation and checking it is still reported under `pnpm exec oxlint`. It is.

Green locally: lint, format, build, 40 test files, 1092 tests, no type errors, and the deno suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public types (`StackablePerspective`, `StudioBaseUrl`, `UsersClient.getById`), but assignability is unchanged and the changes are mostly lint/tooling plus DX. Risk is mainly from broader type-aware lint enforcement going forward.
> 
> **Overview**
> Enables **oxlint type-aware linting** via `oxlint-tsgolint`, then fixes the issues those rules surfaced.
> 
> The main user-facing fix restores editor autocomplete for `StackablePerspective` and `StudioBaseUrl`. Both had `& {}` wrapped around the whole union, which collapsed them to plain `string` and dropped literal/template completions. The intersection now sits on the `string` member only; assignability is unchanged. A type-level regression test guards the idiom.
> 
> Also cleans up redundant type constituents (`UsersClient.getById`), unused generics, floating promises, and redundant awaits. Suppresses `no-unnecessary-type-parameters` for intentional public API params on `studioPath.get` and the `fetch` overloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 179b2bb0c10f551b1cd4e2d13b4c49a4031ffa4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->