### PR TITLE
refactor: swap `debug` for `obug`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,10 +98,10 @@
     "format:check": "oxfmt --check"
   },
   "dependencies": {
-    "debug": "^4.4.0",
     "eventsource": "^5.0.0",
     "get-it": "^9.4.1",
     "nanoid": "^6.0.1",
+    "obug": "^2.1.4",
     "rxjs": "^7.8.2"
   },
   "devDependencies": {
@@ -110,7 +110,6 @@
     "@edge-runtime/types": "^4.0.0",
     "@edge-runtime/vm": "^5.0.0",
     "@sanity/pkg-utils": "^12.1.2",
-    "@types/debug": "^4.1.12",
     "@types/json-diff": "^1.0.3",
     "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      debug:
-        specifier: ^4.4.0
-        version: 4.4.3(supports-color@10.2.2)
       eventsource:
         specifier: ^5.0.0
         version: 5.0.0
@@ -20,6 +17,9 @@ importers:
       nanoid:
         specifier: ^6.0.1
         version: 6.0.1
+      obug:
+        specifier: ^2.1.4
+        version: 2.1.4
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -39,9 +39,6 @@ importers:
       '@sanity/pkg-utils':
         specifier: ^12.1.2
         version: 12.1.2(@babel/runtime@7.29.7)(@types/node@22.20.1)(rolldown@1.2.3)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(terser@5.49.2)(tsx@4.23.12))
-      '@types/debug':
-        specifier: ^4.1.12
-        version: 4.1.13
       '@types/json-diff':
         specifier: ^1.0.3
         version: 1.0.3
@@ -1670,9 +1667,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/debug@4.1.13':
-    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1681,9 +1675,6 @@ packages:
 
   '@types/json-diff@1.0.3':
     resolution: {integrity: sha512-Qvxm8fpRMv/1zZR3sQWImeRK2mBYJji20xF51Fq9Gt//Ed18u0x6/FNLogLS1xhfUWTEmDyqveJqn95ltB6Kvw==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -5492,17 +5483,11 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/debug@4.1.13':
-    dependencies:
-      '@types/ms': 2.1.0
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
   '@types/json-diff@1.0.3': {}
-
-  '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
 

--- a/src/http/browserUpload.ts
+++ b/src/http/browserUpload.ts
@@ -1,11 +1,11 @@
-import createDebugLogger from 'debug'
+import {createDebug} from 'obug'
 import {Observable} from 'rxjs'
 
 import type {UploadEvent} from '../types'
 import {ClientError, httpResponseFromFetch, ServerError} from './errors'
 import {parseJsonText} from './request'
 
-const log = createDebugLogger('sanity:client')
+const log = createDebug('sanity:client')
 
 let nextRequestId = 1
 

--- a/src/http/nodeMiddleware.ts
+++ b/src/http/nodeMiddleware.ts
@@ -1,14 +1,14 @@
 import {Readable} from 'node:stream'
 
-import createDebugLogger from 'debug'
 import type {FetchFunction} from 'get-it'
 import {debug} from 'get-it/middleware'
 import {createNodeFetch} from 'get-it/node'
+import {createDebug} from 'obug'
 
 import {name, version} from '../../package.json'
 import type {EnvironmentOptions, LegacyMiddleware} from './request'
 
-const log = createDebugLogger('sanity:client')
+const log = createDebug('sanity:client')
 
 function isNodeReadableStream(value: unknown): value is Readable {
   if (typeof value !== 'object' || value === null) return false


### PR DESCRIPTION
### Description

Requested by @stipsan as debug has some optional peerDependenciesMeta for supports-color which causes a lot of lockfile churn, and `obug` contains types, is small and requires no dependencies.

### What to review

No runtime behavioral changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency swap for debug logging only; API usage is equivalent and no behavioral changes are intended.
> 
> **Overview**
> Replaces the `debug` dependency with **`obug`** to avoid lockfile churn from `debug`'s optional `supports-color` peer, and to pick up a smaller zero-dependency logger that ships its own types.
> 
> Updates the two call sites in `browserUpload.ts` and `nodeMiddleware.ts` to use `createDebug('sanity:client')` instead of `debug`. Removes `@types/debug` as well. No intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5045bd6ef37d6d7b9fa52f09fd296af93815481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->