### PR TITLE
chore(oxfmt): ignore changesets when formatting

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,5 +6,12 @@
   "singleQuote": true,
   "sortImports": true,
   "sortPackageJson": true,
-  "ignorePatterns": ["dist", "coverage", "runtimes/deno", "runtimes/node", "CHANGELOG.md"]
+  "ignorePatterns": [
+    ".changeset",
+    "dist",
+    "coverage",
+    "runtimes/deno",
+    "runtimes/node",
+    "CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION
### Description

These changesets are auto-generated a lot of the time, and formatting them just messes with things.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to formatter ignore patterns; no runtime or security impact.
> 
> **Overview**
> Adds `.changeset` to oxfmt `ignorePatterns` so auto-generated changeset files are left alone by the formatter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7850a88e9ca22a1dcda1f477510b34260e4419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->