### PR TITLE
refactor: drop `#private` fields so client types stay structural

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -1,10 +1,14 @@
 import {defineConfig} from '@sanity/pkg-utils'
 
+import {stripInternalMembers} from './scripts/stripInternalMembers'
+
 export default defineConfig({
   tsconfig: 'tsconfig.dist.json',
 
   // `dist` is cleaned by default; list it alongside `coverage` to keep both.
   clean: ['dist', 'coverage'],
+
+  plugins: [stripInternalMembers()],
 
   deps: {alwaysBundle: ['@vercel/stega']},
 

--- a/scripts/stripInternalMembers.ts
+++ b/scripts/stripInternalMembers.ts
@@ -1,0 +1,238 @@
+// @env node
+import type {PkgConfigOptions} from '@sanity/pkg-utils'
+import {createScanner, LanguageVariant, type Scanner, SyntaxKind} from 'typescript/unstable/ast'
+
+/**
+ * Removes `@internal` members from the class declarations in the emitted `.d.ts` files.
+ *
+ * TypeScript's own `stripInternal` is all-or-nothing: it also drops the `@internal` types and
+ * functions re-exported from `defineCreateClient` (`validateApiPerspective`, `BaseMutationOptions`,
+ * `connectEventSource`, ...), and since it removes the declarations without touching references to
+ * them, the declaration rollup fails with dangling re-exports. Restricting the pass to class bodies
+ * keeps implementation details such as `SanityClient._httpRequest` out of the published types while
+ * every exported `@internal` declaration keeps its typings.
+ *
+ * Interface and type-literal members are deliberately left alone: `@internal` on those (say
+ * `ClientConfig.resolveFetch`) marks an unsupported option, not a private field, and removing it
+ * would change what callers are allowed to pass.
+ */
+type PkgPlugin = NonNullable<PkgConfigOptions['plugins']>
+
+interface Comment {
+  start: number
+  end: number
+}
+
+interface Removal {
+  start: number
+  end: number
+}
+
+interface PendingRemoval {
+  start: number
+  /** Container depth the member started at, so a `;` nested inside it doesn't end it early. */
+  depth: number
+}
+
+interface StripResult {
+  code: string
+  removed: number
+}
+
+/**
+ * `template` tracks the substitutions of a template literal type: its closing `}` is a template
+ * token rather than a container close, and mistaking the two desynchronizes the rest of the file.
+ */
+type ContainerKind = 'class' | 'other' | 'template'
+
+const DECLARATION_FILE_RE = /\.d\.[cm]?ts$/
+const INTERNAL_TAG_RE = /(?:^|\s)@internal(?:\s|$)/
+
+const TRIVIA_TOKENS = new Set([
+  SyntaxKind.SingleLineCommentTrivia,
+  SyntaxKind.MultiLineCommentTrivia,
+  SyntaxKind.NewLineTrivia,
+  SyntaxKind.WhitespaceTrivia,
+  SyntaxKind.ConflictMarkerTrivia,
+  SyntaxKind.NonTextFileMarkerTrivia,
+])
+
+const COMMENT_TOKENS = new Set([
+  SyntaxKind.SingleLineCommentTrivia,
+  SyntaxKind.MultiLineCommentTrivia,
+])
+
+const OPENING_TOKENS = new Set([
+  SyntaxKind.OpenBraceToken,
+  SyntaxKind.OpenParenToken,
+  SyntaxKind.OpenBracketToken,
+])
+
+const CLOSING_TOKENS = new Set([
+  SyntaxKind.CloseBraceToken,
+  SyntaxKind.CloseParenToken,
+  SyntaxKind.CloseBracketToken,
+])
+
+/**
+ * Tokens a class body's `{` can follow: the class name, the end of a heritage clause (`>` is scanned
+ * greedily, so nested type arguments arrive as `>>`), or an anonymous `class {`. An inline object
+ * type in a heritage clause (`extends Foo<{a: 1}>`) follows `<` or `,` instead, which is how that
+ * brace is told apart from the body that comes after it.
+ */
+const CLASS_BODY_PRECEDERS = new Set([
+  SyntaxKind.Identifier,
+  SyntaxKind.GreaterThanToken,
+  SyntaxKind.GreaterThanGreaterThanToken,
+  SyntaxKind.GreaterThanGreaterThanGreaterThanToken,
+  SyntaxKind.CloseParenToken,
+  SyntaxKind.ClassKeyword,
+])
+
+function lineStartOf(code: string, pos: number): number {
+  return code.lastIndexOf('\n', pos - 1) + 1
+}
+
+function startsLine(code: string, pos: number): boolean {
+  return code.slice(lineStartOf(code, pos), pos).trim() === ''
+}
+
+/**
+ * Where the removal starts for a member carrying the given leading comments, or `undefined` when
+ * none of them tag it `@internal`.
+ */
+function findRemovalStart(code: string, comments: readonly Comment[]): number | undefined {
+  const internalIndex = comments.findIndex((comment) =>
+    INTERNAL_TAG_RE.test(code.slice(comment.start, comment.end)),
+  )
+  if (internalIndex === -1) return undefined
+
+  // Comments on their own line above the tag document the member that is going away, so take those
+  // too rather than leaving them stranded above whichever member follows.
+  let firstIndex = internalIndex
+  while (firstIndex > 0 && startsLine(code, comments[firstIndex - 1].start)) firstIndex--
+
+  const start = comments[firstIndex].start
+  return startsLine(code, start) ? lineStartOf(code, start) : start
+}
+
+/** Extends a removal past the trailing whitespace and line break left behind by the member. */
+function findRemovalEnd(code: string, end: number): number {
+  let next = end
+  while (code[next] === ' ' || code[next] === '\t') next++
+  if (code[next] === '\r') next++
+  if (code[next] === '\n') next++
+  return next
+}
+
+/**
+ * Re-reads a `}` that closes a template literal substitution, which the scanner only knows to do
+ * when asked. Returns the token it turned out to be: a tail ends the template, a middle opens the
+ * next substitution.
+ */
+function rescanTemplateToken(scanner: Scanner): SyntaxKind {
+  return scanner.reScanTemplateToken(false)
+}
+
+/** Removes every `@internal` class member from a declaration file's source text. */
+export function stripInternalClassMembers(code: string): StripResult {
+  const scanner = createScanner(false, LanguageVariant.Standard, code)
+  const containers: ContainerKind[] = []
+  const comments: Comment[] = []
+  const removals: Removal[] = []
+  let pending: PendingRemoval | undefined
+  let previousToken = SyntaxKind.Unknown
+  let pendingClass = false
+  let token = scanner.scan()
+
+  // Every token advances at least one character, so anything past this means the scanner stopped
+  // making progress and the pass would spin. Fail the build rather than hang it.
+  const maxSteps = code.length * 2 + 1000
+  let steps = 0
+
+  while (token !== SyntaxKind.EndOfFile) {
+    if (steps++ > maxSteps) {
+      throw new Error(
+        `stripInternalClassMembers: scanner stopped advancing at offset ${scanner.getTokenStart()}`,
+      )
+    }
+
+    if (TRIVIA_TOKENS.has(token)) {
+      if (COMMENT_TOKENS.has(token)) {
+        comments.push({start: scanner.getTokenStart(), end: scanner.getTokenEnd()})
+      }
+      token = scanner.scan()
+      continue
+    }
+
+    if (!pending && containers[containers.length - 1] === 'class' && !CLOSING_TOKENS.has(token)) {
+      const start = findRemovalStart(code, comments)
+      if (start !== undefined) pending = {start, depth: containers.length}
+    }
+
+    comments.length = 0
+
+    if (token === SyntaxKind.ClassKeyword) {
+      pendingClass = true
+    } else if (token === SyntaxKind.TemplateHead) {
+      containers.push('template')
+    } else if (OPENING_TOKENS.has(token)) {
+      const opensClassBody =
+        pendingClass &&
+        token === SyntaxKind.OpenBraceToken &&
+        CLASS_BODY_PRECEDERS.has(previousToken)
+      containers.push(opensClassBody ? 'class' : 'other')
+      if (opensClassBody) pendingClass = false
+    } else if (
+      token === SyntaxKind.CloseBraceToken &&
+      containers[containers.length - 1] === 'template'
+    ) {
+      token = rescanTemplateToken(scanner)
+      if (token === SyntaxKind.TemplateTail) containers.pop()
+    } else if (CLOSING_TOKENS.has(token)) {
+      containers.pop()
+    } else if (token === SyntaxKind.SemicolonToken) {
+      pendingClass = false
+    }
+
+    if (pending) {
+      if (token === SyntaxKind.SemicolonToken && containers.length === pending.depth) {
+        removals.push({start: pending.start, end: findRemovalEnd(code, scanner.getTokenEnd())})
+        pending = undefined
+      } else if (containers.length < pending.depth) {
+        // The class body ended before the member was terminated by a `;`.
+        removals.push({start: pending.start, end: findRemovalEnd(code, scanner.getTokenStart())})
+        pending = undefined
+      }
+    }
+
+    previousToken = token
+    token = scanner.scan()
+  }
+
+  if (removals.length === 0) return {code, removed: 0}
+
+  let stripped = ''
+  let cursor = 0
+  for (const removal of removals) {
+    if (removal.start < cursor) continue
+    stripped += code.slice(cursor, removal.start)
+    cursor = removal.end
+  }
+
+  return {code: stripped + code.slice(cursor), removed: removals.length}
+}
+
+/** pkg-utils plugin that applies {@link stripInternalClassMembers} to every emitted `.d.ts`. */
+export function stripInternalMembers(): PkgPlugin {
+  return {
+    name: 'strip-internal-members',
+    generateBundle(_options, bundle) {
+      for (const output of Object.values(bundle)) {
+        if (output.type !== 'chunk' || !DECLARATION_FILE_RE.test(output.fileName)) continue
+        const {code, removed} = stripInternalClassMembers(output.code)
+        if (removed > 0) output.code = code
+      }
+    },
+  }
+}

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -84,10 +84,18 @@ export class ObservableSanityClient {
   releases: ObservableReleasesClient
 
   /**
-   * Private properties
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
    */
-  #clientConfig: InitializedClientConfig
-  #httpRequest: HttpRequest
+
+  /** @internal */
+  _clientConfig: InitializedClientConfig
+
+  /** @internal */
+  _httpRequest: HttpRequest
 
   /**
    * Instance properties
@@ -97,27 +105,27 @@ export class ObservableSanityClient {
   constructor(httpRequest: HttpRequest, config: ClientConfig = defaultConfig) {
     this.config(config)
 
-    this.#httpRequest = httpRequest
+    this._httpRequest = httpRequest
 
-    this.assets = new ObservableAssetsClient(this, this.#httpRequest)
-    this.datasets = new ObservableDatasetsClient(this, this.#httpRequest)
+    this.assets = new ObservableAssetsClient(this, this._httpRequest)
+    this.datasets = new ObservableDatasetsClient(this, this._httpRequest)
     this.live = new LiveClient(this)
     this.mediaLibrary = {
-      video: new ObservableMediaLibraryVideoClient(this, this.#httpRequest),
+      video: new ObservableMediaLibraryVideoClient(this, this._httpRequest),
     }
-    this.projects = new ObservableProjectsClient(this, this.#httpRequest)
-    this.users = new ObservableUsersClient(this, this.#httpRequest)
+    this.projects = new ObservableProjectsClient(this, this._httpRequest)
+    this.users = new ObservableUsersClient(this, this._httpRequest)
     this.agent = {
-      action: new ObservableAgentsActionClient(this, this.#httpRequest),
+      action: new ObservableAgentsActionClient(this, this._httpRequest),
     }
-    this.releases = new ObservableReleasesClient(this, this.#httpRequest)
+    this.releases = new ObservableReleasesClient(this, this._httpRequest)
   }
 
   /**
    * Clone the client - returns a new instance
    */
   clone(): ObservableSanityClient {
-    return new ObservableSanityClient(this.#httpRequest, this.config())
+    return new ObservableSanityClient(this._httpRequest, this.config())
   }
 
   /**
@@ -130,16 +138,16 @@ export class ObservableSanityClient {
   config(newConfig?: Partial<ClientConfig>): this
   config(newConfig?: Partial<ClientConfig>): ClientConfig | this {
     if (newConfig === undefined) {
-      return {...this.#clientConfig}
+      return {...this._clientConfig}
     }
 
-    if (this.#clientConfig && this.#clientConfig.allowReconfigure === false) {
+    if (this._clientConfig && this._clientConfig.allowReconfigure === false) {
       throw new Error(
         'Existing client instance cannot be reconfigured - use `withConfig(newConfig)` to return a new client',
       )
     }
 
-    this.#clientConfig = initConfig(newConfig, this.#clientConfig || {})
+    this._clientConfig = initConfig(newConfig, this._clientConfig || {})
     return this
   }
 
@@ -150,7 +158,7 @@ export class ObservableSanityClient {
    */
   withConfig(newConfig?: Partial<ClientConfig>): ObservableSanityClient {
     const thisConfig = this.config()
-    return new ObservableSanityClient(this.#httpRequest, {
+    return new ObservableSanityClient(this._httpRequest, {
       ...thisConfig,
       ...newConfig,
       stega: {
@@ -227,8 +235,8 @@ export class ObservableSanityClient {
   ): Observable<RawQueryResponse<R> | R> {
     return dataMethods._fetchObservable<R, Q>(
       this,
-      this.#httpRequest,
-      this.#clientConfig.stega,
+      this._httpRequest,
+      this._clientConfig.stega,
       query,
       params,
       options,
@@ -276,7 +284,7 @@ export class ObservableSanityClient {
   ): Observable<SanityDocument<R> | undefined | SanityDocument<R>[]> {
     // Implementation needs to handle union type safely
     if (options?.includeAllVersions === true) {
-      return dataMethods._getDocumentObservable<R>(this, this.#httpRequest, id, {
+      return dataMethods._getDocumentObservable<R>(this, this._httpRequest, id, {
         ...options,
         includeAllVersions: true,
       })
@@ -288,7 +296,7 @@ export class ObservableSanityClient {
       releaseId: options?.releaseId,
       ...(options && 'includeAllVersions' in options ? {includeAllVersions: false as const} : {}),
     }
-    return dataMethods._getDocumentObservable<R>(this, this.#httpRequest, id, opts)
+    return dataMethods._getDocumentObservable<R>(this, this._httpRequest, id, opts)
   }
 
   /**
@@ -304,7 +312,7 @@ export class ObservableSanityClient {
     ids: string[],
     options?: {tag?: string},
   ): Observable<(SanityDocument<R> | null)[]> {
-    return dataMethods._getDocumentsObservable<R>(this, this.#httpRequest, ids, options)
+    return dataMethods._getDocumentsObservable<R>(this, this._httpRequest, ids, options)
   }
 
   /**
@@ -318,7 +326,7 @@ export class ObservableSanityClient {
     ids: string[],
     options?: {signal?: AbortSignal; tag?: string},
   ): Observable<Set<string>> {
-    return dataMethods._documentsExistsObservable(this, this.#httpRequest, ids, options)
+    return dataMethods._documentsExistsObservable(this, this._httpRequest, ids, options)
   }
 
   /**
@@ -387,7 +395,7 @@ export class ObservableSanityClient {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._createObservable<R>(this, this.#httpRequest, document, 'create', options)
+    return dataMethods._createObservable<R>(this, this._httpRequest, document, 'create', options)
   }
 
   /**
@@ -456,7 +464,7 @@ export class ObservableSanityClient {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._createIfNotExistsObservable<R>(this, this.#httpRequest, document, options)
+    return dataMethods._createIfNotExistsObservable<R>(this, this._httpRequest, document, options)
   }
 
   /**
@@ -525,7 +533,7 @@ export class ObservableSanityClient {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._createOrReplaceObservable<R>(this, this.#httpRequest, document, options)
+    return dataMethods._createOrReplaceObservable<R>(this, this._httpRequest, document, options)
   }
 
   /**
@@ -640,7 +648,7 @@ export class ObservableSanityClient {
     if (!document) {
       return dataMethods._createVersionFromBaseObservable(
         this,
-        this.#httpRequest,
+        this._httpRequest,
         publishedId,
         baseId,
         releaseId,
@@ -660,7 +668,7 @@ export class ObservableSanityClient {
 
     return dataMethods._createVersionObservable<R>(
       this,
-      this.#httpRequest,
+      this._httpRequest,
       documentVersion,
       versionPublishedId,
       options,
@@ -782,7 +790,7 @@ export class ObservableSanityClient {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._deleteObservable<R>(this, this.#httpRequest, selection, options)
+    return dataMethods._deleteObservable<R>(this, this._httpRequest, selection, options)
   }
 
   /**
@@ -822,7 +830,7 @@ export class ObservableSanityClient {
 
     return dataMethods._discardVersionObservable(
       this,
-      this.#httpRequest,
+      this._httpRequest,
       documentVersionId,
       purge,
       options,
@@ -932,7 +940,7 @@ export class ObservableSanityClient {
 
     return dataMethods._replaceVersionObservable<R>(
       this,
-      this.#httpRequest,
+      this._httpRequest,
       documentVersion,
       options,
     )
@@ -967,7 +975,7 @@ export class ObservableSanityClient {
 
     return dataMethods._unpublishVersionObservable(
       this,
-      this.#httpRequest,
+      this._httpRequest,
       versionId,
       publishedId,
       options,
@@ -1040,7 +1048,7 @@ export class ObservableSanityClient {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._mutateObservable<R>(this, this.#httpRequest, operations, options)
+    return dataMethods._mutateObservable<R>(this, this._httpRequest, operations, options)
   }
 
   /**
@@ -1102,7 +1110,7 @@ export class ObservableSanityClient {
     operations: Action | Action[],
     options?: BaseActionOptions,
   ): Observable<SingleActionResult | MultipleActionResult> {
-    return dataMethods._actionObservable(this, this.#httpRequest, operations, options)
+    return dataMethods._actionObservable(this, this._httpRequest, operations, options)
   }
 
   /**
@@ -1111,7 +1119,7 @@ export class ObservableSanityClient {
    * @param options - Request options
    */
   request<R = Any>(options: RawRequestOptions): Observable<R> {
-    return dataMethods._requestObservable(this, this.#httpRequest, options)
+    return dataMethods._requestObservable(this, this._httpRequest, options)
   }
 
   /**
@@ -1156,10 +1164,18 @@ export class SanityClient {
   observable: ObservableSanityClient
 
   /**
-   * Private properties
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
    */
-  #clientConfig: InitializedClientConfig
-  #httpRequest: HttpRequest
+
+  /** @internal */
+  _clientConfig: InitializedClientConfig
+
+  /** @internal */
+  _httpRequest: HttpRequest
 
   /**
    * Instance properties
@@ -1169,20 +1185,20 @@ export class SanityClient {
   constructor(httpRequest: HttpRequest, config: ClientConfig = defaultConfig) {
     this.config(config)
 
-    this.#httpRequest = httpRequest
+    this._httpRequest = httpRequest
 
-    this.assets = new AssetsClient(this, this.#httpRequest)
-    this.datasets = new DatasetsClient(this, this.#httpRequest)
+    this.assets = new AssetsClient(this, this._httpRequest)
+    this.datasets = new DatasetsClient(this, this._httpRequest)
     this.live = new LiveClient(this)
     this.mediaLibrary = {
-      video: new MediaLibraryVideoClient(this, this.#httpRequest),
+      video: new MediaLibraryVideoClient(this, this._httpRequest),
     }
-    this.projects = new ProjectsClient(this, this.#httpRequest)
-    this.users = new UsersClient(this, this.#httpRequest)
+    this.projects = new ProjectsClient(this, this._httpRequest)
+    this.users = new UsersClient(this, this._httpRequest)
     this.agent = {
-      action: new AgentActionsClient(this, this.#httpRequest),
+      action: new AgentActionsClient(this, this._httpRequest),
     }
-    this.releases = new ReleasesClient(this, this.#httpRequest)
+    this.releases = new ReleasesClient(this, this._httpRequest)
 
     this.observable = new ObservableSanityClient(httpRequest, config)
   }
@@ -1191,7 +1207,7 @@ export class SanityClient {
    * Clone the client - returns a new instance
    */
   clone(): SanityClient {
-    return new SanityClient(this.#httpRequest, this.config())
+    return new SanityClient(this._httpRequest, this.config())
   }
 
   /**
@@ -1204,10 +1220,10 @@ export class SanityClient {
   config(newConfig?: Partial<ClientConfig>): this
   config(newConfig?: Partial<ClientConfig>): ClientConfig | this {
     if (newConfig === undefined) {
-      return {...this.#clientConfig}
+      return {...this._clientConfig}
     }
 
-    if (this.#clientConfig && this.#clientConfig.allowReconfigure === false) {
+    if (this._clientConfig && this._clientConfig.allowReconfigure === false) {
       throw new Error(
         'Existing client instance cannot be reconfigured - use `withConfig(newConfig)` to return a new client',
       )
@@ -1217,7 +1233,7 @@ export class SanityClient {
       this.observable.config(newConfig)
     }
 
-    this.#clientConfig = initConfig(newConfig, this.#clientConfig || {})
+    this._clientConfig = initConfig(newConfig, this._clientConfig || {})
     return this
   }
 
@@ -1228,7 +1244,7 @@ export class SanityClient {
    */
   withConfig(newConfig?: Partial<ClientConfig>): SanityClient {
     const thisConfig = this.config()
-    return new SanityClient(this.#httpRequest, {
+    return new SanityClient(this._httpRequest, {
       ...thisConfig,
       ...newConfig,
       stega: {
@@ -1305,8 +1321,8 @@ export class SanityClient {
   ): Promise<RawQueryResponse<ClientReturn<G, R>> | ClientReturn<G, R>> {
     return dataMethods._fetch<ClientReturn<G, R>, Q>(
       this,
-      this.#httpRequest,
-      this.#clientConfig.stega,
+      this._httpRequest,
+      this._clientConfig.stega,
       query,
       params,
       options,
@@ -1354,7 +1370,7 @@ export class SanityClient {
   ): Promise<SanityDocument<R> | undefined | SanityDocument<R>[]> {
     // Implementation needs to handle union type safely
     if (options?.includeAllVersions === true) {
-      return dataMethods._getDocument<R>(this, this.#httpRequest, id, {
+      return dataMethods._getDocument<R>(this, this._httpRequest, id, {
         ...options,
         includeAllVersions: true,
       })
@@ -1366,7 +1382,7 @@ export class SanityClient {
       releaseId: options?.releaseId,
       ...(options && 'includeAllVersions' in options ? {includeAllVersions: false as const} : {}),
     }
-    return dataMethods._getDocument<R>(this, this.#httpRequest, id, opts)
+    return dataMethods._getDocument<R>(this, this._httpRequest, id, opts)
   }
 
   /**
@@ -1382,7 +1398,7 @@ export class SanityClient {
     ids: string[],
     options?: {signal?: AbortSignal; tag?: string},
   ): Promise<(SanityDocument<R> | null)[]> {
-    return dataMethods._getDocuments<R>(this, this.#httpRequest, ids, options)
+    return dataMethods._getDocuments<R>(this, this._httpRequest, ids, options)
   }
 
   /**
@@ -1396,7 +1412,7 @@ export class SanityClient {
     ids: string[],
     options?: {signal?: AbortSignal; tag?: string},
   ): Promise<Set<string>> {
-    return dataMethods._documentsExists(this, this.#httpRequest, ids, options)
+    return dataMethods._documentsExists(this, this._httpRequest, ids, options)
   }
 
   /**
@@ -1465,7 +1481,7 @@ export class SanityClient {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._create<R>(this, this.#httpRequest, document, 'create', options)
+    return dataMethods._create<R>(this, this._httpRequest, document, 'create', options)
   }
 
   /**
@@ -1534,7 +1550,7 @@ export class SanityClient {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._createIfNotExists<R>(this, this.#httpRequest, document, options)
+    return dataMethods._createIfNotExists<R>(this, this._httpRequest, document, options)
   }
 
   /**
@@ -1603,7 +1619,7 @@ export class SanityClient {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._createOrReplace<R>(this, this.#httpRequest, document, options)
+    return dataMethods._createOrReplace<R>(this, this._httpRequest, document, options)
   }
 
   /**
@@ -1706,7 +1722,7 @@ export class SanityClient {
     if (!document) {
       return dataMethods._createVersionFromBase(
         this,
-        this.#httpRequest,
+        this._httpRequest,
         publishedId,
         baseId,
         releaseId,
@@ -1726,7 +1742,7 @@ export class SanityClient {
 
     return dataMethods._createVersion<R>(
       this,
-      this.#httpRequest,
+      this._httpRequest,
       documentVersion,
       versionPublishedId,
       options,
@@ -1848,7 +1864,7 @@ export class SanityClient {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._delete<R>(this, this.#httpRequest, selection, options)
+    return dataMethods._delete<R>(this, this._httpRequest, selection, options)
   }
 
   /**
@@ -1886,7 +1902,7 @@ export class SanityClient {
   ): Promise<SingleActionResult | MultipleActionResult> {
     const documentVersionId = getDocumentVersionId(publishedId, releaseId)
 
-    return dataMethods._discardVersion(this, this.#httpRequest, documentVersionId, purge, options)
+    return dataMethods._discardVersion(this, this._httpRequest, documentVersionId, purge, options)
   }
 
   /**
@@ -1991,7 +2007,7 @@ export class SanityClient {
 
     const documentVersion = {...document, _id: documentVersionId}
 
-    return dataMethods._replaceVersion<R>(this, this.#httpRequest, documentVersion, options)
+    return dataMethods._replaceVersion<R>(this, this._httpRequest, documentVersion, options)
   }
 
   /**
@@ -2021,7 +2037,7 @@ export class SanityClient {
   ): Promise<SingleActionResult | MultipleActionResult> {
     const versionId = getVersionId(publishedId, releaseId)
 
-    return dataMethods._unpublishVersion(this, this.#httpRequest, versionId, publishedId, options)
+    return dataMethods._unpublishVersion(this, this._httpRequest, versionId, publishedId, options)
   }
 
   /**
@@ -2090,7 +2106,7 @@ export class SanityClient {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    return dataMethods._mutate<R>(this, this.#httpRequest, operations, options)
+    return dataMethods._mutate<R>(this, this._httpRequest, operations, options)
   }
 
   /**
@@ -2153,7 +2169,7 @@ export class SanityClient {
     operations: Action | Action[],
     options?: BaseActionOptions,
   ): Promise<SingleActionResult | MultipleActionResult> {
-    return dataMethods._action(this, this.#httpRequest, operations, options)
+    return dataMethods._action(this, this._httpRequest, operations, options)
   }
 
   /**
@@ -2164,7 +2180,7 @@ export class SanityClient {
    * @returns Promise resolving to the response body
    */
   request<R = Any>(options: RawRequestOptions): Promise<R> {
-    return dataMethods._request<R>(this, this.#httpRequest, options)
+    return dataMethods._request<R>(this, this._httpRequest, options)
   }
 
   /**
@@ -2178,7 +2194,7 @@ export class SanityClient {
    * @internal
    */
   dataRequest(endpoint: string, body: unknown, options?: BaseMutationOptions): Promise<Any> {
-    return dataMethods._dataRequest(this, this.#httpRequest, endpoint, body, options)
+    return dataMethods._dataRequest(this, this._httpRequest, endpoint, body, options)
   }
 
   /**

--- a/src/agent/actions/AgentActionsClient.ts
+++ b/src/agent/actions/AgentActionsClient.ts
@@ -10,11 +10,23 @@ import {_translate, _translateObservable, type TranslateDocument} from './transl
 
 /** @public */
 export class ObservableAgentsActionClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: ObservableSanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -28,7 +40,7 @@ export class ObservableAgentsActionClient {
       ? {_id: string}
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
-    return _generateObservable(this.#client, this.#httpRequest, request)
+    return _generateObservable(this._client, this._httpRequest, request)
   }
 
   /**
@@ -42,7 +54,7 @@ export class ObservableAgentsActionClient {
       ? {_id: string}
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
-    return _transformObservable(this.#client, this.#httpRequest, request)
+    return _transformObservable(this._client, this._httpRequest, request)
   }
 
   /**
@@ -56,17 +68,29 @@ export class ObservableAgentsActionClient {
       ? {_id: string}
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
-    return _translateObservable(this.#client, this.#httpRequest, request)
+    return _translateObservable(this._client, this._httpRequest, request)
   }
 }
 
 /** @public */
 export class AgentActionsClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -80,7 +104,7 @@ export class AgentActionsClient {
       ? {_id: string}
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
-    return _generate(this.#client, this.#httpRequest, request)
+    return _generate(this._client, this._httpRequest, request)
   }
 
   /**
@@ -94,7 +118,7 @@ export class AgentActionsClient {
       ? {_id: string}
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
-    return _transform(this.#client, this.#httpRequest, request)
+    return _transform(this._client, this._httpRequest, request)
   }
 
   /**
@@ -108,7 +132,7 @@ export class AgentActionsClient {
       ? {_id: string}
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
-    return _translate(this.#client, this.#httpRequest, request)
+    return _translate(this._client, this._httpRequest, request)
   }
 
   /**
@@ -118,7 +142,7 @@ export class AgentActionsClient {
   prompt<const DocumentShape extends Record<string, Any>>(
     request: PromptRequest<DocumentShape>,
   ): Promise<(typeof request)['format'] extends 'json' ? DocumentShape : string> {
-    return _prompt(this.#client, this.#httpRequest, request)
+    return _prompt(this._client, this._httpRequest, request)
   }
 
   /**
@@ -133,6 +157,6 @@ export class AgentActionsClient {
       ? {_id: string}
       : IdentifiedSanityDocumentStub & DocumentShape
   > {
-    return _patch(this.#client, this.#httpRequest, request)
+    return _patch(this._client, this._httpRequest, request)
   }
 }

--- a/src/assets/AssetsClient.ts
+++ b/src/assets/AssetsClient.ts
@@ -19,11 +19,23 @@ import * as validators from '../validators'
 
 /** @internal */
 export class ObservableAssetsClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: ObservableSanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -68,17 +80,29 @@ export class ObservableAssetsClient {
     body: UploadBody,
     options?: UploadClientConfig,
   ): Observable<UploadEvent<{document: SanityAssetDocument | SanityImageAssetDocument}>> {
-    return _upload(this.#client, this.#httpRequest, assetType, body, options)
+    return _upload(this._client, this._httpRequest, assetType, body, options)
   }
 }
 
 /** @internal */
 export class AssetsClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -123,7 +147,7 @@ export class AssetsClient {
     options?: UploadClientConfig,
   ): Promise<SanityAssetDocument | SanityImageAssetDocument> {
     type Doc = {document: SanityAssetDocument | SanityImageAssetDocument}
-    const observable = _upload<Doc>(this.#client, this.#httpRequest, assetType, body, options)
+    const observable = _upload<Doc>(this._client, this._httpRequest, assetType, body, options)
     return lastValueFrom(
       observable.pipe(
         filter((event): event is UploadResponseEvent<Doc> => event.type === 'response'),

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -26,9 +26,19 @@ const requiredApiVersion = '2021-03-25'
  * @public
  */
 export class LiveClient {
-  #client: SanityClient | ObservableSanityClient
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient | ObservableSanityClient
+
   constructor(client: SanityClient | ObservableSanityClient) {
-    this.#client = client
+    this._client = client
   }
 
   /**
@@ -52,7 +62,7 @@ export class LiveClient {
      */
     waitFor?: 'function'
   } = {}): Observable<LiveEvent> {
-    const config = this.#client.config()
+    const config = this._client.config()
     const {
       projectId,
       apiVersion: _apiVersion,
@@ -74,8 +84,8 @@ export class LiveClient {
         `The live events API requires a token or withCredentials when 'includeDrafts: true'. Please update your client configuration. The token should have the lowest possible access role.`,
       )
     }
-    const path = _getDataUrl(this.#client, 'live/events')
-    const url = new URL(this.#client.getUrl(path, false))
+    const path = _getDataUrl(this._client, 'live/events')
+    const url = new URL(this._client.getUrl(path, false))
     const tag = _tag && requestTagPrefix ? [requestTagPrefix, _tag].join('.') : _tag
     if (tag) {
       url.searchParams.set('tag', tag)
@@ -129,7 +139,7 @@ export class LiveClient {
     ])
 
     const checkCors = checkCorsObservable(
-      new URL(this.#client.getUrl('/check/cors', false)),
+      new URL(this._client.getUrl('/check/cors', false)),
       projectId,
       eventSourceWithCredentials,
     )

--- a/src/data/patch.ts
+++ b/src/data/patch.ts
@@ -193,7 +193,8 @@ export class BasePatch {
 
 /** @public */
 export class ObservablePatch extends BasePatch {
-  #client?: ObservableSanityClient
+  /** @internal */
+  _client?: ObservableSanityClient
 
   constructor(
     selection: PatchSelection,
@@ -201,14 +202,14 @@ export class ObservablePatch extends BasePatch {
     client?: ObservableSanityClient,
   ) {
     super(selection, operations)
-    this.#client = client
+    this._client = client
   }
 
   /**
    * Clones the patch
    */
   clone(): ObservablePatch {
-    return new ObservablePatch(this.selection, {...this.operations}, this.#client)
+    return new ObservablePatch(this.selection, {...this.operations}, this._client)
   }
 
   /**
@@ -257,7 +258,7 @@ export class ObservablePatch extends BasePatch {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    if (!this.#client) {
+    if (!this._client) {
       throw new Error(
         'No `client` passed to patch, either provide one or pass the ' +
           'patch to a clients `mutate()` method',
@@ -266,23 +267,25 @@ export class ObservablePatch extends BasePatch {
 
     const returnFirst = typeof this.selection === 'string'
     const opts = Object.assign({returnFirst, returnDocuments: true}, options)
-    return this.#client.mutate<R>({patch: this.serialize()} as Any, opts)
+    return this._client.mutate<R>({patch: this.serialize()} as Any, opts)
   }
 }
 
 /** @public */
 export class Patch extends BasePatch {
-  #client?: SanityClient
+  /** @internal */
+  _client?: SanityClient
+
   constructor(selection: PatchSelection, operations?: PatchOperations, client?: SanityClient) {
     super(selection, operations)
-    this.#client = client
+    this._client = client
   }
 
   /**
    * Clones the patch
    */
   clone(): Patch {
-    return new Patch(this.selection, {...this.operations}, this.#client)
+    return new Patch(this.selection, {...this.operations}, this._client)
   }
 
   /**
@@ -331,7 +334,7 @@ export class Patch extends BasePatch {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    if (!this.#client) {
+    if (!this._client) {
       throw new Error(
         'No `client` passed to patch, either provide one or pass the ' +
           'patch to a clients `mutate()` method',
@@ -340,6 +343,6 @@ export class Patch extends BasePatch {
 
     const returnFirst = typeof this.selection === 'string'
     const opts = Object.assign({returnFirst, returnDocuments: true}, options)
-    return this.#client.mutate<R>({patch: this.serialize()} as Any, opts)
+    return this._client.mutate<R>({patch: this.serialize()} as Any, opts)
   }
 }

--- a/src/data/transaction.ts
+++ b/src/data/transaction.ts
@@ -136,17 +136,19 @@ export class BaseTransaction {
 
 /** @public */
 export class Transaction extends BaseTransaction {
-  #client?: SanityClient
+  /** @internal */
+  _client?: SanityClient
+
   constructor(operations?: Mutation[], client?: SanityClient, transactionId?: string) {
     super(operations, transactionId)
-    this.#client = client
+    this._client = client
   }
 
   /**
    * Clones the transaction
    */
   clone(): Transaction {
-    return new Transaction([...this.operations], this.#client, this.trxId)
+    return new Transaction([...this.operations], this._client, this.trxId)
   }
 
   /**
@@ -193,14 +195,14 @@ export class Transaction extends BaseTransaction {
   ): Promise<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    if (!this.#client) {
+    if (!this._client) {
       throw new Error(
         'No `client` passed to transaction, either provide one or pass the ' +
           'transaction to a clients `mutate()` method',
       )
     }
 
-    return this.#client.mutate<R>(
+    return this._client.mutate<R>(
       this.serialize() as Any,
       Object.assign({transactionId: this.trxId}, defaultMutateOptions, options || {}),
     )
@@ -245,7 +247,7 @@ export class Transaction extends BaseTransaction {
 
     // patch => patch.inc({visits: 1}).set({foo: 'bar'})
     if (isBuilder) {
-      const patch = patchOps(new Patch(patchOrDocumentId, {}, this.#client))
+      const patch = patchOps(new Patch(patchOrDocumentId, {}, this._client))
       if (!(patch instanceof Patch)) {
         throw new Error('function passed to `patch()` must return the patch')
       }
@@ -260,7 +262,7 @@ export class Transaction extends BaseTransaction {
      * )
      */
     if (isMutationSelection) {
-      const patch = new Patch(patchOrDocumentId, patchOps || {}, this.#client)
+      const patch = new Patch(patchOrDocumentId, patchOps || {}, this._client)
       return this._add({patch: patch.serialize()})
     }
 
@@ -270,17 +272,19 @@ export class Transaction extends BaseTransaction {
 
 /** @public */
 export class ObservableTransaction extends BaseTransaction {
-  #client?: ObservableSanityClient
+  /** @internal */
+  _client?: ObservableSanityClient
+
   constructor(operations?: Mutation[], client?: ObservableSanityClient, transactionId?: string) {
     super(operations, transactionId)
-    this.#client = client
+    this._client = client
   }
 
   /**
    * Clones the transaction
    */
   clone(): ObservableTransaction {
-    return new ObservableTransaction([...this.operations], this.#client, this.trxId)
+    return new ObservableTransaction([...this.operations], this._client, this.trxId)
   }
 
   /**
@@ -327,14 +331,14 @@ export class ObservableTransaction extends BaseTransaction {
   ): Observable<
     SanityDocument<R> | SanityDocument<R>[] | SingleMutationResult | MultipleMutationResult
   > {
-    if (!this.#client) {
+    if (!this._client) {
       throw new Error(
         'No `client` passed to transaction, either provide one or pass the ' +
           'transaction to a clients `mutate()` method',
       )
     }
 
-    return this.#client.mutate<R>(
+    return this._client.mutate<R>(
       this.serialize() as Any,
       Object.assign({transactionId: this.trxId}, defaultMutateOptions, options || {}),
     )
@@ -370,7 +374,7 @@ export class ObservableTransaction extends BaseTransaction {
 
     // patch => patch.inc({visits: 1}).set({foo: 'bar'})
     if (isBuilder) {
-      const patch = patchOps(new ObservablePatch(patchOrDocumentId, {}, this.#client))
+      const patch = patchOps(new ObservablePatch(patchOrDocumentId, {}, this._client))
       if (!(patch instanceof ObservablePatch)) {
         throw new Error('function passed to `patch()` must return the patch')
       }

--- a/src/datasets/DatasetsClient.ts
+++ b/src/datasets/DatasetsClient.ts
@@ -15,11 +15,23 @@ import * as validate from '../validators'
 
 /** @internal */
 export class ObservableDatasetsClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: ObservableSanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -29,7 +41,7 @@ export class ObservableDatasetsClient {
    * @param options - Options for the dataset, including optional embeddings configuration
    */
   create(name: string, options?: DatasetCreateOptions): Observable<DatasetResponse> {
-    return _modifyObservable<DatasetResponse>(this.#client, this.#httpRequest, 'PUT', name, options)
+    return _modifyObservable<DatasetResponse>(this._client, this._httpRequest, 'PUT', name, options)
   }
 
   /**
@@ -40,8 +52,8 @@ export class ObservableDatasetsClient {
    */
   edit(name: string, options?: DatasetEditOptions): Observable<DatasetResponse> {
     return _modifyObservable<DatasetResponse>(
-      this.#client,
-      this.#httpRequest,
+      this._client,
+      this._httpRequest,
       'PATCH',
       name,
       options,
@@ -54,22 +66,22 @@ export class ObservableDatasetsClient {
    * @param name - Name of the dataset to delete
    */
   delete(name: string): Observable<{deleted: true}> {
-    return _modifyObservable<{deleted: true}>(this.#client, this.#httpRequest, 'DELETE', name)
+    return _modifyObservable<{deleted: true}>(this._client, this._httpRequest, 'DELETE', name)
   }
 
   /**
    * Fetch a list of datasets for the configured project
    */
   list(): Observable<DatasetsResponse> {
-    validate.resourceGuard('dataset', this.#client.config())
-    const config = this.#client.config()
+    validate.resourceGuard('dataset', this._client.config())
+    const config = this._client.config()
     const projectId = config.projectId
     let url = '/datasets'
     if (config.useProjectHostname === false) {
       url = `/projects/${projectId}/datasets`
     }
 
-    return _requestObservable<DatasetsResponse>(this.#client, this.#httpRequest, {
+    return _requestObservable<DatasetsResponse>(this._client, this._httpRequest, {
       url,
       tag: null,
     })
@@ -81,10 +93,10 @@ export class ObservableDatasetsClient {
    * @param name - Name of the dataset
    */
   getEmbeddingsSettings(name: string): Observable<EmbeddingsSettings> {
-    validate.resourceGuard('dataset', this.#client.config())
+    validate.resourceGuard('dataset', this._client.config())
     validate.dataset(name)
-    return _requestObservable<EmbeddingsSettings>(this.#client, this.#httpRequest, {
-      url: _embeddingsSettingsUri(this.#client, name),
+    return _requestObservable<EmbeddingsSettings>(this._client, this._httpRequest, {
+      url: _embeddingsSettingsUri(this._client, name),
       tag: null,
     })
   }
@@ -96,11 +108,11 @@ export class ObservableDatasetsClient {
    * @param settings - Embeddings settings to apply
    */
   editEmbeddingsSettings(name: string, settings: EmbeddingsSettingsBody): Observable<void> {
-    validate.resourceGuard('dataset', this.#client.config())
+    validate.resourceGuard('dataset', this._client.config())
     validate.dataset(name)
-    return _requestObservable<void>(this.#client, this.#httpRequest, {
+    return _requestObservable<void>(this._client, this._httpRequest, {
       method: 'PUT',
-      url: _embeddingsSettingsUri(this.#client, name),
+      url: _embeddingsSettingsUri(this._client, name),
       body: settings,
       tag: null,
     })
@@ -109,11 +121,23 @@ export class ObservableDatasetsClient {
 
 /** @internal */
 export class DatasetsClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -123,8 +147,8 @@ export class DatasetsClient {
    * @param options - Options for the dataset, including optional embeddings configuration
    */
   create(name: string, options?: DatasetCreateOptions): Promise<DatasetResponse> {
-    validate.resourceGuard('dataset', this.#client.config())
-    return _modify<DatasetResponse>(this.#client, this.#httpRequest, 'PUT', name, options)
+    validate.resourceGuard('dataset', this._client.config())
+    return _modify<DatasetResponse>(this._client, this._httpRequest, 'PUT', name, options)
   }
 
   /**
@@ -134,8 +158,8 @@ export class DatasetsClient {
    * @param options - New options for the dataset
    */
   edit(name: string, options?: DatasetEditOptions): Promise<DatasetResponse> {
-    validate.resourceGuard('dataset', this.#client.config())
-    return _modify<DatasetResponse>(this.#client, this.#httpRequest, 'PATCH', name, options)
+    validate.resourceGuard('dataset', this._client.config())
+    return _modify<DatasetResponse>(this._client, this._httpRequest, 'PATCH', name, options)
   }
 
   /**
@@ -144,23 +168,23 @@ export class DatasetsClient {
    * @param name - Name of the dataset to delete
    */
   delete(name: string): Promise<{deleted: true}> {
-    validate.resourceGuard('dataset', this.#client.config())
-    return _modify<{deleted: true}>(this.#client, this.#httpRequest, 'DELETE', name)
+    validate.resourceGuard('dataset', this._client.config())
+    return _modify<{deleted: true}>(this._client, this._httpRequest, 'DELETE', name)
   }
 
   /**
    * Fetch a list of datasets for the configured project
    */
   list(): Promise<DatasetsResponse> {
-    validate.resourceGuard('dataset', this.#client.config())
-    const config = this.#client.config()
+    validate.resourceGuard('dataset', this._client.config())
+    const config = this._client.config()
     const projectId = config.projectId
     let url = '/datasets'
     if (config.useProjectHostname === false) {
       url = `/projects/${projectId}/datasets`
     }
 
-    return _request<DatasetsResponse>(this.#client, this.#httpRequest, {
+    return _request<DatasetsResponse>(this._client, this._httpRequest, {
       url,
       tag: null,
     })
@@ -172,10 +196,10 @@ export class DatasetsClient {
    * @param name - Name of the dataset
    */
   getEmbeddingsSettings(name: string): Promise<EmbeddingsSettings> {
-    validate.resourceGuard('dataset', this.#client.config())
+    validate.resourceGuard('dataset', this._client.config())
     validate.dataset(name)
-    return _request<EmbeddingsSettings>(this.#client, this.#httpRequest, {
-      url: _embeddingsSettingsUri(this.#client, name),
+    return _request<EmbeddingsSettings>(this._client, this._httpRequest, {
+      url: _embeddingsSettingsUri(this._client, name),
       tag: null,
     })
   }
@@ -187,11 +211,11 @@ export class DatasetsClient {
    * @param settings - Embeddings settings to apply
    */
   editEmbeddingsSettings(name: string, settings: EmbeddingsSettingsBody): Promise<void> {
-    validate.resourceGuard('dataset', this.#client.config())
+    validate.resourceGuard('dataset', this._client.config())
     validate.dataset(name)
-    return _request<void>(this.#client, this.#httpRequest, {
+    return _request<void>(this._client, this._httpRequest, {
       method: 'PUT',
-      url: _embeddingsSettingsUri(this.#client, name),
+      url: _embeddingsSettingsUri(this._client, name),
       body: settings,
       tag: null,
     })

--- a/src/mediaLibrary/MediaLibraryVideoClient.ts
+++ b/src/mediaLibrary/MediaLibraryVideoClient.ts
@@ -12,11 +12,23 @@ import type {
 
 /** @internal */
 export class ObservableMediaLibraryVideoClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: ObservableSanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -29,7 +41,7 @@ export class ObservableMediaLibraryVideoClient {
     assetIdentifier: MediaLibraryAssetInstanceIdentifier,
     options: MediaLibraryPlaybackInfoOptions = {},
   ): Observable<VideoPlaybackInfo> {
-    const config = this.#client.config()
+    const config = this._client.config()
     const resource = config.resource || config['~experimental_resource']
     const configMediaLibraryId = resource?.id
 
@@ -45,7 +57,7 @@ export class ObservableMediaLibraryVideoClient {
     const url = buildVideoPlaybackInfoUrl(instanceId, effectiveLibraryId)
     const queryParams = buildQueryParams(options)
 
-    return _requestObservable<VideoPlaybackInfo>(this.#client, this.#httpRequest, {
+    return _requestObservable<VideoPlaybackInfo>(this._client, this._httpRequest, {
       method: 'GET',
       url,
       query: queryParams,
@@ -55,11 +67,23 @@ export class ObservableMediaLibraryVideoClient {
 
 /** @internal */
 export class MediaLibraryVideoClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -72,7 +96,7 @@ export class MediaLibraryVideoClient {
     assetIdentifier: MediaLibraryAssetInstanceIdentifier,
     options: MediaLibraryPlaybackInfoOptions = {},
   ): Promise<VideoPlaybackInfo> {
-    const config = this.#client.config()
+    const config = this._client.config()
     const resource = config.resource || config['~experimental_resource']
     const configMediaLibraryId = resource?.id
 
@@ -88,7 +112,7 @@ export class MediaLibraryVideoClient {
     const url = buildVideoPlaybackInfoUrl(instanceId, effectiveLibraryId)
     const queryParams = buildQueryParams(options)
 
-    return _request<VideoPlaybackInfo>(this.#client, this.#httpRequest, {
+    return _request<VideoPlaybackInfo>(this._client, this._httpRequest, {
       method: 'GET',
       url,
       query: queryParams,

--- a/src/projects/ProjectsClient.ts
+++ b/src/projects/ProjectsClient.ts
@@ -17,11 +17,23 @@ type OmittedProjectFields<T extends ListOptions | undefined> =
 
 /** @internal */
 export class ObservableProjectsClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: ObservableSanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -51,7 +63,7 @@ export class ObservableProjectsClient {
       query.onlyExplicitMembership = 'true'
     }
 
-    return _requestObservable<SanityProject[]>(this.#client, this.#httpRequest, {
+    return _requestObservable<SanityProject[]>(this._client, this._httpRequest, {
       url,
       query,
     }) as Observable<Omit<SanityProject, OmittedProjectFields<T>>[]>
@@ -63,7 +75,7 @@ export class ObservableProjectsClient {
    * @param projectId - ID of the project to fetch
    */
   getById(projectId: string): Observable<SanityProject> {
-    return _requestObservable<SanityProject>(this.#client, this.#httpRequest, {
+    return _requestObservable<SanityProject>(this._client, this._httpRequest, {
       url: `/projects/${projectId}`,
     })
   }
@@ -71,11 +83,23 @@ export class ObservableProjectsClient {
 
 /** @internal */
 export class ProjectsClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -104,7 +128,7 @@ export class ProjectsClient {
     if (options?.onlyExplicitMembership) {
       query.onlyExplicitMembership = 'true'
     }
-    return _request<SanityProject[]>(this.#client, this.#httpRequest, {
+    return _request<SanityProject[]>(this._client, this._httpRequest, {
       url,
       query,
     }) as Promise<Omit<SanityProject, OmittedProjectFields<T>>[]>
@@ -116,7 +140,7 @@ export class ProjectsClient {
    * @param projectId - ID of the project to fetch
    */
   getById(projectId: string): Promise<SanityProject> {
-    return _request<SanityProject>(this.#client, this.#httpRequest, {
+    return _request<SanityProject>(this._client, this._httpRequest, {
       url: `/projects/${projectId}`,
     })
   }

--- a/src/releases/ReleasesClient.ts
+++ b/src/releases/ReleasesClient.ts
@@ -30,11 +30,23 @@ import {createRelease} from './createRelease'
 
 /** @public */
 export class ObservableReleasesClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: ObservableSanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -69,8 +81,8 @@ export class ObservableReleasesClient {
     options?: {signal?: AbortSignal; tag?: string},
   ): Observable<ReleaseDocument | undefined> {
     return _getDocumentObservable<ReleaseDocument>(
-      this.#client,
-      this.#httpRequest,
+      this._client,
+      this._httpRequest,
       `_.releases.${releaseId}`,
       options,
     )
@@ -147,7 +159,7 @@ export class ObservableReleasesClient {
     const {action, options} = createRelease(releaseOrOptions, maybeOptions)
     const {releaseId, metadata} = action
 
-    return _actionObservable(this.#client, this.#httpRequest, action, options).pipe(
+    return _actionObservable(this._client, this._httpRequest, action, options).pipe(
       map((actionResult) => ({
         ...actionResult,
         releaseId,
@@ -179,7 +191,7 @@ export class ObservableReleasesClient {
       patch,
     }
 
-    return _actionObservable(this.#client, this.#httpRequest, editAction, options)
+    return _actionObservable(this._client, this._httpRequest, editAction, options)
   }
 
   /**
@@ -209,7 +221,7 @@ export class ObservableReleasesClient {
       releaseId,
     }
 
-    return _actionObservable(this.#client, this.#httpRequest, publishAction, options)
+    return _actionObservable(this._client, this._httpRequest, publishAction, options)
   }
 
   /**
@@ -236,7 +248,7 @@ export class ObservableReleasesClient {
       releaseId,
     }
 
-    return _actionObservable(this.#client, this.#httpRequest, archiveAction, options)
+    return _actionObservable(this._client, this._httpRequest, archiveAction, options)
   }
 
   /**
@@ -261,7 +273,7 @@ export class ObservableReleasesClient {
       releaseId,
     }
 
-    return _actionObservable(this.#client, this.#httpRequest, unarchiveAction, options)
+    return _actionObservable(this._client, this._httpRequest, unarchiveAction, options)
   }
 
   /**
@@ -290,7 +302,7 @@ export class ObservableReleasesClient {
       publishAt,
     }
 
-    return _actionObservable(this.#client, this.#httpRequest, scheduleAction, options)
+    return _actionObservable(this._client, this._httpRequest, scheduleAction, options)
   }
 
   /**
@@ -317,7 +329,7 @@ export class ObservableReleasesClient {
       releaseId,
     }
 
-    return _actionObservable(this.#client, this.#httpRequest, unscheduleAction, options)
+    return _actionObservable(this._client, this._httpRequest, unscheduleAction, options)
   }
 
   /**
@@ -342,7 +354,7 @@ export class ObservableReleasesClient {
       releaseId,
     }
 
-    return _actionObservable(this.#client, this.#httpRequest, deleteAction, options)
+    return _actionObservable(this._client, this._httpRequest, deleteAction, options)
   }
 
   /**
@@ -361,17 +373,29 @@ export class ObservableReleasesClient {
     {releaseId}: {releaseId: string},
     options?: BaseMutationOptions,
   ): Observable<RawQueryResponse<SanityDocument[]>> {
-    return _getReleaseDocumentsObservable(this.#client, this.#httpRequest, releaseId, options)
+    return _getReleaseDocumentsObservable(this._client, this._httpRequest, releaseId, options)
   }
 }
 
 /** @public */
 export class ReleasesClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -405,8 +429,8 @@ export class ReleasesClient {
     options?: {signal?: AbortSignal; tag?: string},
   ): Promise<ReleaseDocument | undefined> {
     return _getDocument<ReleaseDocument>(
-      this.#client,
-      this.#httpRequest,
+      this._client,
+      this._httpRequest,
       `_.releases.${releaseId}`,
       options,
     )
@@ -475,7 +499,7 @@ export class ReleasesClient {
     const {action, options} = createRelease(releaseOrOptions, maybeOptions)
     const {releaseId, metadata} = action
 
-    const actionResult = await _action(this.#client, this.#httpRequest, action, options)
+    const actionResult = await _action(this._client, this._httpRequest, action, options)
 
     return {...actionResult, releaseId, metadata}
   }
@@ -503,7 +527,7 @@ export class ReleasesClient {
       patch,
     }
 
-    return _action(this.#client, this.#httpRequest, editAction, options)
+    return _action(this._client, this._httpRequest, editAction, options)
   }
 
   /**
@@ -533,7 +557,7 @@ export class ReleasesClient {
       releaseId,
     }
 
-    return _action(this.#client, this.#httpRequest, publishAction, options)
+    return _action(this._client, this._httpRequest, publishAction, options)
   }
 
   /**
@@ -560,7 +584,7 @@ export class ReleasesClient {
       releaseId,
     }
 
-    return _action(this.#client, this.#httpRequest, archiveAction, options)
+    return _action(this._client, this._httpRequest, archiveAction, options)
   }
 
   /**
@@ -585,7 +609,7 @@ export class ReleasesClient {
       releaseId,
     }
 
-    return _action(this.#client, this.#httpRequest, unarchiveAction, options)
+    return _action(this._client, this._httpRequest, unarchiveAction, options)
   }
 
   /**
@@ -614,7 +638,7 @@ export class ReleasesClient {
       publishAt,
     }
 
-    return _action(this.#client, this.#httpRequest, scheduleAction, options)
+    return _action(this._client, this._httpRequest, scheduleAction, options)
   }
 
   /**
@@ -641,7 +665,7 @@ export class ReleasesClient {
       releaseId,
     }
 
-    return _action(this.#client, this.#httpRequest, unscheduleAction, options)
+    return _action(this._client, this._httpRequest, unscheduleAction, options)
   }
 
   /**
@@ -666,7 +690,7 @@ export class ReleasesClient {
       releaseId,
     }
 
-    return _action(this.#client, this.#httpRequest, deleteAction, options)
+    return _action(this._client, this._httpRequest, deleteAction, options)
   }
 
   /**
@@ -685,6 +709,6 @@ export class ReleasesClient {
     {releaseId}: {releaseId: string},
     options?: BaseMutationOptions,
   ): Promise<RawQueryResponse<SanityDocument[]>> {
-    return _getReleaseDocuments(this.#client, this.#httpRequest, releaseId, options)
+    return _getReleaseDocuments(this._client, this._httpRequest, releaseId, options)
   }
 }

--- a/src/users/UsersClient.ts
+++ b/src/users/UsersClient.ts
@@ -6,11 +6,23 @@ import type {CurrentSanityUser, HttpRequest, SanityUser} from '../types'
 
 /** @public */
 export class ObservableUsersClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: ObservableSanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -20,8 +32,8 @@ export class ObservableUsersClient {
    */
   getById<T extends string>(id: T): Observable<T extends 'me' ? CurrentSanityUser : SanityUser> {
     return _requestObservable<T extends 'me' ? CurrentSanityUser : SanityUser>(
-      this.#client,
-      this.#httpRequest,
+      this._client,
+      this._httpRequest,
       {url: `/users/${id}`},
     )
   }
@@ -29,11 +41,23 @@ export class ObservableUsersClient {
 
 /** @public */
 export class UsersClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  /**
+   * Private properties. These do not use `#` (JS private) because TS collapses them to a
+   * to a single `#private` in the emitted declaration, and that brands nominally, which
+   * creates all sorts of type issues when there's multiple versions of `@sanity/client`
+   * in the dependency tree. Instead, we rely on `@internal` to remove them from definitions,
+   * the underscore prefix as a runtime "do not use" signal to external users.
+   */
+
+  /** @internal */
+  _client: SanityClient
+
+  /** @internal */
+  _httpRequest: HttpRequest
+
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this._client = client
+    this._httpRequest = httpRequest
   }
 
   /**
@@ -43,8 +67,8 @@ export class UsersClient {
    */
   getById<T extends string>(id: T): Promise<T extends 'me' ? CurrentSanityUser : SanityUser> {
     return _request<T extends 'me' ? CurrentSanityUser : SanityUser>(
-      this.#client,
-      this.#httpRequest,
+      this._client,
+      this._httpRequest,
       {url: `/users/${id}`},
     )
   }

--- a/test/stripInternalMembers.test.ts
+++ b/test/stripInternalMembers.test.ts
@@ -148,9 +148,11 @@ describe('stripInternalClassMembers', () => {
  * a build; `npm test` on a clean checkout skips.
  */
 describe.skipIf(!existsSync(resolve(distDir, 'index.d.ts')))('built declarations', () => {
-  const declarationFiles = readdirSync(distDir).filter((file) => file.endsWith('.d.ts'))
-
   test('every emitted .d.ts is already stripped', () => {
+    // Read the directory here rather than in the `describe` body: a skipped suite still runs its
+    // callback, so scanning at collection time fails the file on an unbuilt checkout.
+    const declarationFiles = readdirSync(distDir).filter((file) => file.endsWith('.d.ts'))
+
     expect(declarationFiles.length).toBeGreaterThan(0)
 
     const remaining = declarationFiles.filter(

--- a/test/stripInternalMembers.test.ts
+++ b/test/stripInternalMembers.test.ts
@@ -1,0 +1,162 @@
+import {existsSync, readdirSync, readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+
+import {describe, expect, test} from 'vitest'
+
+import {stripInternalClassMembers} from '../scripts/stripInternalMembers'
+
+// `__dirname` rather than `import.meta.url`: the happy-dom suite rewrites `import.meta.url` to an
+// http URL, which `node:path` can't resolve.
+const distDir = resolve(__dirname, '../dist')
+
+/**
+ * Guards the build-time pass that keeps `@internal` class members (the `_client`/`_httpRequest`
+ * plumbing every client class carries) out of the published `.d.ts` files. See
+ * `scripts/stripInternalMembers.ts` for why TypeScript's own `stripInternal` can't be used here.
+ */
+describe('stripInternalClassMembers', () => {
+  test('removes tagged properties and methods from class bodies', () => {
+    const {code, removed} = stripInternalClassMembers(
+      [
+        'declare class UsersClient {',
+        '  /** @internal */',
+        '  _client: SanityClient;',
+        '  /** @internal */',
+        '  _request(options: RequestOptions): void;',
+        '  constructor(client: SanityClient);',
+        '  getById(id: string): Promise<SanityUser>;',
+        '}',
+        '',
+      ].join('\n'),
+    )
+
+    expect(removed).toBe(2)
+    expect(code).toBe(
+      [
+        'declare class UsersClient {',
+        '  constructor(client: SanityClient);',
+        '  getById(id: string): Promise<SanityUser>;',
+        '}',
+        '',
+      ].join('\n'),
+    )
+  })
+
+  test('takes the explanatory comment block above the tag with it', () => {
+    const {code, removed} = stripInternalClassMembers(
+      [
+        'declare class Patch {',
+        '  /**',
+        '   * Not `#private`: that brands the class nominally.',
+        '   */',
+        '  /** @internal */',
+        '  _selection: PatchSelection;',
+        '  commit(): void;',
+        '}',
+        '',
+      ].join('\n'),
+    )
+
+    expect(removed).toBe(1)
+    expect(code).toBe(['declare class Patch {', '  commit(): void;', '}', ''].join('\n'))
+  })
+
+  test('keeps semicolons inside an inline object type from ending the member early', () => {
+    const {code, removed} = stripInternalClassMembers(
+      [
+        'declare class Transaction {',
+        '  /** @internal */',
+        '  _state: {id: string; mutations: Mutation[]};',
+        '  commit(): void;',
+        '}',
+        '',
+      ].join('\n'),
+    )
+
+    expect(removed).toBe(1)
+    expect(code).toBe(['declare class Transaction {', '  commit(): void;', '}', ''].join('\n'))
+  })
+
+  test('finds the class body after a heritage clause with an inline object type', () => {
+    const {code, removed} = stripInternalClassMembers(
+      [
+        'declare class LiveClient extends Base<{id: string}> {',
+        '  /** @internal */',
+        '  _sse: EventSourceInstance;',
+        '  events(): Observable<LiveEvent>;',
+        '}',
+        '',
+      ].join('\n'),
+    )
+
+    expect(removed).toBe(1)
+    expect(code).toBe(
+      [
+        'declare class LiveClient extends Base<{id: string}> {',
+        '  events(): Observable<LiveEvent>;',
+        '}',
+        '',
+      ].join('\n'),
+    )
+  })
+
+  test('leaves interface members, type literals and exported declarations alone', () => {
+    const source = [
+      '/** @internal */',
+      'declare function validateApiPerspective(perspective: unknown): void;',
+      'interface ClientConfig {',
+      '  /** @internal */',
+      '  resolveFetch?: () => FetchFunction;',
+      '  projectId?: string;',
+      '}',
+      'type Internals = {',
+      '  /** @internal */',
+      '  httpRequest: HttpRequest;',
+      '};',
+      '',
+    ].join('\n')
+
+    const {code, removed} = stripInternalClassMembers(source)
+
+    expect(removed).toBe(0)
+    expect(code).toBe(source)
+  })
+
+  test('leaves untagged members and their doc comments untouched', () => {
+    const source = [
+      'declare class AssetsClient {',
+      '  /**',
+      '   * Uploads an asset.',
+      '   *',
+      '   * @param body - The asset contents',
+      '   */',
+      '  upload(body: Blob): Promise<SanityAssetDocument>;',
+      '}',
+      '',
+    ].join('\n')
+
+    const {code, removed} = stripInternalClassMembers(source)
+
+    expect(removed).toBe(0)
+    expect(code).toBe(source)
+  })
+})
+
+/**
+ * Catches the pass silently going missing - a pkg-utils upgrade that stops routing plugins at the
+ * declaration output would otherwise publish the internals again without failing anything. Requires
+ * a build; `npm test` on a clean checkout skips.
+ */
+describe.skipIf(!existsSync(resolve(distDir, 'index.d.ts')))('built declarations', () => {
+  const declarationFiles = readdirSync(distDir).filter((file) => file.endsWith('.d.ts'))
+
+  test('every emitted .d.ts is already stripped', () => {
+    expect(declarationFiles.length).toBeGreaterThan(0)
+
+    const remaining = declarationFiles.filter(
+      (file) => stripInternalClassMembers(readFileSync(resolve(distDir, file), 'utf8')).removed > 0,
+    )
+
+    expect(remaining).toEqual([])
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.settings",
-  "include": ["./src", "./test"],
+  "include": ["./src", "./test", "./scripts"],
   "exclude": ["./test-esm/test.ts", "./node_modules/next", "./test-next"],
   "compilerOptions": {
     "types": ["@edge-runtime/types", "node"],


### PR DESCRIPTION
### Description

TypeScript collapses every `#`-private field into a single `#private` marker in the emitted declarations, and that marker brands the class nominally. With more than one copy of `@sanity/client` in a dependency tree, two otherwise identical `SanityClient` types stop being assignable to each other.

The client classes now keep their plumbing in underscore-prefixed properties tagged `@internal` instead. The underscore is the runtime "do not touch" signal, and a build pass keeps the properties out of the published types.

### The build pass

`@internal` on its own removes nothing, and TypeScript's `stripInternal` can't be turned on here:

- It's global, and around 158 of the `@internal` tags in `src` sit on exported declarations (`validateApiPerspective`, `BaseMutationOptions`, `connectEventSource`, the eventsource types). Those are part of the emitted surface.
- It deletes declarations without touching references to them, so the declaration rollup fails with dangling re-exports (`"isQueryParseError" is not exported by "src/http/errors.d.ts"`, and four more).
- pkg-utils v12 doesn't forward `dts.compilerOptions` to rolldown-plugin-dts, so it can only be set in the build tsconfig, all or nothing.

`scripts/stripInternalMembers.ts` does it surgically instead, as a rolldown plugin wired up in `package.config.ts`:

- Class bodies only. `@internal` on an interface member (`ClientConfig.resolveFetch`) marks an unsupported option rather than a private field, so those keep their typings.
- Template literal types are tracked explicitly. Without `reScanTemplateToken` the scanner desyncs on a member like ``imageUrl?: `https://${string}` ``, starts reading doc comment prose as code, and spins forever on the `#` in `### Targeting non-image fields`.
- It throws with an offset if the scanner ever stops advancing, so a future oddity fails the build instead of hanging it.
- The explanatory comment block above the members goes with them, so that doesn't ship either.

Note that `typescript@7` no longer exposes the classic compiler API, so the pass uses the scanner from `typescript/unstable/ast`. That subpath can change across TS 7 minors; the tests are what will catch it.

### What to review

No runtime behavior changes: same values, new names, and `@internal` plus the underscore prefix marks them unsupported exactly as `#` did.

Worth a closer look:

- Dropping the members shrinks each client class's published type. That's the point, since the `#private` brand goes with it, but it also means anything reaching into `client._client` loses its types.
- `test/stripInternalMembers.test.ts` re-runs the pass over `dist/*.d.ts` and asserts there's nothing left to strip, which catches a pkg-utils upgrade that stops routing plugins at declaration output. It needs a build, and it skips without one, so as things stand it only fires locally: `Build and lint` builds but never runs the suite, and `Test and report coverage` runs the suite without a build. Worth adding a step to `Build and lint` so it runs in CI too?
