### PR TITLE
feat: add client.context with knowledge bases, builds, triage, telemetry, and GROQ reads

### DIFF
--- a/.changeset/pr-1276.md
+++ b/.changeset/pr-1276.md
@@ -3,4 +3,4 @@
 '@sanity/client': minor
 ---
 
-feat: add client.context namespace for knowledge bases
+feat: client.context — knowledge bases, builds, triage, telemetry, and GROQ reads

--- a/.changeset/pr-1276.md
+++ b/.changeset/pr-1276.md
@@ -3,4 +3,4 @@
 '@sanity/client': minor
 ---
 
-feat: client.context — knowledge bases, builds, triage, telemetry, and GROQ reads
+feat: add client.context with knowledge bases, builds, triage, telemetry, and GROQ reads

--- a/.changeset/pr-1276.md
+++ b/.changeset/pr-1276.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': minor
+---
+
+feat: add client.context namespace for knowledge bases

--- a/.changeset/pr-1276.md
+++ b/.changeset/pr-1276.md
@@ -1,10 +1,6 @@
 <!-- auto-generated -->
-
 ---
-
 '@sanity/client': minor
 ---
 
 feat: add client.context namespace for knowledge bases
-
-Knowledge-base management (`knowledgeBases.create/list/get/edit/delete`), imports (including staged file uploads), sources (`sources.list/get/content/delete`), builds (`build`, `cancelBuild`, `refresh`, `entries.rebuild`, `jobs.get`), issue triage writes (`issues.resolve/dismiss/reopen/apply`), instruction writes (`instructions.create/edit/delete`), and conversation telemetry (`conversations.save/classify`). Reads go through the organization's document store with GROQ: `context.fetch`/`context.listen` for arbitrary queries, plus canned read helpers (`entries.get/list`, `issues.get/list`, `instructions.list`, `mcpEndpoints.get/list`, `conversations.get`) typed from the published document schemas under the `Context` namespace.

--- a/.changeset/pr-1276.md
+++ b/.changeset/pr-1276.md
@@ -1,6 +1,10 @@
 <!-- auto-generated -->
+
 ---
+
 '@sanity/client': minor
 ---
 
 feat: add client.context namespace for knowledge bases
+
+Knowledge-base management (`knowledgeBases.create/list/get/edit/delete`), imports (including staged file uploads), sources (`sources.list/get/content/delete`), builds (`build`, `cancelBuild`, `refresh`, `entries.rebuild`, `jobs.get`), issue triage writes (`issues.resolve/dismiss/reopen/apply`), instruction writes (`instructions.create/edit/delete`), and conversation telemetry (`conversations.save/classify`). Reads go through the organization's document store with GROQ: `context.fetch`/`context.listen` for arbitrary queries, plus canned read helpers (`entries.get/list`, `issues.get/list`, `instructions.list`, `mcpEndpoints.get/list`, `conversations.get`) typed from the published document schemas under the `Context` namespace.

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -8,6 +8,7 @@ import {
   ObservableCollaborationCommentsClient,
 } from './collaboration/CollaborationCommentsClient'
 import {defaultConfig, initConfig} from './config'
+import {ContextClient, ObservableContextClient} from './context/ContextClient'
 import * as dataMethods from './data/dataMethods'
 import {_listen} from './data/listen'
 import {LiveClient} from './data/live'
@@ -94,6 +95,8 @@ export class ObservableSanityClient {
   }
   functions: ObservableFunctionsClient
   releases: ObservableReleasesClient
+  /** @beta */
+  context: ObservableContextClient
 
   /**
    * Private properties
@@ -127,6 +130,7 @@ export class ObservableSanityClient {
     }
     this.functions = new ObservableFunctionsClient(this, this.#httpRequest)
     this.releases = new ObservableReleasesClient(this, this.#httpRequest)
+    this.context = new ObservableContextClient(this, this.#httpRequest)
   }
 
   /**
@@ -1167,6 +1171,8 @@ export class SanityClient {
   }
   functions: FunctionsClient
   releases: ReleasesClient
+  /** @beta */
+  context: ContextClient
 
   /**
    * Observable version of the Sanity client, with the same configuration as the promise-based one
@@ -1205,6 +1211,7 @@ export class SanityClient {
     }
     this.functions = new FunctionsClient(this, this.#httpRequest)
     this.releases = new ReleasesClient(this, this.#httpRequest)
+    this.context = new ContextClient(this, this.#httpRequest)
 
     this.observable = new ObservableSanityClient(httpRequest, config)
   }

--- a/src/assets/AssetsClient.ts
+++ b/src/assets/AssetsClient.ts
@@ -303,6 +303,11 @@ function buildAssetUploadUrl(config: InitializedClientConfig, assetType: 'image'
       case 'canvas': {
         return `/canvases/${id}/assets/${assetTypeEndpoint}`
       }
+      case 'knowledge-base': {
+        throw new Error(
+          'Assets are not supported for knowledge-base resources. Use `client.context.imports` to add content instead.',
+        )
+      }
       case 'media-library': {
         return `/media-libraries/${id}/upload`
       }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -32,7 +32,6 @@ import type {
   CreateImportParams,
   CreateInstructionParams,
   CreateKnowledgeBaseParams,
-  DeleteSourceResponse,
   DismissIssueResponse,
   EditCrawlOptionsParams,
   EditInstructionParams,
@@ -422,11 +421,12 @@ export class KnowledgeBaseHandle {
         }),
         ...options,
       }),
-    delete: (params: {sourceId: string}, options?: RequestOptions) =>
-      this.#request<DeleteSourceResponse>(`/sources/${params.sourceId}`, {
+    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/sources/${params.sourceId}`, {
         method: 'DELETE',
         ...options,
-      }),
+      })
+    },
   }
 
   /** The audit feed: who did what, when. */

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -49,7 +49,30 @@ import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types
 
 type ListOptions = RequestOptions & {cursor?: string; limit?: number}
 
+type Client = SanityClient | ObservableSanityClient
+
 const COLLECTION_URL = '/context/knowledge-bases'
+
+/**
+ * The knowledge base every scoped method operates on comes from the client's
+ * `resource` configuration, matching how media libraries and canvases are
+ * addressed. Resolved per call so `withConfig` clones behave.
+ */
+function _resolveKnowledgeBaseId(client: Client): string {
+  const resource = client.config().resource
+
+  if (resource?.type !== 'knowledge-base') {
+    throw new Error(
+      '`resource` of type `knowledge-base` must be configured to use knowledge-base methods',
+    )
+  }
+
+  return resource.id
+}
+
+function _knowledgeBaseUrl(knowledgeBaseId: string, suffix = ''): string {
+  return `${COLLECTION_URL}/${encodeURIComponent(knowledgeBaseId)}${suffix}`
+}
 
 /** Serialize defined values into query params, dropping the undefined ones. */
 function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
@@ -68,27 +91,43 @@ function _fetchBody(file: CreateFileImportParams['file']) {
 }
 
 /**
- * Everything scoped to one knowledge base, addressed by its id alone.
- * Construct via {@link ContextClient.knowledgeBase}.
+ * `client.context` — knowledge bases and everything scoped to them.
+ *
+ * Collection-level management (create, list, get, edit, delete) addresses
+ * knowledge bases per call, like `client.projects`. Everything scoped to one
+ * knowledge base (imports, builds, issues, entries, ...) operates on the
+ * client's configured `resource`, like media libraries:
+ *
+ * @example Full lifecycle
+ * ```ts
+ * const created = await client.context.knowledgeBases.create({
+ *   organizationId: 'org123',
+ *   title: 'Support docs',
+ *   description: 'Product docs and troubleshooting guides',
+ * })
+ *
+ * const kb = createClient({
+ *   apiVersion: '2026-08-25',
+ *   token,
+ *   resource: {type: 'knowledge-base', id: created.publicId},
+ * })
+ *
+ * await kb.context.imports.create({type: 'text', title: 'Refund policy', content: refundMd})
+ * const {jobId} = await kb.context.build()
+ * ```
  *
  * @beta
  */
-export class KnowledgeBaseHandle {
+export class ContextClient {
   #client: SanityClient
   #httpRequest: HttpRequest
-  #knowledgeBaseId: string
 
-  constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
+  constructor(client: SanityClient, httpRequest: HttpRequest) {
     this.#client = client
     this.#httpRequest = httpRequest
-    this.#knowledgeBaseId = knowledgeBaseId
   }
 
-  /** The knowledge base id this handle was constructed with. */
-  get knowledgeBaseId(): string {
-    return this.#knowledgeBaseId
-  }
-
+  /** Request against the configured knowledge base. */
   #request<R>(
     suffix: string,
     reqOptions: {
@@ -98,12 +137,12 @@ export class KnowledgeBaseHandle {
     } & RequestOptions = {},
   ): Promise<R> {
     return _request<R>(this.#client, this.#httpRequest, {
-      url: `${COLLECTION_URL}/${this.#knowledgeBaseId}${suffix}`,
+      url: _knowledgeBaseUrl(_resolveKnowledgeBaseId(this.#client), suffix),
       ...reqOptions,
     })
   }
 
-  /** Shared shape of every paginated list endpoint under the handle. */
+  /** Shared shape of every paginated list endpoint scoped to the knowledge base. */
   #list<R>(
     suffix: string,
     params?: ListOptions,
@@ -155,25 +194,60 @@ export class KnowledgeBaseHandle {
     })
   }
 
-  /** Fetch the knowledge base. */
-  get(options?: RequestOptions): Promise<KnowledgeBase> {
-    return this.#request('', options)
-  }
-
-  /** Edit the knowledge base's configuration. */
-  edit(params: EditKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> {
-    return this.#request('', {method: 'PATCH', body: params, ...options})
-  }
-
-  /** Delete the knowledge base and its generated content. */
-  async delete(options?: RequestOptions): Promise<void> {
-    await this.#request('', {method: 'DELETE', ...options})
+  /** The knowledge base collection: management addressed per call. */
+  knowledgeBases = {
+    /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
+    create: (params: CreateKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> =>
+      _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+        url: COLLECTION_URL,
+        method: 'POST',
+        body: params,
+        ...options,
+      }),
+    /** List the organization's knowledge bases. */
+    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
+      _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
+        url: COLLECTION_URL,
+        query: _query({
+          organizationId: params.organizationId,
+          cursor: params.cursor,
+          limit: params.limit,
+        }),
+        signal: params.signal,
+        tag: params.tag,
+      }),
+    /** Fetch a knowledge base by its id. */
+    get: (knowledgeBaseId: string, options?: RequestOptions): Promise<KnowledgeBase> =>
+      _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+        url: _knowledgeBaseUrl(knowledgeBaseId),
+        ...options,
+      }),
+    /** Edit a knowledge base's configuration. */
+    edit: (
+      knowledgeBaseId: string,
+      params: EditKnowledgeBaseParams,
+      options?: RequestOptions,
+    ): Promise<KnowledgeBase> =>
+      _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+        url: _knowledgeBaseUrl(knowledgeBaseId),
+        method: 'PATCH',
+        body: params,
+        ...options,
+      }),
+    /** Delete a knowledge base and its generated content. */
+    delete: async (knowledgeBaseId: string, options?: RequestOptions): Promise<void> => {
+      await _request<void>(this.#client, this.#httpRequest, {
+        url: _knowledgeBaseUrl(knowledgeBaseId),
+        method: 'DELETE',
+        ...options,
+      })
+    },
   }
 
   /**
-   * Build the knowledge base. The server waits for pending import processing
-   * before assembling, so importing and building back to back is safe. Track
-   * the returned job with {@link jobs}.
+   * Build the configured knowledge base. The server waits for pending import
+   * processing before assembling, so importing and building back to back is
+   * safe. Track the returned job with {@link jobs}.
    */
   build(options?: RequestOptions): Promise<JobAccepted> {
     return this.#request('/build', {method: 'POST', ...options})
@@ -209,7 +283,7 @@ export class KnowledgeBaseHandle {
     return this.#request('/changes', options)
   }
 
-  /** Imports: feed content into the knowledge base. */
+  /** Imports: feed content into the configured knowledge base. */
   imports = {
     /**
      * Import content. One entry point, discriminated on `type`: inline
@@ -397,7 +471,7 @@ export class KnowledgeBaseHandle {
       this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
   }
 
-  /** Crawl options for the knowledge base's web source. */
+  /** Crawl options for the configured knowledge base's web source. */
   crawlOptions = {
     edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
       this.#request<CrawlOptions>('/crawl-options', {
@@ -409,68 +483,9 @@ export class KnowledgeBaseHandle {
 }
 
 /**
- * `client.context` — knowledge bases and everything scoped to them.
- *
- * @example Zero to knowledge base
- * ```ts
- * const created = await client.context.knowledgeBases.create({
- *   organizationId: 'org123',
- *   title: 'Support docs',
- *   description: 'Product docs and troubleshooting guides',
- * })
- * const kb = client.context.knowledgeBase(created.publicId)
- * await kb.imports.create({type: 'text', title: 'Refund policy', content: refundMd})
- * const {jobId} = await kb.build()
- * ```
- *
- * @beta
- */
-export class ContextClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
-
-  constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
-  }
-
-  /** The knowledge base collection. */
-  knowledgeBases = {
-    /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
-    create: (params: CreateKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> =>
-      _request<KnowledgeBase>(this.#client, this.#httpRequest, {
-        url: COLLECTION_URL,
-        method: 'POST',
-        body: params,
-        ...options,
-      }),
-    /** List the organization's knowledge bases. */
-    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
-      _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
-        url: COLLECTION_URL,
-        query: _query({
-          organizationId: params.organizationId,
-          cursor: params.cursor,
-          limit: params.limit,
-        }),
-        signal: params.signal,
-        tag: params.tag,
-      }),
-  }
-
-  /**
-   * A handle carrying everything scoped to one knowledge base, addressed by
-   * its id.
-   */
-  knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
-    return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
-  }
-}
-
-/**
  * Observable counterpart of {@link ContextClient}. Collection-level methods
- * only; the per-knowledge-base handle is promise-based, so use the promise
- * client (`client.context.knowledgeBase(id)`) for handle operations.
+ * only; knowledge-base scoped operations are promise-based, so use the
+ * promise client (`client.context`) for those.
  *
  * @beta
  */
@@ -483,7 +498,7 @@ export class ObservableContextClient {
     this.#httpRequest = httpRequest
   }
 
-  /** The knowledge base collection. */
+  /** The knowledge base collection: management addressed per call. */
   knowledgeBases = {
     /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
     create: (
@@ -510,6 +525,40 @@ export class ObservableContextClient {
             limit: params.limit,
           }),
           tag: params.tag,
+          signal,
+        }),
+      ),
+    /** Fetch a knowledge base by its id. */
+    get: (knowledgeBaseId: string, options?: RequestOptions): Observable<KnowledgeBase> =>
+      _observe(options?.signal, (signal) =>
+        _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+          url: _knowledgeBaseUrl(knowledgeBaseId),
+          tag: options?.tag,
+          signal,
+        }),
+      ),
+    /** Edit a knowledge base's configuration. */
+    edit: (
+      knowledgeBaseId: string,
+      params: EditKnowledgeBaseParams,
+      options?: RequestOptions,
+    ): Observable<KnowledgeBase> =>
+      _observe(options?.signal, (signal) =>
+        _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+          url: _knowledgeBaseUrl(knowledgeBaseId),
+          method: 'PATCH',
+          body: params,
+          tag: options?.tag,
+          signal,
+        }),
+      ),
+    /** Delete a knowledge base and its generated content. */
+    delete: (knowledgeBaseId: string, options?: RequestOptions): Observable<void> =>
+      _observe(options?.signal, (signal) =>
+        _request<void>(this.#client, this.#httpRequest, {
+          url: _knowledgeBaseUrl(knowledgeBaseId),
+          method: 'DELETE',
+          tag: options?.tag,
           signal,
         }),
       ),

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -48,11 +48,14 @@ import type {
   StagedUpload,
 } from './types'
 import type {
+  ClassifyConversationParams,
   ContextListenOptions,
   ContextRequestOptions,
+  Conversation,
   CreateFileImportParams,
   RenderFormat,
   RequestOptions,
+  SaveConversationParams,
 } from './types'
 
 type ListOptions = RequestOptions & {cursor?: string; limit?: number}
@@ -83,6 +86,20 @@ function _knowledgeBaseUrl(knowledgeBaseId: string, suffix = ''): string {
 }
 
 /** Serialize defined values into query params, dropping the undefined ones. */
+function _conversationUrl(client: Client, threadId: string): string {
+  const organizationId = client.config().context?.organizationId
+
+  if (!organizationId) {
+    throw new Error('`context.organizationId` must be configured to record conversations')
+  }
+
+  if (!threadId) {
+    throw new Error('`threadId` must be provided')
+  }
+
+  return `/context/organizations/${encodeURIComponent(organizationId)}/conversations/${encodeURIComponent(threadId)}`
+}
+
 function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(entries).flatMap(([key, value]) =>
@@ -281,6 +298,51 @@ export class ContextClient {
     options?: Opts,
   ): Observable<ListenEventFromOptions<SanityDocument, Opts>> {
     return _listenStore(this.#client, query, params, options)
+  }
+
+  /**
+   * Conversation telemetry: the API-owned writes. `threadId` identifies the
+   * conversation within the organization — reuse means the same
+   * conversation. Reads go through {@link fetch} and {@link listen} with
+   * GROQ (`_type == "sanity.context.conversation"`).
+   *
+   * Requires `context.organizationId` in the client configuration.
+   */
+  conversations = {
+    /**
+     * Record a conversation. Messages replace the stored transcript
+     * wholesale; `metadata` and model fields only overwrite when present.
+     * Last write per thread wins — retries are safe.
+     */
+    save: (
+      params: {threadId: string} & SaveConversationParams,
+      options?: RequestOptions,
+    ): Promise<Conversation> => {
+      const {threadId, ...body} = params
+      return _request<Conversation>(this.#client, this.#httpRequest, {
+        url: _conversationUrl(this.#client, threadId),
+        method: 'PUT',
+        body,
+        ...options,
+      })
+    },
+    /**
+     * Record the classification your own model produced for one thread:
+     * exactly one of `coreMetrics` (a verdict) or `classificationError`
+     * (why classification failed).
+     */
+    classify: (
+      params: {threadId: string} & ClassifyConversationParams,
+      options?: RequestOptions,
+    ): Promise<Conversation> => {
+      const {threadId, ...body} = params
+      return _request<Conversation>(this.#client, this.#httpRequest, {
+        url: _conversationUrl(this.#client, threadId),
+        method: 'PATCH',
+        body,
+        ...options,
+      })
+    },
   }
 
   /**
@@ -641,5 +703,56 @@ export class ObservableContextClient {
     options?: Opts,
   ): Observable<ListenEventFromOptions<SanityDocument, Opts>> {
     return _listenStore(this.#client, query, params, options)
+  }
+
+  /**
+   * Conversation telemetry: the API-owned writes. `threadId` identifies the
+   * conversation within the organization — reuse means the same
+   * conversation. Reads go through {@link fetch} and {@link listen} with
+   * GROQ (`_type == "sanity.context.conversation"`).
+   *
+   * Requires `context.organizationId` in the client configuration.
+   */
+  conversations = {
+    /**
+     * Record a conversation. Messages replace the stored transcript
+     * wholesale; `metadata` and model fields only overwrite when present.
+     * Last write per thread wins — retries are safe.
+     */
+    save: (
+      params: {threadId: string} & SaveConversationParams,
+      options?: RequestOptions,
+    ): Observable<Conversation> => {
+      const {threadId, ...body} = params
+      return _observe(options?.signal, (signal) =>
+        _request<Conversation>(this.#client, this.#httpRequest, {
+          url: _conversationUrl(this.#client, threadId),
+          method: 'PUT',
+          body,
+          tag: options?.tag,
+          signal,
+        }),
+      )
+    },
+    /**
+     * Record the classification your own model produced for one thread:
+     * exactly one of `coreMetrics` (a verdict) or `classificationError`
+     * (why classification failed).
+     */
+    classify: (
+      params: {threadId: string} & ClassifyConversationParams,
+      options?: RequestOptions,
+    ): Observable<Conversation> => {
+      const {threadId, ...body} = params
+      return _observe(options?.signal, (signal) =>
+        _request<Conversation>(this.#client, this.#httpRequest, {
+          url: _conversationUrl(this.#client, threadId),
+          method: 'PATCH',
+          body,
+          tag: options?.tag,
+          signal,
+        }),
+      )
+    },
   }
 }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -203,8 +203,17 @@ export class KnowledgeBaseHandle {
   }
 
   /** Fetch the knowledge base. */
-  get(options?: RequestOptions): Promise<KnowledgeBase> {
-    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
+  async get(options?: RequestOptions): Promise<KnowledgeBase> {
+    const kb = await _getKnowledgeBaseById(
+      this.#client,
+      this.#httpRequest,
+      this.#knowledgeBaseId,
+      options,
+    )
+    // Seed the address cache: a follow-up scoped call should not pay for a
+    // second by-id resolve when this fetch already carries org and slug.
+    this.#address ??= Promise.resolve({organizationId: kb.organizationId, slug: kb.slug})
+    return kb
   }
 
   /** Edit the knowledge base's configuration. */
@@ -232,7 +241,7 @@ export class KnowledgeBaseHandle {
   }
 
   /** Run an incremental refresh: re-check sources and apply what changed. */
-  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
+  refresh(options?: RequestOptions): Promise<{jobId: string; started: boolean}> {
     return this.#request('/refresh', {method: 'POST', ...options})
   }
 

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,11 +1,11 @@
-import {type FetchFunction} from 'get-it'
+import { type FetchFunction } from "get-it";
 
-type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
-import {type Observable} from 'rxjs'
+type FetchBody = NonNullable<Parameters<FetchFunction>[1]>["body"];
+import { type Observable } from "rxjs";
 
-import {_observe, _request} from '../data/dataMethods'
-import type {ObservableSanityClient, SanityClient} from '../SanityClient'
-import type {HttpRequest} from '../types'
+import { _observe, _request } from "../data/dataMethods";
+import type { ObservableSanityClient, SanityClient } from "../SanityClient";
+import type { HttpRequest } from "../types";
 import type {
   ApplyIssuesParams,
   ApplyIssuesResponse,
@@ -46,12 +46,16 @@ import type {
   ResolveIssueResponse,
   SourceContentResponse,
   StagedUpload,
-} from './types'
-import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types'
+} from "./types";
+import type {
+  CreateFileImportParams,
+  RenderFormat,
+  RequestOptions,
+} from "./types";
 
-type ListOptions = RequestOptions & {cursor?: string; limit?: number}
+type ListOptions = RequestOptions & { cursor?: string; limit?: number };
 
-type Client = SanityClient | ObservableSanityClient
+type Client = SanityClient | ObservableSanityClient;
 
 /**
  * The knowledge base's org-scoped address. Every operation except the by-id
@@ -59,7 +63,7 @@ type Client = SanityClient | ObservableSanityClient
  * handle is constructed from the id alone, so the address is resolved once
  * through the by-id endpoint and reused.
  */
-type ResolvedAddress = {organizationId: string; slug: string}
+type ResolvedAddress = { organizationId: string; slug: string };
 
 function _getKnowledgeBaseById(
   client: Client,
@@ -70,20 +74,22 @@ function _getKnowledgeBaseById(
   return _request<KnowledgeBase>(client, httpRequest, {
     url: `/context/knowledge-bases/${knowledgeBaseId}`,
     ...options,
-  })
+  });
 }
 
 function _collectionUrl(organizationId: string): string {
-  return `/context/organizations/${organizationId}/knowledge-bases`
+  return `/context/organizations/${organizationId}/knowledge-bases`;
 }
 
 /** Serialize defined values into query params, dropping the undefined ones. */
-function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
+function _query(
+  entries: Record<string, string | number | undefined>,
+): Record<string, string> {
   return Object.fromEntries(
     Object.entries(entries).flatMap(([key, value]) =>
       value === undefined ? [] : [[key, `${value}`]],
     ),
-  )
+  );
 }
 
 /**
@@ -93,20 +99,24 @@ function _query(entries: Record<string, string | number | undefined>): Record<st
  * @beta
  */
 export class KnowledgeBaseHandle {
-  #client: SanityClient
-  #httpRequest: HttpRequest
-  #knowledgeBaseId: string
-  #address: Promise<ResolvedAddress> | undefined
+  #client: SanityClient;
+  #httpRequest: HttpRequest;
+  #knowledgeBaseId: string;
+  #address: Promise<ResolvedAddress> | undefined;
 
-  constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
-    this.#client = client
-    this.#httpRequest = httpRequest
-    this.#knowledgeBaseId = knowledgeBaseId
+  constructor(
+    client: SanityClient,
+    httpRequest: HttpRequest,
+    knowledgeBaseId: string,
+  ) {
+    this.#client = client;
+    this.#httpRequest = httpRequest;
+    this.#knowledgeBaseId = knowledgeBaseId;
   }
 
   /** The knowledge base id this handle was constructed with. */
   get knowledgeBaseId(): string {
-    return this.#knowledgeBaseId
+    return this.#knowledgeBaseId;
   }
 
   // The resolution is shared by every method on the handle, so it must not
@@ -120,29 +130,29 @@ export class KnowledgeBaseHandle {
       this.#httpRequest,
       this.#knowledgeBaseId,
     ).then(
-      (kb) => ({organizationId: kb.organizationId, slug: kb.slug}),
+      (kb) => ({ organizationId: kb.organizationId, slug: kb.slug }),
       (err) => {
         // A failed resolution must not poison the handle for retries.
-        this.#address = undefined
-        throw err
+        this.#address = undefined;
+        throw err;
       },
-    )
-    return this.#address
+    );
+    return this.#address;
   }
 
   async #request<R>(
     suffix: string,
     reqOptions: {
-      method?: string
-      body?: unknown
-      query?: Record<string, string>
+      method?: string;
+      body?: unknown;
+      query?: Record<string, string>;
     } & RequestOptions = {},
   ): Promise<R> {
-    const address = await this.#resolveAddress()
+    const address = await this.#resolveAddress();
     return _request<R>(this.#client, this.#httpRequest, {
       url: `${_collectionUrl(address.organizationId)}/${address.slug}${suffix}`,
       ...reqOptions,
-    })
+    });
   }
 
   /** Shared shape of every paginated list endpoint under the handle. */
@@ -159,59 +169,73 @@ export class KnowledgeBaseHandle {
       }),
       signal: params?.signal,
       tag: params?.tag,
-    })
+    });
   }
 
   async #uploadFile(
     params: CreateFileImportParams,
     options?: RequestOptions,
   ): Promise<JobAccepted> {
-    const staged = await this.#request<StagedUpload>('/imports/uploads', {
-      method: 'POST',
+    const staged = await this.#request<StagedUpload>("/imports/uploads", {
+      method: "POST",
       body: {
         filename: params.filename,
-        ...(params.contentType && {contentType: params.contentType}),
+        ...(params.contentType && { contentType: params.contentType }),
       },
       ...options,
-    })
+    });
     // The signed URL PUT goes straight to storage, outside the API pipeline:
     // no auth header, and the body is raw bytes rather than JSON. Still uses
     // the client's fetch resolution so proxy config applies in Node.
-    const config = this.#client.config()
-    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
+    const config = this.#client.config();
+    const doFetch =
+      config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction);
     const putResponse = await doFetch(staged.uploadUrl, {
-      method: 'PUT',
+      method: "PUT",
       // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
       // bound, even though fetch accepts it at runtime.
       body: params.file as FetchBody,
       ...(params.contentType && {
-        headers: {'content-type': params.contentType},
+        headers: { "content-type": params.contentType },
       }),
       signal: options?.signal,
-    })
+    });
     if (!putResponse.ok) {
-      throw new Error(`File upload failed: ${putResponse.status} ${putResponse.statusText}`)
+      throw new Error(
+        `File upload failed: ${putResponse.status} ${putResponse.statusText}`,
+      );
     }
-    return this.#request<JobAccepted>(`/imports/uploads/${staged.importId}/complete`, {
-      method: 'POST',
-      body: {},
-      ...options,
-    })
+    return this.#request<JobAccepted>(
+      `/imports/uploads/${staged.importId}/complete`,
+      {
+        method: "POST",
+        body: {},
+        ...options,
+      },
+    );
   }
 
   /** Fetch the knowledge base. */
   get(options?: RequestOptions): Promise<KnowledgeBase> {
-    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
+    return _getKnowledgeBaseById(
+      this.#client,
+      this.#httpRequest,
+      this.#knowledgeBaseId,
+      options,
+    );
   }
 
   /** Edit the knowledge base's configuration. */
-  edit(params: EditKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> {
-    return this.#request('', {method: 'PATCH', body: params, ...options})
+  edit(
+    params: EditKnowledgeBaseParams,
+    options?: RequestOptions,
+  ): Promise<KnowledgeBase> {
+    return this.#request("", { method: "PATCH", body: params, ...options });
   }
 
   /** Delete the knowledge base and its generated content. */
   async delete(options?: RequestOptions): Promise<void> {
-    await this.#request('', {method: 'DELETE', ...options})
+    await this.#request("", { method: "DELETE", ...options });
   }
 
   /**
@@ -220,17 +244,19 @@ export class KnowledgeBaseHandle {
    * the returned job with {@link jobs}.
    */
   build(options?: RequestOptions): Promise<JobAccepted> {
-    return this.#request('/build', {method: 'POST', ...options})
+    return this.#request("/build", { method: "POST", ...options });
   }
 
   /** Cancel the running build, if any. */
-  cancelBuild(options?: RequestOptions): Promise<{cancelled: boolean}> {
-    return this.#request('/build/cancel', {method: 'POST', ...options})
+  cancelBuild(options?: RequestOptions): Promise<{ cancelled: boolean }> {
+    return this.#request("/build/cancel", { method: "POST", ...options });
   }
 
   /** Run an incremental refresh: re-check sources and apply what changed. */
-  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
-    return this.#request('/refresh', {method: 'POST', ...options})
+  refresh(
+    options?: RequestOptions,
+  ): Promise<{ jobId: string | null; started: boolean }> {
+    return this.#request("/refresh", { method: "POST", ...options });
   }
 
   /**
@@ -238,19 +264,19 @@ export class KnowledgeBaseHandle {
    * `json` format resolves to {@link Outline}; `markdown` and
    * `plain` resolve to a string.
    */
-  outline<const F extends RenderFormat = 'json'>(
-    params?: {format?: F},
+  outline<const F extends RenderFormat = "json">(
+    params?: { format?: F },
     options?: RequestOptions,
-  ): Promise<F extends 'json' ? Outline : string> {
-    return this.#request('/outline', {
-      query: params?.format ? {format: params.format} : {},
+  ): Promise<F extends "json" ? Outline : string> {
+    return this.#request("/outline", {
+      query: params?.format ? { format: params.format } : {},
       ...options,
-    })
+    });
   }
 
   /** What changed in the corpus since the last build. */
   changes(options?: RequestOptions): Promise<Changes> {
-    return this.#request('/changes', options)
+    return this.#request("/changes", options);
   }
 
   /** Imports: feed content into the knowledge base. */
@@ -266,114 +292,130 @@ export class KnowledgeBaseHandle {
       params: CreateImportParams | CreateFileImportParams,
       options?: RequestOptions,
     ): Promise<JobAccepted> =>
-      params.type === 'file'
+      params.type === "file"
         ? this.#uploadFile(params, options)
-        : this.#request('/imports', {
-            method: 'POST',
+        : this.#request("/imports", {
+            method: "POST",
             body: params,
             ...options,
           }),
-    list: (params?: ListOptions) => this.#list<ImportsResponse>('/imports', params),
-    get: (params: {importId: string}, options?: RequestOptions) =>
+    list: (params?: ListOptions) =>
+      this.#list<ImportsResponse>("/imports", params),
+    get: (params: { importId: string }, options?: RequestOptions) =>
       this.#request<ImportDetail>(`/imports/${params.importId}`, options),
     /** A short-lived signed URL for the original uploaded bytes. */
-    download: (params: {importId: string}, options?: RequestOptions) =>
-      this.#request<ImportDownloadResponse>(`/imports/${params.importId}/download`, options),
-    delete: async (params: {importId: string}, options?: RequestOptions) => {
+    download: (params: { importId: string }, options?: RequestOptions) =>
+      this.#request<ImportDownloadResponse>(
+        `/imports/${params.importId}/download`,
+        options,
+      ),
+    delete: async (params: { importId: string }, options?: RequestOptions) => {
       await this.#request<void>(`/imports/${params.importId}`, {
-        method: 'DELETE',
+        method: "DELETE",
         ...options,
-      })
+      });
     },
     /** Preview which pages a crawl would ingest, before committing to it. */
     crawlPreview: (params: CrawlPreviewParams, options?: RequestOptions) =>
-      this.#request<CrawlPreviewResponse>('/imports/crawl-preview', {
-        method: 'POST',
+      this.#request<CrawlPreviewResponse>("/imports/crawl-preview", {
+        method: "POST",
         body: params,
         ...options,
       }),
-  }
+  };
 
   /** Jobs: poll async work (builds, imports) to a terminal state. */
   jobs = {
-    get: (params: {jobId: string}, options?: RequestOptions) =>
+    get: (params: { jobId: string }, options?: RequestOptions) =>
       this.#request<Job>(`/jobs/${params.jobId}`, options),
-  }
+  };
 
   /** Issues: findings from builds awaiting triage. */
   issues = {
-    list: (params?: {status?: 'open' | 'accepted' | 'rejected'} & ListOptions) =>
-      this.#list<IssuesResponse>('/issues', params, {
+    list: (
+      params?: { status?: "open" | "accepted" | "rejected" } & ListOptions,
+    ) =>
+      this.#list<IssuesResponse>("/issues", params, {
         status: params?.status,
       }),
-    get: (params: {issueId: string}, options?: RequestOptions) =>
+    get: (params: { issueId: string }, options?: RequestOptions) =>
       this.#request<IssueDetail>(`/issues/${params.issueId}`, options),
     /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
-    resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
-      const {issueId, ...body} = params
+    resolve: (
+      params: { issueId: string } & ResolveIssueParams,
+      options?: RequestOptions,
+    ) => {
+      const { issueId, ...body } = params;
       return this.#request<ResolveIssueResponse>(`/issues/${issueId}/resolve`, {
-        method: 'POST',
+        method: "POST",
         body,
         ...options,
-      })
+      });
     },
-    dismiss: (params: {issueId: string}, options?: RequestOptions) =>
+    dismiss: (params: { issueId: string }, options?: RequestOptions) =>
       this.#request<DismissIssueResponse>(`/issues/${params.issueId}/dismiss`, {
-        method: 'POST',
+        method: "POST",
         ...options,
       }),
-    reopen: (params: {issueId: string}, options?: RequestOptions) =>
+    reopen: (params: { issueId: string }, options?: RequestOptions) =>
       this.#request<ReopenIssueResponse>(`/issues/${params.issueId}/reopen`, {
-        method: 'POST',
+        method: "POST",
         ...options,
       }),
     /** Apply already-accepted issues to the knowledge base in one batch. */
     apply: (params: ApplyIssuesParams, options?: RequestOptions) =>
-      this.#request<ApplyIssuesResponse>('/issues/apply', {
-        method: 'POST',
+      this.#request<ApplyIssuesResponse>("/issues/apply", {
+        method: "POST",
         body: params,
         ...options,
       }),
-  }
+  };
 
   /** Instructions: standing decisions that steer every build. */
   instructions = {
     create: (params: CreateInstructionParams, options?: RequestOptions) =>
-      this.#request<Instruction>('/instructions', {
-        method: 'POST',
+      this.#request<Instruction>("/instructions", {
+        method: "POST",
         body: params,
         ...options,
       }),
-    list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
-    edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
-      const {instructionId, ...body} = params
+    list: (params?: ListOptions) =>
+      this.#list<InstructionsResponse>("/instructions", params),
+    edit: (
+      params: { instructionId: string } & EditInstructionParams,
+      options?: RequestOptions,
+    ) => {
+      const { instructionId, ...body } = params;
       return this.#request<Instruction>(`/instructions/${instructionId}`, {
-        method: 'PATCH',
+        method: "PATCH",
         body,
         ...options,
-      })
+      });
     },
-    delete: async (params: {instructionId: string}, options?: RequestOptions) => {
+    delete: async (
+      params: { instructionId: string },
+      options?: RequestOptions,
+    ) => {
       await this.#request<void>(`/instructions/${params.instructionId}`, {
-        method: 'DELETE',
+        method: "DELETE",
         ...options,
-      })
+      });
     },
-  }
+  };
 
   /** Entries: the built outline, one entry per node. */
   entries = {
     /** List entries, optionally filtered by status or searched (`q`). */
     list: (
       params?: {
-        status?: EntryStatus
-        q?: string
-        mode?: 'keyword' | 'hybrid'
-        include?: 'metadata' | 'body'
-        paths?: string
+        status?: EntryStatus;
+        q?: string;
+        mode?: "keyword" | "hybrid";
+        include?: "metadata" | "body";
+        paths?: string;
       } & ListOptions,
     ) =>
-      this.#list<EntriesResponse>('/entries', params, {
+      this.#list<EntriesResponse>("/entries", params, {
         status: params?.status,
         q: params?.q,
         mode: params?.mode,
@@ -385,88 +427,83 @@ export class KnowledgeBaseHandle {
      * The default `json` format resolves to {@link EntryDetail};
      * `markdown` and `plain` resolve to a string.
      */
-    get: <const F extends RenderFormat = 'json'>(
-      params: {path: string; format?: F},
+    get: <const F extends RenderFormat = "json">(
+      params: { path: string; format?: F },
       options?: RequestOptions,
     ) =>
-      this.#request<F extends 'json' ? EntryDetail : string>(
+      this.#request<F extends "json" ? EntryDetail : string>(
         `/entries/${encodeURIComponent(params.path)}`,
         {
-          query: params.format ? {format: params.format} : {},
+          query: params.format ? { format: params.format } : {},
           ...options,
         },
       ),
-  }
+  };
 
   /** Sources: the distilled units builds cite. */
   sources = {
-    list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
-    get: (params: {sourceId: string}, options?: RequestOptions) =>
+    list: (params?: ListOptions) =>
+      this.#list<SourcesResponse>("/sources", params),
+    get: (params: { sourceId: string }, options?: RequestOptions) =>
       this.#request<SourceDetail>(`/sources/${params.sourceId}`, options),
     /**
      * Distilled source content, optionally a line range: the evidence behind
      * a citation or an issue.
      */
     content: (
-      params: {sourceId: string; startLine?: number; endLine?: number},
+      params: { sourceId: string; startLine?: number; endLine?: number },
       options?: RequestOptions,
     ) =>
-      this.#request<SourceContentResponse>(`/sources/${params.sourceId}/content`, {
-        query: _query({
-          startLine: params.startLine,
-          endLine: params.endLine,
-        }),
-        ...options,
-      }),
-    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      this.#request<SourceContentResponse>(
+        `/sources/${params.sourceId}/content`,
+        {
+          query: _query({
+            startLine: params.startLine,
+            endLine: params.endLine,
+          }),
+          ...options,
+        },
+      ),
+    delete: async (params: { sourceId: string }, options?: RequestOptions) => {
       await this.#request<void>(`/sources/${params.sourceId}`, {
-        method: 'DELETE',
+        method: "DELETE",
         ...options,
-      })
+      });
     },
-  }
+  };
 
   /** The audit feed: who did what, when. */
   activity = {
-    list: (params?: ListOptions) => this.#list<ActivityResponse>('/activity', params),
-  }
+    list: (params?: ListOptions) =>
+      this.#list<ActivityResponse>("/activity", params),
+  };
 
   /** Revisions: one per build, with an accounting report per revision. */
   revisions = {
-    list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
-    report: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionReport>(`/revisions/${params.revisionId}/report`, options),
+    list: (params?: ListOptions) =>
+      this.#list<RevisionsResponse>("/revisions", params),
+    report: (params: { revisionId: string }, options?: RequestOptions) =>
+      this.#request<RevisionReport>(
+        `/revisions/${params.revisionId}/report`,
+        options,
+      ),
     /** The outline as it was at a past build revision. */
-    outline: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
-  }
+    outline: (params: { revisionId: string }, options?: RequestOptions) =>
+      this.#request<RevisionOutline>(
+        `/revisions/${params.revisionId}/outline`,
+        options,
+      ),
+  };
 
   /** Crawl options for the knowledge base's web source. */
   crawlOptions = {
     edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
-      this.#request<CrawlOptions>('/crawl-options', {
-        method: 'PATCH',
+      this.#request<CrawlOptions>("/crawl-options", {
+        method: "PATCH",
         body: params,
         ...options,
       }),
-  }
-
-  /**
-   * An ordinary `@sanity/client` bound to the knowledge base's dataset, for
-   * GROQ reads, listeners, and anything else the platform ships for
-   * documents. Not a wrapper: the returned client is a plain client.
-   */
-  async contentClient(options?: RequestOptions): Promise<SanityClient> {
-    const kb = await this.get(options)
-    if (!kb.sanityProjectId || !kb.sanityDatasetId) {
-      throw new Error(`Knowledge base "${this.#knowledgeBaseId}" has no dataset binding`)
-    }
-    return this.#client.withConfig({
-      projectId: kb.sanityProjectId,
-      dataset: kb.sanityDatasetId,
-      useCdn: false,
-    })
-  }
+  };
 }
 
 /**
@@ -489,38 +526,40 @@ export class KnowledgeBaseHandle {
  * @beta
  */
 export class ContextClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  #client: SanityClient;
+  #httpRequest: HttpRequest;
 
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this.#client = client;
+    this.#httpRequest = httpRequest;
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & {organizationId: string},
+      params: CreateKnowledgeBaseParams & { organizationId: string },
       options?: RequestOptions,
     ): Promise<KnowledgeBase> => {
-      const {organizationId, ...body} = params
+      const { organizationId, ...body } = params;
       return _request<KnowledgeBase>(this.#client, this.#httpRequest, {
         url: _collectionUrl(organizationId),
-        method: 'POST',
+        method: "POST",
         body,
         ...options,
-      })
+      });
     },
     /** List the organization's knowledge bases. */
-    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
+    list: (
+      params: { organizationId: string } & ListOptions,
+    ): Promise<KnowledgeBasesResponse> =>
       _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
         url: _collectionUrl(params.organizationId),
-        query: _query({cursor: params.cursor, limit: params.limit}),
+        query: _query({ cursor: params.cursor, limit: params.limit }),
         signal: params.signal,
         tag: params.tag,
       }),
-  }
+  };
 
   /**
    * A handle carrying everything scoped to one knowledge base, addressed by
@@ -528,7 +567,11 @@ export class ContextClient {
    * the first request and is reused after that.
    */
   knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
-    return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
+    return new KnowledgeBaseHandle(
+      this.#client,
+      this.#httpRequest,
+      knowledgeBaseId,
+    );
   }
 }
 
@@ -540,41 +583,43 @@ export class ContextClient {
  * @beta
  */
 export class ObservableContextClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  #client: ObservableSanityClient;
+  #httpRequest: HttpRequest;
 
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this.#client = client;
+    this.#httpRequest = httpRequest;
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & {organizationId: string},
+      params: CreateKnowledgeBaseParams & { organizationId: string },
       options?: RequestOptions,
     ): Observable<KnowledgeBase> => {
-      const {organizationId, ...body} = params
+      const { organizationId, ...body } = params;
       return _observe(options?.signal, (signal) =>
         _request<KnowledgeBase>(this.#client, this.#httpRequest, {
           url: _collectionUrl(organizationId),
-          method: 'POST',
+          method: "POST",
           body,
           tag: options?.tag,
           signal,
         }),
-      )
+      );
     },
     /** List the organization's knowledge bases. */
-    list: (params: {organizationId: string} & ListOptions): Observable<KnowledgeBasesResponse> =>
+    list: (
+      params: { organizationId: string } & ListOptions,
+    ): Observable<KnowledgeBasesResponse> =>
       _observe(params.signal, (signal) =>
         _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
           url: _collectionUrl(params.organizationId),
-          query: _query({cursor: params.cursor, limit: params.limit}),
+          query: _query({ cursor: params.cursor, limit: params.limit }),
           tag: params.tag,
           signal,
         }),
       ),
-  }
+  };
 }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -32,6 +32,7 @@ import type {
   CreateImportParams,
   CreateInstructionParams,
   CreateKnowledgeBaseParams,
+  DeleteSourceResponse,
   DismissIssueResponse,
   EditCrawlOptionsParams,
   EditInstructionParams,
@@ -421,12 +422,11 @@ export class KnowledgeBaseHandle {
         }),
         ...options,
       }),
-    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
-      await this.#request<void>(`/sources/${params.sourceId}`, {
+    delete: (params: {sourceId: string}, options?: RequestOptions) =>
+      this.#request<DeleteSourceResponse>(`/sources/${params.sourceId}`, {
         method: 'DELETE',
         ...options,
-      })
-    },
+      }),
   }
 
   /** The audit feed: who did what, when. */

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -49,31 +49,7 @@ import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types
 
 type ListOptions = RequestOptions & {cursor?: string; limit?: number}
 
-type Client = SanityClient | ObservableSanityClient
-
-/**
- * The knowledge base's org-scoped address. Every operation except the by-id
- * read lives under `/organizations/{orgId}/knowledge-bases/{slug}`, but the
- * handle is constructed from the id alone, so the address is resolved once
- * through the by-id endpoint and reused.
- */
-type ResolvedAddress = {organizationId: string; slug: string}
-
-function _getKnowledgeBaseById(
-  client: Client,
-  httpRequest: HttpRequest,
-  knowledgeBaseId: string,
-  options?: RequestOptions,
-): Promise<KnowledgeBase> {
-  return _request<KnowledgeBase>(client, httpRequest, {
-    url: `/context/knowledge-bases/${knowledgeBaseId}`,
-    ...options,
-  })
-}
-
-function _collectionUrl(organizationId: string): string {
-  return `/context/organizations/${organizationId}/knowledge-bases`
-}
+const COLLECTION_URL = '/context/knowledge-bases'
 
 /** Serialize defined values into query params, dropping the undefined ones. */
 function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
@@ -101,7 +77,6 @@ export class KnowledgeBaseHandle {
   #client: SanityClient
   #httpRequest: HttpRequest
   #knowledgeBaseId: string
-  #address: Promise<ResolvedAddress> | undefined
 
   constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
     this.#client = client
@@ -114,28 +89,7 @@ export class KnowledgeBaseHandle {
     return this.#knowledgeBaseId
   }
 
-  // The resolution is shared by every method on the handle, so it must not
-  // carry any one caller's abort signal: aborting one request would reject
-  // the cached promise for every concurrent caller. An aborted caller still
-  // rejects, because its own follow-up request starts with the aborted
-  // signal.
-  #resolveAddress(): Promise<ResolvedAddress> {
-    this.#address ??= _getKnowledgeBaseById(
-      this.#client,
-      this.#httpRequest,
-      this.#knowledgeBaseId,
-    ).then(
-      (kb) => ({organizationId: kb.organizationId, slug: kb.slug}),
-      (err) => {
-        // A failed resolution must not poison the handle for retries.
-        this.#address = undefined
-        throw err
-      },
-    )
-    return this.#address
-  }
-
-  async #request<R>(
+  #request<R>(
     suffix: string,
     reqOptions: {
       method?: string
@@ -143,9 +97,8 @@ export class KnowledgeBaseHandle {
       query?: Record<string, string>
     } & RequestOptions = {},
   ): Promise<R> {
-    const address = await this.#resolveAddress()
     return _request<R>(this.#client, this.#httpRequest, {
-      url: `${_collectionUrl(address.organizationId)}/${address.slug}${suffix}`,
+      url: `${COLLECTION_URL}/${this.#knowledgeBaseId}${suffix}`,
       ...reqOptions,
     })
   }
@@ -203,17 +156,8 @@ export class KnowledgeBaseHandle {
   }
 
   /** Fetch the knowledge base. */
-  async get(options?: RequestOptions): Promise<KnowledgeBase> {
-    const kb = await _getKnowledgeBaseById(
-      this.#client,
-      this.#httpRequest,
-      this.#knowledgeBaseId,
-      options,
-    )
-    // Seed the address cache: a follow-up scoped call should not pay for a
-    // second by-id resolve when this fetch already carries org and slug.
-    this.#address ??= Promise.resolve({organizationId: kb.organizationId, slug: kb.slug})
-    return kb
+  get(options?: RequestOptions): Promise<KnowledgeBase> {
+    return this.#request('', options)
   }
 
   /** Edit the knowledge base's configuration. */
@@ -471,7 +415,7 @@ export class KnowledgeBaseHandle {
  * ```ts
  * const created = await client.context.knowledgeBases.create({
  *   organizationId: 'org123',
- *   name: 'Support docs',
+ *   title: 'Support docs',
  *   description: 'Product docs and troubleshooting guides',
  * })
  * const kb = client.context.knowledgeBase(created.publicId)
@@ -493,23 +437,22 @@ export class ContextClient {
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
-    create: (
-      params: CreateKnowledgeBaseParams & {organizationId: string},
-      options?: RequestOptions,
-    ): Promise<KnowledgeBase> => {
-      const {organizationId, ...body} = params
-      return _request<KnowledgeBase>(this.#client, this.#httpRequest, {
-        url: _collectionUrl(organizationId),
+    create: (params: CreateKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> =>
+      _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+        url: COLLECTION_URL,
         method: 'POST',
-        body,
+        body: params,
         ...options,
-      })
-    },
+      }),
     /** List the organization's knowledge bases. */
     list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
       _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
-        url: _collectionUrl(params.organizationId),
-        query: _query({cursor: params.cursor, limit: params.limit}),
+        url: COLLECTION_URL,
+        query: _query({
+          organizationId: params.organizationId,
+          cursor: params.cursor,
+          limit: params.limit,
+        }),
         signal: params.signal,
         tag: params.tag,
       }),
@@ -517,8 +460,7 @@ export class ContextClient {
 
   /**
    * A handle carrying everything scoped to one knowledge base, addressed by
-   * id alone. Synchronous: the id-to-address resolution happens lazily on
-   * the first request and is reused after that.
+   * its id.
    */
   knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
     return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
@@ -545,26 +487,28 @@ export class ObservableContextClient {
   knowledgeBases = {
     /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
     create: (
-      params: CreateKnowledgeBaseParams & {organizationId: string},
+      params: CreateKnowledgeBaseParams,
       options?: RequestOptions,
-    ): Observable<KnowledgeBase> => {
-      const {organizationId, ...body} = params
-      return _observe(options?.signal, (signal) =>
+    ): Observable<KnowledgeBase> =>
+      _observe(options?.signal, (signal) =>
         _request<KnowledgeBase>(this.#client, this.#httpRequest, {
-          url: _collectionUrl(organizationId),
+          url: COLLECTION_URL,
           method: 'POST',
-          body,
+          body: params,
           tag: options?.tag,
           signal,
         }),
-      )
-    },
+      ),
     /** List the organization's knowledge bases. */
     list: (params: {organizationId: string} & ListOptions): Observable<KnowledgeBasesResponse> =>
       _observe(params.signal, (signal) =>
         _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
-          url: _collectionUrl(params.organizationId),
-          query: _query({cursor: params.cursor, limit: params.limit}),
+          url: COLLECTION_URL,
+          query: _query({
+            organizationId: params.organizationId,
+            cursor: params.cursor,
+            limit: params.limit,
+          }),
           tag: params.tag,
           signal,
         }),

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -473,8 +473,6 @@ export class KnowledgeBaseHandle {
  *   organizationId: 'org123',
  *   name: 'Support docs',
  *   description: 'Product docs and troubleshooting guides',
- *   sanityProjectId: 'abc123',
- *   sanityDatasetId: 'production',
  * })
  * const kb = client.context.knowledgeBase(created.publicId)
  * await kb.imports.create({type: 'text', title: 'Refund policy', content: refundMd})
@@ -494,7 +492,7 @@ export class ContextClient {
 
   /** The knowledge base collection. */
   knowledgeBases = {
-    /** Create a knowledge base. Requires provisioning access to the target project. */
+    /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
     create: (
       params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,
@@ -545,7 +543,7 @@ export class ObservableContextClient {
 
   /** The knowledge base collection. */
   knowledgeBases = {
-    /** Create a knowledge base. Requires provisioning access to the target project. */
+    /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
     create: (
       params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -5,46 +5,48 @@ import {_observe, _request} from '../data/dataMethods'
 import type {ListenEventFromOptions} from '../data/listen'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import type {HttpRequest, QueryParams, SanityDocument} from '../types'
+import {
+  _listEntries,
+  _listInstructions,
+  _listIssues,
+  _listMcpEndpoints,
+  _readConversation,
+  _readEntry,
+  _readIssue,
+  _readMcpEndpoint,
+} from './reads'
 import {_fetch as _fetchStore, _listen as _listenStore} from './store'
 import type {
   ApplyIssuesParams,
   ApplyIssuesResponse,
-  ActivityResponse,
-  Changes,
-  EntriesResponse,
-  EntryDetail,
-  EntryStatus,
-  ImportDetail,
-  ImportsResponse,
-  Instruction,
-  InstructionsResponse,
-  IssueDetail,
-  IssuesResponse,
-  Job,
-  JobAccepted,
-  Outline,
-  RevisionOutline,
-  RevisionReport,
-  RevisionsResponse,
-  SourceDetail,
-  SourcesResponse,
-  CrawlOptions,
-  CrawlPreviewParams,
-  CrawlPreviewResponse,
+  ConversationDoc,
   CreateImportParams,
   CreateInstructionParams,
+  CreateInstructionResponse,
   CreateKnowledgeBaseParams,
   DismissIssueResponse,
-  EditCrawlOptionsParams,
   EditInstructionParams,
   EditKnowledgeBaseParams,
+  Entry,
+  EntryDoc,
+  ImportDetail,
   ImportDownloadResponse,
+  ImportsResponse,
+  Instruction,
+  InstructionDoc,
+  IssueDoc,
+  Job,
+  JobAccepted,
   KnowledgeBase,
   KnowledgeBasesResponse,
+  McpDoc,
+  RebuildEntryResponse,
   ReopenIssueResponse,
   ResolveIssueParams,
   ResolveIssueResponse,
   SourceContentResponse,
+  SourceDetail,
+  SourcesResponse,
   StagedUpload,
 } from './types'
 import type {
@@ -53,7 +55,6 @@ import type {
   ContextRequestOptions,
   Conversation,
   CreateFileImportParams,
-  RenderFormat,
   RequestOptions,
   SaveConversationParams,
 } from './types'
@@ -301,10 +302,10 @@ export class ContextClient {
   }
 
   /**
-   * Conversation telemetry: the API-owned writes. `threadId` identifies the
-   * conversation within the organization — reuse means the same
-   * conversation. Reads go through {@link fetch} and {@link listen} with
-   * GROQ (`_type == "sanity.context.conversation"`).
+   * Conversation telemetry. `threadId` identifies the conversation within
+   * the organization — reuse means the same conversation. Beyond the canned
+   * `get`, reads go through {@link fetch} and {@link listen} with GROQ
+   * (`_type == "sanity.context.conversation"`).
    *
    * Requires `context.organizationId` in the client configuration.
    */
@@ -343,6 +344,19 @@ export class ContextClient {
         ...options,
       })
     },
+    /**
+     * One recorded conversation by its thread id, or `null` when the thread
+     * was never recorded. Runs:
+     *
+     * `*[_type == "sanity.context.conversation" && organizationId == $org && threadId == $threadId][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (
+      params: {threadId: string},
+      options?: ContextRequestOptions,
+    ): Promise<ConversationDoc | null> =>
+      _readConversation(this.#client, this.#httpRequest, params.threadId, options),
   }
 
   /**
@@ -362,26 +376,6 @@ export class ContextClient {
   /** Run an incremental refresh: re-check sources and apply what changed. */
   refresh(options?: RequestOptions): Promise<{jobId: string; started: boolean}> {
     return this.#request('/refresh', {method: 'POST', ...options})
-  }
-
-  /**
-   * The built outline: every entry, ordered, with stats. The default
-   * `json` format resolves to {@link Outline}; `markdown` and
-   * `plain` resolve to a string.
-   */
-  outline<const F extends RenderFormat = 'json'>(
-    params?: {format?: F},
-    options?: RequestOptions,
-  ): Promise<F extends 'json' ? Outline : string> {
-    return this.#request('/outline', {
-      query: params?.format ? {format: params.format} : {},
-      ...options,
-    })
-  }
-
-  /** What changed in the corpus since the last build. */
-  changes(options?: RequestOptions): Promise<Changes> {
-    return this.#request('/changes', options)
   }
 
   /** Imports: feed content into the configured knowledge base. */
@@ -419,13 +413,6 @@ export class ContextClient {
         ...options,
       })
     },
-    /** Preview which pages a crawl would ingest, before committing to it. */
-    crawlPreview: (params: CrawlPreviewParams, options?: RequestOptions) =>
-      this.#request<CrawlPreviewResponse>('/imports/crawl-preview', {
-        method: 'POST',
-        body: params,
-        ...options,
-      }),
   }
 
   /** Jobs: poll async work (builds, imports) to a terminal state. */
@@ -434,14 +421,48 @@ export class ContextClient {
       this.#request<Job>(`/jobs/${encodeURIComponent(params.jobId)}`, options),
   }
 
-  /** Issues: findings from builds awaiting triage. */
+  /**
+   * Issues: findings from builds awaiting triage. Reads are canned GROQ
+   * queries against the organization's document store; for anything more,
+   * use {@link fetch}. Reads require `context.organizationId` alongside the
+   * knowledge-base `resource` in the client configuration.
+   */
   issues = {
-    list: (params?: {status?: 'open' | 'accepted' | 'rejected'} & ListOptions) =>
-      this.#list<IssuesResponse>('/issues', params, {
-        status: params?.status,
-      }),
-    get: (params: {issueId: string}, options?: RequestOptions) =>
-      this.#request<IssueDetail>(`/issues/${encodeURIComponent(params.issueId)}`, options),
+    /**
+     * Every issue on the knowledge base, oldest first, optionally narrowed
+     * to one status. Drains keyset pages internally and resolves with the
+     * complete set. Runs:
+     *
+     * `*[_type == "sanity.context.issue" && knowledgeBaseId == $kb && status == $status] | order(_createdAt asc, _id asc)`
+     *
+     * (the status clause only when given). For anything more, use {@link fetch}.
+     */
+    list: (
+      params?: {status?: 'open' | 'accepted' | 'rejected'},
+      options?: ContextRequestOptions,
+    ): Promise<IssueDoc[]> =>
+      _listIssues(
+        this.#client,
+        this.#httpRequest,
+        _resolveKnowledgeBaseId(this.#client),
+        params?.status,
+        options,
+      ),
+    /**
+     * One issue by its document id, or `null` when it does not exist. Runs:
+     *
+     * `*[_type == "sanity.context.issue" && knowledgeBaseId == $kb && _id == $id][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (params: {issueId: string}, options?: ContextRequestOptions): Promise<IssueDoc | null> =>
+      _readIssue(
+        this.#client,
+        this.#httpRequest,
+        _resolveKnowledgeBaseId(this.#client),
+        params.issueId,
+        options,
+      ),
     /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
     resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
       const {issueId, ...body} = params
@@ -472,13 +493,32 @@ export class ContextClient {
 
   /** Instructions: standing decisions that steer every build. */
   instructions = {
-    create: (params: CreateInstructionParams, options?: RequestOptions) =>
-      this.#request<Instruction>('/instructions', {
+    create: (
+      params: CreateInstructionParams,
+      options?: RequestOptions,
+    ): Promise<CreateInstructionResponse> =>
+      this.#request<CreateInstructionResponse>('/instructions', {
         method: 'POST',
         body: params,
         ...options,
       }),
-    list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
+    /**
+     * Every current-schema instruction on the knowledge base, oldest first.
+     * Drains keyset pages internally and resolves with the complete set.
+     * Runs:
+     *
+     * `*[_type == "sanity.context.instruction" && knowledgeBaseId == $kb && schemaVersion == 1] | order(_createdAt asc, _id asc)`
+     *
+     * For anything more, use {@link fetch}. Requires `context.organizationId`
+     * alongside the knowledge-base `resource` in the client configuration.
+     */
+    list: (options?: ContextRequestOptions): Promise<InstructionDoc[]> =>
+      _listInstructions(
+        this.#client,
+        this.#httpRequest,
+        _resolveKnowledgeBaseId(this.#client),
+        options,
+      ),
     edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
       const {instructionId, ...body} = params
       return this.#request<Instruction>(`/instructions/${encodeURIComponent(instructionId)}`, {
@@ -495,41 +535,76 @@ export class ContextClient {
     },
   }
 
-  /** Entries: the built outline, one entry per node. */
+  /**
+   * Entries: the built outline, one entry per node. Reads are canned GROQ
+   * queries against the organization's document store; for anything more,
+   * use {@link fetch}. Requires `context.organizationId` alongside the
+   * knowledge-base `resource` in the client configuration.
+   */
   entries = {
-    /** List entries, optionally filtered by status or searched (`q`). */
-    list: (
-      params?: {
-        status?: EntryStatus
-        q?: string
-        mode?: 'keyword' | 'hybrid'
-        include?: 'metadata' | 'body'
-        paths?: string
-      } & ListOptions,
-    ) =>
-      this.#list<EntriesResponse>('/entries', params, {
-        status: params?.status,
-        q: params?.q,
-        mode: params?.mode,
-        include: params?.include,
-        paths: params?.paths,
-      }),
     /**
-     * One entry with its full body, by outline path (e.g. `billing/refunds`).
-     * The default `json` format resolves to {@link EntryDetail};
-     * `markdown` and `plain` resolve to a string.
+     * Every entry, path-ordered, as a metadata view (`_id`, `path`,
+     * `title`, `tldr`, `status`) with bodies excluded. Drains keyset pages
+     * internally and resolves with the complete set. Runs:
+     *
+     * `*[_type == "sanity.context.entry" && knowledgeBaseId == $kb && path > $after] | order(path asc) [0...200] {_id, path, title, tldr, status}`
+     *
+     * For bodies, use `entries.get` or {@link fetch}.
      */
-    get: <const F extends RenderFormat = 'json'>(
-      params: {path: string; format?: F},
-      options?: RequestOptions,
-    ) =>
-      this.#request<F extends 'json' ? EntryDetail : string>(
-        `/entries/${encodeURIComponent(params.path)}`,
-        {
-          query: params.format ? {format: params.format} : {},
-          ...options,
-        },
+    list: (options?: ContextRequestOptions): Promise<Entry[]> =>
+      _listEntries(this.#client, this.#httpRequest, _resolveKnowledgeBaseId(this.#client), options),
+    /**
+     * One entry with its full body and citations, by outline path (e.g.
+     * `billing/refunds`), or `null` when no entry sits at that path. Runs:
+     *
+     * `*[_type == "sanity.context.entry" && knowledgeBaseId == $kb && path == $path][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (params: {path: string}, options?: ContextRequestOptions): Promise<EntryDoc | null> =>
+      _readEntry(
+        this.#client,
+        this.#httpRequest,
+        _resolveKnowledgeBaseId(this.#client),
+        params.path,
+        options,
       ),
+    /**
+     * Rebuild one entry from its already-placed sources, by outline path.
+     * Poll the returned job with {@link jobs}; `affectedEntries` lists every
+     * entry the rebuild touches.
+     */
+    rebuild: (params: {path: string}, options?: RequestOptions): Promise<RebuildEntryResponse> =>
+      this.#request<RebuildEntryResponse>(`/entries/${encodeURIComponent(params.path)}/rebuild`, {
+        method: 'POST',
+        ...options,
+      }),
+  }
+
+  /**
+   * MCP endpoint configurations, org-owned documents read with canned GROQ
+   * queries. Requires `context.organizationId` in the client configuration.
+   */
+  mcpEndpoints = {
+    /**
+     * The organization's MCP endpoint configurations, oldest first. Runs:
+     *
+     * `*[_type == "sanity.context.mcp" && organizationId == $org] | order(_createdAt asc, _id asc) [0...500]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    list: (options?: ContextRequestOptions): Promise<McpDoc[]> =>
+      _listMcpEndpoints(this.#client, this.#httpRequest, options),
+    /**
+     * One MCP endpoint configuration by its URL name, or `null` when none
+     * carries that name. Runs:
+     *
+     * `*[_type == "sanity.context.mcp" && organizationId == $org && name == $name][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (params: {name: string}, options?: ContextRequestOptions): Promise<McpDoc | null> =>
+      _readMcpEndpoint(this.#client, this.#httpRequest, params.name, options),
   }
 
   /** Sources: the distilled units builds cite. */
@@ -562,43 +637,13 @@ export class ContextClient {
       })
     },
   }
-
-  /** The audit feed: who did what, when. */
-  activity = {
-    list: (params?: ListOptions) => this.#list<ActivityResponse>('/activity', params),
-  }
-
-  /** Revisions: one per build, with an accounting report per revision. */
-  revisions = {
-    list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
-    report: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionReport>(
-        `/revisions/${encodeURIComponent(params.revisionId)}/report`,
-        options,
-      ),
-    /** The outline as it was at a past build revision. */
-    outline: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionOutline>(
-        `/revisions/${encodeURIComponent(params.revisionId)}/outline`,
-        options,
-      ),
-  }
-
-  /** Crawl options for the configured knowledge base's web source. */
-  crawlOptions = {
-    edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
-      this.#request<CrawlOptions>('/crawl-options', {
-        method: 'PATCH',
-        body: params,
-        ...options,
-      }),
-  }
 }
 
 /**
- * Observable counterpart of {@link ContextClient}. Collection-level methods
- * only; knowledge-base scoped operations are promise-based, so use the
- * promise client (`client.context`) for those.
+ * Observable counterpart of {@link ContextClient}. Collection-level
+ * methods and the GROQ-backed reads; knowledge-base scoped write
+ * operations are promise-based, so use the promise client
+ * (`client.context`) for those.
  *
  * @beta
  */
@@ -706,10 +751,10 @@ export class ObservableContextClient {
   }
 
   /**
-   * Conversation telemetry: the API-owned writes. `threadId` identifies the
-   * conversation within the organization — reuse means the same
-   * conversation. Reads go through {@link fetch} and {@link listen} with
-   * GROQ (`_type == "sanity.context.conversation"`).
+   * Conversation telemetry. `threadId` identifies the conversation within
+   * the organization — reuse means the same conversation. Beyond the canned
+   * `get`, reads go through {@link fetch} and {@link listen} with GROQ
+   * (`_type == "sanity.context.conversation"`).
    *
    * Requires `context.organizationId` in the client configuration.
    */
@@ -754,5 +799,193 @@ export class ObservableContextClient {
         }),
       )
     },
+    /**
+     * One recorded conversation by its thread id, or `null` when the thread
+     * was never recorded. Runs:
+     *
+     * `*[_type == "sanity.context.conversation" && organizationId == $org && threadId == $threadId][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (
+      params: {threadId: string},
+      options?: ContextRequestOptions,
+    ): Observable<ConversationDoc | null> =>
+      _observe(options?.signal, (signal) =>
+        _readConversation(this.#client, this.#httpRequest, params.threadId, {
+          ...options,
+          signal,
+        }),
+      ),
+  }
+
+  /**
+   * Entries: the built outline, one entry per node. Reads are canned GROQ
+   * queries against the organization's document store; for anything more,
+   * use {@link fetch}. Requires `context.organizationId` alongside the
+   * knowledge-base `resource` in the client configuration.
+   */
+  entries = {
+    /**
+     * Every entry, path-ordered, as a metadata view (`_id`, `path`,
+     * `title`, `tldr`, `status`) with bodies excluded. Drains keyset pages
+     * internally and emits the complete set. Runs:
+     *
+     * `*[_type == "sanity.context.entry" && knowledgeBaseId == $kb && path > $after] | order(path asc) [0...200] {_id, path, title, tldr, status}`
+     *
+     * For bodies, use `entries.get` or {@link fetch}.
+     */
+    list: (options?: ContextRequestOptions): Observable<Entry[]> =>
+      _observe(options?.signal, (signal) =>
+        _listEntries(this.#client, this.#httpRequest, _resolveKnowledgeBaseId(this.#client), {
+          ...options,
+          signal,
+        }),
+      ),
+    /**
+     * One entry with its full body and citations, by outline path (e.g.
+     * `billing/refunds`), or `null` when no entry sits at that path. Runs:
+     *
+     * `*[_type == "sanity.context.entry" && knowledgeBaseId == $kb && path == $path][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (params: {path: string}, options?: ContextRequestOptions): Observable<EntryDoc | null> =>
+      _observe(options?.signal, (signal) =>
+        _readEntry(
+          this.#client,
+          this.#httpRequest,
+          _resolveKnowledgeBaseId(this.#client),
+          params.path,
+          {...options, signal},
+        ),
+      ),
+    /**
+     * Rebuild one entry from its already-placed sources, by outline path.
+     * Poll the returned job with the promise client's `jobs`;
+     * `affectedEntries` lists every entry the rebuild touches.
+     */
+    rebuild: (params: {path: string}, options?: RequestOptions): Observable<RebuildEntryResponse> =>
+      _observe(options?.signal, (signal) =>
+        _request<RebuildEntryResponse>(this.#client, this.#httpRequest, {
+          url: _knowledgeBaseUrl(
+            _resolveKnowledgeBaseId(this.#client),
+            `/entries/${encodeURIComponent(params.path)}/rebuild`,
+          ),
+          method: 'POST',
+          tag: options?.tag,
+          signal,
+        }),
+      ),
+  }
+
+  /**
+   * Issues: findings from builds awaiting triage. Reads are canned GROQ
+   * queries against the organization's document store; for anything more,
+   * use {@link fetch}. Requires `context.organizationId` alongside the
+   * knowledge-base `resource` in the client configuration.
+   */
+  issues = {
+    /**
+     * Every issue on the knowledge base, oldest first, optionally narrowed
+     * to one status. Drains keyset pages internally and emits the complete
+     * set. Runs:
+     *
+     * `*[_type == "sanity.context.issue" && knowledgeBaseId == $kb && status == $status] | order(_createdAt asc, _id asc)`
+     *
+     * (the status clause only when given). For anything more, use {@link fetch}.
+     */
+    list: (
+      params?: {status?: 'open' | 'accepted' | 'rejected'},
+      options?: ContextRequestOptions,
+    ): Observable<IssueDoc[]> =>
+      _observe(options?.signal, (signal) =>
+        _listIssues(
+          this.#client,
+          this.#httpRequest,
+          _resolveKnowledgeBaseId(this.#client),
+          params?.status,
+          {...options, signal},
+        ),
+      ),
+    /**
+     * One issue by its document id, or `null` when it does not exist. Runs:
+     *
+     * `*[_type == "sanity.context.issue" && knowledgeBaseId == $kb && _id == $id][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (
+      params: {issueId: string},
+      options?: ContextRequestOptions,
+    ): Observable<IssueDoc | null> =>
+      _observe(options?.signal, (signal) =>
+        _readIssue(
+          this.#client,
+          this.#httpRequest,
+          _resolveKnowledgeBaseId(this.#client),
+          params.issueId,
+          {...options, signal},
+        ),
+      ),
+  }
+
+  /**
+   * Instructions: standing decisions that steer every build. The canned
+   * GROQ read; writes are promise-based on `client.context`.
+   */
+  instructions = {
+    /**
+     * Every current-schema instruction on the knowledge base, oldest first.
+     * Drains keyset pages internally and emits the complete set. Runs:
+     *
+     * `*[_type == "sanity.context.instruction" && knowledgeBaseId == $kb && schemaVersion == 1] | order(_createdAt asc, _id asc)`
+     *
+     * For anything more, use {@link fetch}. Requires `context.organizationId`
+     * alongside the knowledge-base `resource` in the client configuration.
+     */
+    list: (options?: ContextRequestOptions): Observable<InstructionDoc[]> =>
+      _observe(options?.signal, (signal) =>
+        _listInstructions(this.#client, this.#httpRequest, _resolveKnowledgeBaseId(this.#client), {
+          ...options,
+          signal,
+        }),
+      ),
+  }
+
+  /**
+   * MCP endpoint configurations, org-owned documents read with canned GROQ
+   * queries. Requires `context.organizationId` in the client configuration.
+   */
+  mcpEndpoints = {
+    /**
+     * The organization's MCP endpoint configurations, oldest first. Runs:
+     *
+     * `*[_type == "sanity.context.mcp" && organizationId == $org] | order(_createdAt asc, _id asc) [0...500]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    list: (options?: ContextRequestOptions): Observable<McpDoc[]> =>
+      _observe(options?.signal, (signal) =>
+        _listMcpEndpoints(this.#client, this.#httpRequest, {
+          ...options,
+          signal,
+        }),
+      ),
+    /**
+     * One MCP endpoint configuration by its URL name, or `null` when none
+     * carries that name. Runs:
+     *
+     * `*[_type == "sanity.context.mcp" && organizationId == $org && name == $name][0]`
+     *
+     * For anything more, use {@link fetch}.
+     */
+    get: (params: {name: string}, options?: ContextRequestOptions): Observable<McpDoc | null> =>
+      _observe(options?.signal, (signal) =>
+        _readMcpEndpoint(this.#client, this.#httpRequest, params.name, {
+          ...options,
+          signal,
+        }),
+      ),
   }
 }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,9 +1,11 @@
 import {type FetchFunction} from 'get-it'
-import {type Observable} from 'rxjs'
+import {lastValueFrom, type Observable} from 'rxjs'
 
 import {_observe, _request} from '../data/dataMethods'
+import type {ListenEventFromOptions} from '../data/listen'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
-import type {HttpRequest} from '../types'
+import type {HttpRequest, QueryParams, SanityDocument} from '../types'
+import {_fetch as _fetchStore, _listen as _listenStore} from './store'
 import type {
   ApplyIssuesParams,
   ApplyIssuesResponse,
@@ -45,7 +47,13 @@ import type {
   SourceContentResponse,
   StagedUpload,
 } from './types'
-import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types'
+import type {
+  ContextListenOptions,
+  ContextRequestOptions,
+  CreateFileImportParams,
+  RenderFormat,
+  RequestOptions,
+} from './types'
 
 type ListOptions = RequestOptions & {cursor?: string; limit?: number}
 
@@ -245,6 +253,34 @@ export class ContextClient {
         ...options,
       })
     },
+  }
+
+  /**
+   * GROQ over the organization's Context documents (conversation telemetry
+   * today; the store holds every Context family and the caller's access
+   * decides what a query returns, so filter on `_type`).
+   *
+   * Requires `context.organizationId` in the client configuration.
+   */
+  fetch<R = unknown>(
+    query: string,
+    params?: QueryParams,
+    options?: ContextRequestOptions,
+  ): Promise<R> {
+    return lastValueFrom(_fetchStore<R>(this.#client, this.#httpRequest, query, params, options))
+  }
+
+  /**
+   * Listen for changes to the organization's Context documents. Mirrors
+   * `client.listen(query, params, options)` and emits mutation events by
+   * default.
+   */
+  listen<Opts extends ContextListenOptions | undefined = undefined>(
+    query: string,
+    params?: QueryParams,
+    options?: Opts,
+  ): Observable<ListenEventFromOptions<SanityDocument, Opts>> {
+    return _listenStore(this.#client, query, params, options)
   }
 
   /**
@@ -577,5 +613,33 @@ export class ObservableContextClient {
           signal,
         }),
       ),
+  }
+
+  /**
+   * GROQ over the organization's Context documents (conversation telemetry
+   * today; the store holds every Context family and the caller's access
+   * decides what a query returns, so filter on `_type`).
+   *
+   * Requires `context.organizationId` in the client configuration.
+   */
+  fetch<R = unknown>(
+    query: string,
+    params?: QueryParams,
+    options?: ContextRequestOptions,
+  ): Observable<R> {
+    return _fetchStore<R>(this.#client, this.#httpRequest, query, params, options)
+  }
+
+  /**
+   * Listen for changes to the organization's Context documents. Mirrors
+   * `client.listen(query, params, options)` and emits mutation events by
+   * default.
+   */
+  listen<Opts extends ContextListenOptions | undefined = undefined>(
+    query: string,
+    params?: QueryParams,
+    options?: Opts,
+  ): Observable<ListenEventFromOptions<SanityDocument, Opts>> {
+    return _listenStore(this.#client, query, params, options)
   }
 }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -187,11 +187,14 @@ export class ContextClient {
     if (!putResponse.ok) {
       throw new Error(`File upload failed: ${putResponse.status} ${putResponse.statusText}`)
     }
-    return this.#request<JobAccepted>(`/imports/uploads/${staged.importId}/complete`, {
-      method: 'POST',
-      body: {},
-      ...options,
-    })
+    return this.#request<JobAccepted>(
+      `/imports/uploads/${encodeURIComponent(staged.importId)}/complete`,
+      {
+        method: 'POST',
+        body: {},
+        ...options,
+      },
+    )
   }
 
   /** The knowledge base collection: management addressed per call. */
@@ -305,12 +308,15 @@ export class ContextClient {
           }),
     list: (params?: ListOptions) => this.#list<ImportsResponse>('/imports', params),
     get: (params: {importId: string}, options?: RequestOptions) =>
-      this.#request<ImportDetail>(`/imports/${params.importId}`, options),
+      this.#request<ImportDetail>(`/imports/${encodeURIComponent(params.importId)}`, options),
     /** A short-lived signed URL for the original uploaded bytes. */
     download: (params: {importId: string}, options?: RequestOptions) =>
-      this.#request<ImportDownloadResponse>(`/imports/${params.importId}/download`, options),
+      this.#request<ImportDownloadResponse>(
+        `/imports/${encodeURIComponent(params.importId)}/download`,
+        options,
+      ),
     delete: async (params: {importId: string}, options?: RequestOptions) => {
-      await this.#request<void>(`/imports/${params.importId}`, {
+      await this.#request<void>(`/imports/${encodeURIComponent(params.importId)}`, {
         method: 'DELETE',
         ...options,
       })
@@ -327,7 +333,7 @@ export class ContextClient {
   /** Jobs: poll async work (builds, imports) to a terminal state. */
   jobs = {
     get: (params: {jobId: string}, options?: RequestOptions) =>
-      this.#request<Job>(`/jobs/${params.jobId}`, options),
+      this.#request<Job>(`/jobs/${encodeURIComponent(params.jobId)}`, options),
   }
 
   /** Issues: findings from builds awaiting triage. */
@@ -337,23 +343,23 @@ export class ContextClient {
         status: params?.status,
       }),
     get: (params: {issueId: string}, options?: RequestOptions) =>
-      this.#request<IssueDetail>(`/issues/${params.issueId}`, options),
+      this.#request<IssueDetail>(`/issues/${encodeURIComponent(params.issueId)}`, options),
     /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
     resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
       const {issueId, ...body} = params
-      return this.#request<ResolveIssueResponse>(`/issues/${issueId}/resolve`, {
+      return this.#request<ResolveIssueResponse>(`/issues/${encodeURIComponent(issueId)}/resolve`, {
         method: 'POST',
         body,
         ...options,
       })
     },
     dismiss: (params: {issueId: string}, options?: RequestOptions) =>
-      this.#request<DismissIssueResponse>(`/issues/${params.issueId}/dismiss`, {
+      this.#request<DismissIssueResponse>(`/issues/${encodeURIComponent(params.issueId)}/dismiss`, {
         method: 'POST',
         ...options,
       }),
     reopen: (params: {issueId: string}, options?: RequestOptions) =>
-      this.#request<ReopenIssueResponse>(`/issues/${params.issueId}/reopen`, {
+      this.#request<ReopenIssueResponse>(`/issues/${encodeURIComponent(params.issueId)}/reopen`, {
         method: 'POST',
         ...options,
       }),
@@ -377,14 +383,14 @@ export class ContextClient {
     list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
     edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
       const {instructionId, ...body} = params
-      return this.#request<Instruction>(`/instructions/${instructionId}`, {
+      return this.#request<Instruction>(`/instructions/${encodeURIComponent(instructionId)}`, {
         method: 'PATCH',
         body,
         ...options,
       })
     },
     delete: async (params: {instructionId: string}, options?: RequestOptions) => {
-      await this.#request<void>(`/instructions/${params.instructionId}`, {
+      await this.#request<void>(`/instructions/${encodeURIComponent(params.instructionId)}`, {
         method: 'DELETE',
         ...options,
       })
@@ -432,7 +438,7 @@ export class ContextClient {
   sources = {
     list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
     get: (params: {sourceId: string}, options?: RequestOptions) =>
-      this.#request<SourceDetail>(`/sources/${params.sourceId}`, options),
+      this.#request<SourceDetail>(`/sources/${encodeURIComponent(params.sourceId)}`, options),
     /**
      * Distilled source content, optionally a line range: the evidence behind
      * a citation or an issue.
@@ -441,15 +447,18 @@ export class ContextClient {
       params: {sourceId: string; startLine?: number; endLine?: number},
       options?: RequestOptions,
     ) =>
-      this.#request<SourceContentResponse>(`/sources/${params.sourceId}/content`, {
-        query: _query({
-          startLine: params.startLine,
-          endLine: params.endLine,
-        }),
-        ...options,
-      }),
+      this.#request<SourceContentResponse>(
+        `/sources/${encodeURIComponent(params.sourceId)}/content`,
+        {
+          query: _query({
+            startLine: params.startLine,
+            endLine: params.endLine,
+          }),
+          ...options,
+        },
+      ),
     delete: async (params: {sourceId: string}, options?: RequestOptions) => {
-      await this.#request<void>(`/sources/${params.sourceId}`, {
+      await this.#request<void>(`/sources/${encodeURIComponent(params.sourceId)}`, {
         method: 'DELETE',
         ...options,
       })
@@ -465,10 +474,16 @@ export class ContextClient {
   revisions = {
     list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
     report: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionReport>(`/revisions/${params.revisionId}/report`, options),
+      this.#request<RevisionReport>(
+        `/revisions/${encodeURIComponent(params.revisionId)}/report`,
+        options,
+      ),
     /** The outline as it was at a past build revision. */
     outline: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
+      this.#request<RevisionOutline>(
+        `/revisions/${encodeURIComponent(params.revisionId)}/outline`,
+        options,
+      ),
   }
 
   /** Crawl options for the configured knowledge base's web source. */

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,6 +1,4 @@
 import {type FetchFunction} from 'get-it'
-
-type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
 import {type Observable} from 'rxjs'
 
 import {_observe, _request} from '../data/dataMethods'
@@ -84,6 +82,13 @@ function _query(entries: Record<string, string | number | undefined>): Record<st
       value === undefined ? [] : [[key, `${value}`]],
     ),
   )
+}
+
+function _fetchBody(file: CreateFileImportParams['file']) {
+  if (!ArrayBuffer.isView(file)) return file
+  return file.buffer instanceof ArrayBuffer
+    ? new Uint8Array(file.buffer, file.byteOffset, file.byteLength)
+    : Uint8Array.from(file)
 }
 
 /**
@@ -178,12 +183,10 @@ export class KnowledgeBaseHandle {
     // no auth header, and the body is raw bytes rather than JSON. Still uses
     // the client's fetch resolution so proxy config applies in Node.
     const config = this.#client.config()
-    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
+    const doFetch: FetchFunction = config.resolveFetch?.(config.proxy) ?? globalThis.fetch
     const putResponse = await doFetch(staged.uploadUrl, {
       method: 'PUT',
-      // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
-      // bound, even though fetch accepts it at runtime.
-      body: params.file as FetchBody,
+      body: _fetchBody(params.file),
       ...(params.contentType && {
         headers: {'content-type': params.contentType},
       }),

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,11 +1,11 @@
-import { type FetchFunction } from "get-it";
+import {type FetchFunction} from 'get-it'
 
-type FetchBody = NonNullable<Parameters<FetchFunction>[1]>["body"];
-import { type Observable } from "rxjs";
+type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
+import {type Observable} from 'rxjs'
 
-import { _observe, _request } from "../data/dataMethods";
-import type { ObservableSanityClient, SanityClient } from "../SanityClient";
-import type { HttpRequest } from "../types";
+import {_observe, _request} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest} from '../types'
 import type {
   ApplyIssuesParams,
   ApplyIssuesResponse,
@@ -46,16 +46,12 @@ import type {
   ResolveIssueResponse,
   SourceContentResponse,
   StagedUpload,
-} from "./types";
-import type {
-  CreateFileImportParams,
-  RenderFormat,
-  RequestOptions,
-} from "./types";
+} from './types'
+import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types'
 
-type ListOptions = RequestOptions & { cursor?: string; limit?: number };
+type ListOptions = RequestOptions & {cursor?: string; limit?: number}
 
-type Client = SanityClient | ObservableSanityClient;
+type Client = SanityClient | ObservableSanityClient
 
 /**
  * The knowledge base's org-scoped address. Every operation except the by-id
@@ -63,7 +59,7 @@ type Client = SanityClient | ObservableSanityClient;
  * handle is constructed from the id alone, so the address is resolved once
  * through the by-id endpoint and reused.
  */
-type ResolvedAddress = { organizationId: string; slug: string };
+type ResolvedAddress = {organizationId: string; slug: string}
 
 function _getKnowledgeBaseById(
   client: Client,
@@ -74,22 +70,20 @@ function _getKnowledgeBaseById(
   return _request<KnowledgeBase>(client, httpRequest, {
     url: `/context/knowledge-bases/${knowledgeBaseId}`,
     ...options,
-  });
+  })
 }
 
 function _collectionUrl(organizationId: string): string {
-  return `/context/organizations/${organizationId}/knowledge-bases`;
+  return `/context/organizations/${organizationId}/knowledge-bases`
 }
 
 /** Serialize defined values into query params, dropping the undefined ones. */
-function _query(
-  entries: Record<string, string | number | undefined>,
-): Record<string, string> {
+function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(entries).flatMap(([key, value]) =>
       value === undefined ? [] : [[key, `${value}`]],
     ),
-  );
+  )
 }
 
 /**
@@ -99,24 +93,20 @@ function _query(
  * @beta
  */
 export class KnowledgeBaseHandle {
-  #client: SanityClient;
-  #httpRequest: HttpRequest;
-  #knowledgeBaseId: string;
-  #address: Promise<ResolvedAddress> | undefined;
+  #client: SanityClient
+  #httpRequest: HttpRequest
+  #knowledgeBaseId: string
+  #address: Promise<ResolvedAddress> | undefined
 
-  constructor(
-    client: SanityClient,
-    httpRequest: HttpRequest,
-    knowledgeBaseId: string,
-  ) {
-    this.#client = client;
-    this.#httpRequest = httpRequest;
-    this.#knowledgeBaseId = knowledgeBaseId;
+  constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+    this.#knowledgeBaseId = knowledgeBaseId
   }
 
   /** The knowledge base id this handle was constructed with. */
   get knowledgeBaseId(): string {
-    return this.#knowledgeBaseId;
+    return this.#knowledgeBaseId
   }
 
   // The resolution is shared by every method on the handle, so it must not
@@ -130,29 +120,29 @@ export class KnowledgeBaseHandle {
       this.#httpRequest,
       this.#knowledgeBaseId,
     ).then(
-      (kb) => ({ organizationId: kb.organizationId, slug: kb.slug }),
+      (kb) => ({organizationId: kb.organizationId, slug: kb.slug}),
       (err) => {
         // A failed resolution must not poison the handle for retries.
-        this.#address = undefined;
-        throw err;
+        this.#address = undefined
+        throw err
       },
-    );
-    return this.#address;
+    )
+    return this.#address
   }
 
   async #request<R>(
     suffix: string,
     reqOptions: {
-      method?: string;
-      body?: unknown;
-      query?: Record<string, string>;
+      method?: string
+      body?: unknown
+      query?: Record<string, string>
     } & RequestOptions = {},
   ): Promise<R> {
-    const address = await this.#resolveAddress();
+    const address = await this.#resolveAddress()
     return _request<R>(this.#client, this.#httpRequest, {
       url: `${_collectionUrl(address.organizationId)}/${address.slug}${suffix}`,
       ...reqOptions,
-    });
+    })
   }
 
   /** Shared shape of every paginated list endpoint under the handle. */
@@ -169,73 +159,59 @@ export class KnowledgeBaseHandle {
       }),
       signal: params?.signal,
       tag: params?.tag,
-    });
+    })
   }
 
   async #uploadFile(
     params: CreateFileImportParams,
     options?: RequestOptions,
   ): Promise<JobAccepted> {
-    const staged = await this.#request<StagedUpload>("/imports/uploads", {
-      method: "POST",
+    const staged = await this.#request<StagedUpload>('/imports/uploads', {
+      method: 'POST',
       body: {
         filename: params.filename,
-        ...(params.contentType && { contentType: params.contentType }),
+        ...(params.contentType && {contentType: params.contentType}),
       },
       ...options,
-    });
+    })
     // The signed URL PUT goes straight to storage, outside the API pipeline:
     // no auth header, and the body is raw bytes rather than JSON. Still uses
     // the client's fetch resolution so proxy config applies in Node.
-    const config = this.#client.config();
-    const doFetch =
-      config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction);
+    const config = this.#client.config()
+    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
     const putResponse = await doFetch(staged.uploadUrl, {
-      method: "PUT",
+      method: 'PUT',
       // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
       // bound, even though fetch accepts it at runtime.
       body: params.file as FetchBody,
       ...(params.contentType && {
-        headers: { "content-type": params.contentType },
+        headers: {'content-type': params.contentType},
       }),
       signal: options?.signal,
-    });
+    })
     if (!putResponse.ok) {
-      throw new Error(
-        `File upload failed: ${putResponse.status} ${putResponse.statusText}`,
-      );
+      throw new Error(`File upload failed: ${putResponse.status} ${putResponse.statusText}`)
     }
-    return this.#request<JobAccepted>(
-      `/imports/uploads/${staged.importId}/complete`,
-      {
-        method: "POST",
-        body: {},
-        ...options,
-      },
-    );
+    return this.#request<JobAccepted>(`/imports/uploads/${staged.importId}/complete`, {
+      method: 'POST',
+      body: {},
+      ...options,
+    })
   }
 
   /** Fetch the knowledge base. */
   get(options?: RequestOptions): Promise<KnowledgeBase> {
-    return _getKnowledgeBaseById(
-      this.#client,
-      this.#httpRequest,
-      this.#knowledgeBaseId,
-      options,
-    );
+    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
   }
 
   /** Edit the knowledge base's configuration. */
-  edit(
-    params: EditKnowledgeBaseParams,
-    options?: RequestOptions,
-  ): Promise<KnowledgeBase> {
-    return this.#request("", { method: "PATCH", body: params, ...options });
+  edit(params: EditKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> {
+    return this.#request('', {method: 'PATCH', body: params, ...options})
   }
 
   /** Delete the knowledge base and its generated content. */
   async delete(options?: RequestOptions): Promise<void> {
-    await this.#request("", { method: "DELETE", ...options });
+    await this.#request('', {method: 'DELETE', ...options})
   }
 
   /**
@@ -244,19 +220,17 @@ export class KnowledgeBaseHandle {
    * the returned job with {@link jobs}.
    */
   build(options?: RequestOptions): Promise<JobAccepted> {
-    return this.#request("/build", { method: "POST", ...options });
+    return this.#request('/build', {method: 'POST', ...options})
   }
 
   /** Cancel the running build, if any. */
-  cancelBuild(options?: RequestOptions): Promise<{ cancelled: boolean }> {
-    return this.#request("/build/cancel", { method: "POST", ...options });
+  cancelBuild(options?: RequestOptions): Promise<{cancelled: boolean}> {
+    return this.#request('/build/cancel', {method: 'POST', ...options})
   }
 
   /** Run an incremental refresh: re-check sources and apply what changed. */
-  refresh(
-    options?: RequestOptions,
-  ): Promise<{ jobId: string | null; started: boolean }> {
-    return this.#request("/refresh", { method: "POST", ...options });
+  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
+    return this.#request('/refresh', {method: 'POST', ...options})
   }
 
   /**
@@ -264,19 +238,19 @@ export class KnowledgeBaseHandle {
    * `json` format resolves to {@link Outline}; `markdown` and
    * `plain` resolve to a string.
    */
-  outline<const F extends RenderFormat = "json">(
-    params?: { format?: F },
+  outline<const F extends RenderFormat = 'json'>(
+    params?: {format?: F},
     options?: RequestOptions,
-  ): Promise<F extends "json" ? Outline : string> {
-    return this.#request("/outline", {
-      query: params?.format ? { format: params.format } : {},
+  ): Promise<F extends 'json' ? Outline : string> {
+    return this.#request('/outline', {
+      query: params?.format ? {format: params.format} : {},
       ...options,
-    });
+    })
   }
 
   /** What changed in the corpus since the last build. */
   changes(options?: RequestOptions): Promise<Changes> {
-    return this.#request("/changes", options);
+    return this.#request('/changes', options)
   }
 
   /** Imports: feed content into the knowledge base. */
@@ -292,130 +266,114 @@ export class KnowledgeBaseHandle {
       params: CreateImportParams | CreateFileImportParams,
       options?: RequestOptions,
     ): Promise<JobAccepted> =>
-      params.type === "file"
+      params.type === 'file'
         ? this.#uploadFile(params, options)
-        : this.#request("/imports", {
-            method: "POST",
+        : this.#request('/imports', {
+            method: 'POST',
             body: params,
             ...options,
           }),
-    list: (params?: ListOptions) =>
-      this.#list<ImportsResponse>("/imports", params),
-    get: (params: { importId: string }, options?: RequestOptions) =>
+    list: (params?: ListOptions) => this.#list<ImportsResponse>('/imports', params),
+    get: (params: {importId: string}, options?: RequestOptions) =>
       this.#request<ImportDetail>(`/imports/${params.importId}`, options),
     /** A short-lived signed URL for the original uploaded bytes. */
-    download: (params: { importId: string }, options?: RequestOptions) =>
-      this.#request<ImportDownloadResponse>(
-        `/imports/${params.importId}/download`,
-        options,
-      ),
-    delete: async (params: { importId: string }, options?: RequestOptions) => {
+    download: (params: {importId: string}, options?: RequestOptions) =>
+      this.#request<ImportDownloadResponse>(`/imports/${params.importId}/download`, options),
+    delete: async (params: {importId: string}, options?: RequestOptions) => {
       await this.#request<void>(`/imports/${params.importId}`, {
-        method: "DELETE",
+        method: 'DELETE',
         ...options,
-      });
+      })
     },
     /** Preview which pages a crawl would ingest, before committing to it. */
     crawlPreview: (params: CrawlPreviewParams, options?: RequestOptions) =>
-      this.#request<CrawlPreviewResponse>("/imports/crawl-preview", {
-        method: "POST",
+      this.#request<CrawlPreviewResponse>('/imports/crawl-preview', {
+        method: 'POST',
         body: params,
         ...options,
       }),
-  };
+  }
 
   /** Jobs: poll async work (builds, imports) to a terminal state. */
   jobs = {
-    get: (params: { jobId: string }, options?: RequestOptions) =>
+    get: (params: {jobId: string}, options?: RequestOptions) =>
       this.#request<Job>(`/jobs/${params.jobId}`, options),
-  };
+  }
 
   /** Issues: findings from builds awaiting triage. */
   issues = {
-    list: (
-      params?: { status?: "open" | "accepted" | "rejected" } & ListOptions,
-    ) =>
-      this.#list<IssuesResponse>("/issues", params, {
+    list: (params?: {status?: 'open' | 'accepted' | 'rejected'} & ListOptions) =>
+      this.#list<IssuesResponse>('/issues', params, {
         status: params?.status,
       }),
-    get: (params: { issueId: string }, options?: RequestOptions) =>
+    get: (params: {issueId: string}, options?: RequestOptions) =>
       this.#request<IssueDetail>(`/issues/${params.issueId}`, options),
     /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
-    resolve: (
-      params: { issueId: string } & ResolveIssueParams,
-      options?: RequestOptions,
-    ) => {
-      const { issueId, ...body } = params;
+    resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
+      const {issueId, ...body} = params
       return this.#request<ResolveIssueResponse>(`/issues/${issueId}/resolve`, {
-        method: "POST",
+        method: 'POST',
         body,
         ...options,
-      });
+      })
     },
-    dismiss: (params: { issueId: string }, options?: RequestOptions) =>
+    dismiss: (params: {issueId: string}, options?: RequestOptions) =>
       this.#request<DismissIssueResponse>(`/issues/${params.issueId}/dismiss`, {
-        method: "POST",
+        method: 'POST',
         ...options,
       }),
-    reopen: (params: { issueId: string }, options?: RequestOptions) =>
+    reopen: (params: {issueId: string}, options?: RequestOptions) =>
       this.#request<ReopenIssueResponse>(`/issues/${params.issueId}/reopen`, {
-        method: "POST",
+        method: 'POST',
         ...options,
       }),
     /** Apply already-accepted issues to the knowledge base in one batch. */
     apply: (params: ApplyIssuesParams, options?: RequestOptions) =>
-      this.#request<ApplyIssuesResponse>("/issues/apply", {
-        method: "POST",
+      this.#request<ApplyIssuesResponse>('/issues/apply', {
+        method: 'POST',
         body: params,
         ...options,
       }),
-  };
+  }
 
   /** Instructions: standing decisions that steer every build. */
   instructions = {
     create: (params: CreateInstructionParams, options?: RequestOptions) =>
-      this.#request<Instruction>("/instructions", {
-        method: "POST",
+      this.#request<Instruction>('/instructions', {
+        method: 'POST',
         body: params,
         ...options,
       }),
-    list: (params?: ListOptions) =>
-      this.#list<InstructionsResponse>("/instructions", params),
-    edit: (
-      params: { instructionId: string } & EditInstructionParams,
-      options?: RequestOptions,
-    ) => {
-      const { instructionId, ...body } = params;
+    list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
+    edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
+      const {instructionId, ...body} = params
       return this.#request<Instruction>(`/instructions/${instructionId}`, {
-        method: "PATCH",
+        method: 'PATCH',
         body,
         ...options,
-      });
+      })
     },
-    delete: async (
-      params: { instructionId: string },
-      options?: RequestOptions,
-    ) => {
+    delete: async (params: {instructionId: string}, options?: RequestOptions) => {
       await this.#request<void>(`/instructions/${params.instructionId}`, {
-        method: "DELETE",
+        method: 'DELETE',
         ...options,
-      });
+      })
     },
-  };
+  }
 
   /** Entries: the built outline, one entry per node. */
   entries = {
     /** List entries, optionally filtered by status or searched (`q`). */
     list: (
       params?: {
-        status?: EntryStatus;
-        q?: string;
-        mode?: "keyword" | "hybrid";
-        include?: "metadata" | "body";
-        paths?: string;
+        status?: EntryStatus
+        q?: string
+        mode?: 'keyword' | 'hybrid'
+        include?: 'metadata' | 'body'
+        paths?: string
       } & ListOptions,
     ) =>
-      this.#list<EntriesResponse>("/entries", params, {
+      this.#list<EntriesResponse>('/entries', params, {
         status: params?.status,
         q: params?.q,
         mode: params?.mode,
@@ -427,83 +385,71 @@ export class KnowledgeBaseHandle {
      * The default `json` format resolves to {@link EntryDetail};
      * `markdown` and `plain` resolve to a string.
      */
-    get: <const F extends RenderFormat = "json">(
-      params: { path: string; format?: F },
+    get: <const F extends RenderFormat = 'json'>(
+      params: {path: string; format?: F},
       options?: RequestOptions,
     ) =>
-      this.#request<F extends "json" ? EntryDetail : string>(
+      this.#request<F extends 'json' ? EntryDetail : string>(
         `/entries/${encodeURIComponent(params.path)}`,
         {
-          query: params.format ? { format: params.format } : {},
+          query: params.format ? {format: params.format} : {},
           ...options,
         },
       ),
-  };
+  }
 
   /** Sources: the distilled units builds cite. */
   sources = {
-    list: (params?: ListOptions) =>
-      this.#list<SourcesResponse>("/sources", params),
-    get: (params: { sourceId: string }, options?: RequestOptions) =>
+    list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
+    get: (params: {sourceId: string}, options?: RequestOptions) =>
       this.#request<SourceDetail>(`/sources/${params.sourceId}`, options),
     /**
      * Distilled source content, optionally a line range: the evidence behind
      * a citation or an issue.
      */
     content: (
-      params: { sourceId: string; startLine?: number; endLine?: number },
+      params: {sourceId: string; startLine?: number; endLine?: number},
       options?: RequestOptions,
     ) =>
-      this.#request<SourceContentResponse>(
-        `/sources/${params.sourceId}/content`,
-        {
-          query: _query({
-            startLine: params.startLine,
-            endLine: params.endLine,
-          }),
-          ...options,
-        },
-      ),
-    delete: async (params: { sourceId: string }, options?: RequestOptions) => {
-      await this.#request<void>(`/sources/${params.sourceId}`, {
-        method: "DELETE",
+      this.#request<SourceContentResponse>(`/sources/${params.sourceId}/content`, {
+        query: _query({
+          startLine: params.startLine,
+          endLine: params.endLine,
+        }),
         ...options,
-      });
+      }),
+    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/sources/${params.sourceId}`, {
+        method: 'DELETE',
+        ...options,
+      })
     },
-  };
+  }
 
   /** The audit feed: who did what, when. */
   activity = {
-    list: (params?: ListOptions) =>
-      this.#list<ActivityResponse>("/activity", params),
-  };
+    list: (params?: ListOptions) => this.#list<ActivityResponse>('/activity', params),
+  }
 
   /** Revisions: one per build, with an accounting report per revision. */
   revisions = {
-    list: (params?: ListOptions) =>
-      this.#list<RevisionsResponse>("/revisions", params),
-    report: (params: { revisionId: string }, options?: RequestOptions) =>
-      this.#request<RevisionReport>(
-        `/revisions/${params.revisionId}/report`,
-        options,
-      ),
+    list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
+    report: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionReport>(`/revisions/${params.revisionId}/report`, options),
     /** The outline as it was at a past build revision. */
-    outline: (params: { revisionId: string }, options?: RequestOptions) =>
-      this.#request<RevisionOutline>(
-        `/revisions/${params.revisionId}/outline`,
-        options,
-      ),
-  };
+    outline: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
+  }
 
   /** Crawl options for the knowledge base's web source. */
   crawlOptions = {
     edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
-      this.#request<CrawlOptions>("/crawl-options", {
-        method: "PATCH",
+      this.#request<CrawlOptions>('/crawl-options', {
+        method: 'PATCH',
         body: params,
         ...options,
       }),
-  };
+  }
 }
 
 /**
@@ -526,40 +472,38 @@ export class KnowledgeBaseHandle {
  * @beta
  */
 export class ContextClient {
-  #client: SanityClient;
-  #httpRequest: HttpRequest;
+  #client: SanityClient
+  #httpRequest: HttpRequest
 
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client;
-    this.#httpRequest = httpRequest;
+    this.#client = client
+    this.#httpRequest = httpRequest
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & { organizationId: string },
+      params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,
     ): Promise<KnowledgeBase> => {
-      const { organizationId, ...body } = params;
+      const {organizationId, ...body} = params
       return _request<KnowledgeBase>(this.#client, this.#httpRequest, {
         url: _collectionUrl(organizationId),
-        method: "POST",
+        method: 'POST',
         body,
         ...options,
-      });
+      })
     },
     /** List the organization's knowledge bases. */
-    list: (
-      params: { organizationId: string } & ListOptions,
-    ): Promise<KnowledgeBasesResponse> =>
+    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
       _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
         url: _collectionUrl(params.organizationId),
-        query: _query({ cursor: params.cursor, limit: params.limit }),
+        query: _query({cursor: params.cursor, limit: params.limit}),
         signal: params.signal,
         tag: params.tag,
       }),
-  };
+  }
 
   /**
    * A handle carrying everything scoped to one knowledge base, addressed by
@@ -567,11 +511,7 @@ export class ContextClient {
    * the first request and is reused after that.
    */
   knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
-    return new KnowledgeBaseHandle(
-      this.#client,
-      this.#httpRequest,
-      knowledgeBaseId,
-    );
+    return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
   }
 }
 
@@ -583,43 +523,41 @@ export class ContextClient {
  * @beta
  */
 export class ObservableContextClient {
-  #client: ObservableSanityClient;
-  #httpRequest: HttpRequest;
+  #client: ObservableSanityClient
+  #httpRequest: HttpRequest
 
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client;
-    this.#httpRequest = httpRequest;
+    this.#client = client
+    this.#httpRequest = httpRequest
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & { organizationId: string },
+      params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,
     ): Observable<KnowledgeBase> => {
-      const { organizationId, ...body } = params;
+      const {organizationId, ...body} = params
       return _observe(options?.signal, (signal) =>
         _request<KnowledgeBase>(this.#client, this.#httpRequest, {
           url: _collectionUrl(organizationId),
-          method: "POST",
+          method: 'POST',
           body,
           tag: options?.tag,
           signal,
         }),
-      );
+      )
     },
     /** List the organization's knowledge bases. */
-    list: (
-      params: { organizationId: string } & ListOptions,
-    ): Observable<KnowledgeBasesResponse> =>
+    list: (params: {organizationId: string} & ListOptions): Observable<KnowledgeBasesResponse> =>
       _observe(params.signal, (signal) =>
         _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
           url: _collectionUrl(params.organizationId),
-          query: _query({ cursor: params.cursor, limit: params.limit }),
+          query: _query({cursor: params.cursor, limit: params.limit}),
           tag: params.tag,
           signal,
         }),
       ),
-  };
+  }
 }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,0 +1,580 @@
+import {type FetchFunction} from 'get-it'
+
+type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
+import {type Observable} from 'rxjs'
+
+import {_observe, _request} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest} from '../types'
+import type {
+  ApplyIssuesParams,
+  ApplyIssuesResponse,
+  ActivityResponse,
+  Changes,
+  EntriesResponse,
+  EntryDetail,
+  EntryStatus,
+  ImportDetail,
+  ImportsResponse,
+  Instruction,
+  InstructionsResponse,
+  IssueDetail,
+  IssuesResponse,
+  Job,
+  JobAccepted,
+  Outline,
+  RevisionOutline,
+  RevisionReport,
+  RevisionsResponse,
+  SourceDetail,
+  SourcesResponse,
+  CrawlOptions,
+  CrawlPreviewParams,
+  CrawlPreviewResponse,
+  CreateImportParams,
+  CreateInstructionParams,
+  CreateKnowledgeBaseParams,
+  DismissIssueResponse,
+  EditCrawlOptionsParams,
+  EditInstructionParams,
+  EditKnowledgeBaseParams,
+  ImportDownloadResponse,
+  KnowledgeBase,
+  KnowledgeBasesResponse,
+  ReopenIssueResponse,
+  ResolveIssueParams,
+  ResolveIssueResponse,
+  SourceContentResponse,
+  StagedUpload,
+} from './types'
+import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types'
+
+type ListOptions = RequestOptions & {cursor?: string; limit?: number}
+
+type Client = SanityClient | ObservableSanityClient
+
+/**
+ * The knowledge base's org-scoped address. Every operation except the by-id
+ * read lives under `/organizations/{orgId}/knowledge-bases/{slug}`, but the
+ * handle is constructed from the id alone, so the address is resolved once
+ * through the by-id endpoint and reused.
+ */
+type ResolvedAddress = {organizationId: string; slug: string}
+
+function _getKnowledgeBaseById(
+  client: Client,
+  httpRequest: HttpRequest,
+  knowledgeBaseId: string,
+  options?: RequestOptions,
+): Promise<KnowledgeBase> {
+  return _request<KnowledgeBase>(client, httpRequest, {
+    url: `/context/knowledge-bases/${knowledgeBaseId}`,
+    ...options,
+  })
+}
+
+function _collectionUrl(organizationId: string): string {
+  return `/context/organizations/${organizationId}/knowledge-bases`
+}
+
+/** Serialize defined values into query params, dropping the undefined ones. */
+function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(entries).flatMap(([key, value]) =>
+      value === undefined ? [] : [[key, `${value}`]],
+    ),
+  )
+}
+
+/**
+ * Everything scoped to one knowledge base, addressed by its id alone.
+ * Construct via {@link ContextClient.knowledgeBase}.
+ *
+ * @beta
+ */
+export class KnowledgeBaseHandle {
+  #client: SanityClient
+  #httpRequest: HttpRequest
+  #knowledgeBaseId: string
+  #address: Promise<ResolvedAddress> | undefined
+
+  constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+    this.#knowledgeBaseId = knowledgeBaseId
+  }
+
+  /** The knowledge base id this handle was constructed with. */
+  get knowledgeBaseId(): string {
+    return this.#knowledgeBaseId
+  }
+
+  // The resolution is shared by every method on the handle, so it must not
+  // carry any one caller's abort signal: aborting one request would reject
+  // the cached promise for every concurrent caller. An aborted caller still
+  // rejects, because its own follow-up request starts with the aborted
+  // signal.
+  #resolveAddress(): Promise<ResolvedAddress> {
+    this.#address ??= _getKnowledgeBaseById(
+      this.#client,
+      this.#httpRequest,
+      this.#knowledgeBaseId,
+    ).then(
+      (kb) => ({organizationId: kb.organizationId, slug: kb.slug}),
+      (err) => {
+        // A failed resolution must not poison the handle for retries.
+        this.#address = undefined
+        throw err
+      },
+    )
+    return this.#address
+  }
+
+  async #request<R>(
+    suffix: string,
+    reqOptions: {
+      method?: string
+      body?: unknown
+      query?: Record<string, string>
+    } & RequestOptions = {},
+  ): Promise<R> {
+    const address = await this.#resolveAddress()
+    return _request<R>(this.#client, this.#httpRequest, {
+      url: `${_collectionUrl(address.organizationId)}/${address.slug}${suffix}`,
+      ...reqOptions,
+    })
+  }
+
+  /** Shared shape of every paginated list endpoint under the handle. */
+  #list<R>(
+    suffix: string,
+    params?: ListOptions,
+    extraQuery?: Record<string, string | undefined>,
+  ): Promise<R> {
+    return this.#request<R>(suffix, {
+      query: _query({
+        cursor: params?.cursor,
+        limit: params?.limit,
+        ...extraQuery,
+      }),
+      signal: params?.signal,
+      tag: params?.tag,
+    })
+  }
+
+  async #uploadFile(
+    params: CreateFileImportParams,
+    options?: RequestOptions,
+  ): Promise<JobAccepted> {
+    const staged = await this.#request<StagedUpload>('/imports/uploads', {
+      method: 'POST',
+      body: {
+        filename: params.filename,
+        ...(params.contentType && {contentType: params.contentType}),
+      },
+      ...options,
+    })
+    // The signed URL PUT goes straight to storage, outside the API pipeline:
+    // no auth header, and the body is raw bytes rather than JSON. Still uses
+    // the client's fetch resolution so proxy config applies in Node.
+    const config = this.#client.config()
+    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
+    const putResponse = await doFetch(staged.uploadUrl, {
+      method: 'PUT',
+      // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
+      // bound, even though fetch accepts it at runtime.
+      body: params.file as FetchBody,
+      ...(params.contentType && {
+        headers: {'content-type': params.contentType},
+      }),
+      signal: options?.signal,
+    })
+    if (!putResponse.ok) {
+      throw new Error(`File upload failed: ${putResponse.status} ${putResponse.statusText}`)
+    }
+    return this.#request<JobAccepted>(`/imports/uploads/${staged.importId}/complete`, {
+      method: 'POST',
+      body: {},
+      ...options,
+    })
+  }
+
+  /** Fetch the knowledge base. */
+  get(options?: RequestOptions): Promise<KnowledgeBase> {
+    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
+  }
+
+  /** Edit the knowledge base's configuration. */
+  edit(params: EditKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> {
+    return this.#request('', {method: 'PATCH', body: params, ...options})
+  }
+
+  /** Delete the knowledge base and its generated content. */
+  async delete(options?: RequestOptions): Promise<void> {
+    await this.#request('', {method: 'DELETE', ...options})
+  }
+
+  /**
+   * Build the knowledge base. The server waits for pending import processing
+   * before assembling, so importing and building back to back is safe. Track
+   * the returned job with {@link jobs}.
+   */
+  build(options?: RequestOptions): Promise<JobAccepted> {
+    return this.#request('/build', {method: 'POST', ...options})
+  }
+
+  /** Cancel the running build, if any. */
+  cancelBuild(options?: RequestOptions): Promise<{cancelled: boolean}> {
+    return this.#request('/build/cancel', {method: 'POST', ...options})
+  }
+
+  /** Run an incremental refresh: re-check sources and apply what changed. */
+  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
+    return this.#request('/refresh', {method: 'POST', ...options})
+  }
+
+  /**
+   * The built outline: every entry, ordered, with stats. The default
+   * `json` format resolves to {@link Outline}; `markdown` and
+   * `plain` resolve to a string.
+   */
+  outline<const F extends RenderFormat = 'json'>(
+    params?: {format?: F},
+    options?: RequestOptions,
+  ): Promise<F extends 'json' ? Outline : string> {
+    return this.#request('/outline', {
+      query: params?.format ? {format: params.format} : {},
+      ...options,
+    })
+  }
+
+  /** What changed in the corpus since the last build. */
+  changes(options?: RequestOptions): Promise<Changes> {
+    return this.#request('/changes', options)
+  }
+
+  /** Imports: feed content into the knowledge base. */
+  imports = {
+    /**
+     * Import content. One entry point, discriminated on `type`: inline
+     * `text`, a website `crawl`, a Sanity `dataset` bind, or a `file`
+     * upload. Processing queues automatically. The file variant stages the
+     * upload, PUTs the bytes to a signed storage URL, and confirms; the
+     * bytes never pass through the Context API.
+     */
+    create: (
+      params: CreateImportParams | CreateFileImportParams,
+      options?: RequestOptions,
+    ): Promise<JobAccepted> =>
+      params.type === 'file'
+        ? this.#uploadFile(params, options)
+        : this.#request('/imports', {
+            method: 'POST',
+            body: params,
+            ...options,
+          }),
+    list: (params?: ListOptions) => this.#list<ImportsResponse>('/imports', params),
+    get: (params: {importId: string}, options?: RequestOptions) =>
+      this.#request<ImportDetail>(`/imports/${params.importId}`, options),
+    /** A short-lived signed URL for the original uploaded bytes. */
+    download: (params: {importId: string}, options?: RequestOptions) =>
+      this.#request<ImportDownloadResponse>(`/imports/${params.importId}/download`, options),
+    delete: async (params: {importId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/imports/${params.importId}`, {
+        method: 'DELETE',
+        ...options,
+      })
+    },
+    /** Preview which pages a crawl would ingest, before committing to it. */
+    crawlPreview: (params: CrawlPreviewParams, options?: RequestOptions) =>
+      this.#request<CrawlPreviewResponse>('/imports/crawl-preview', {
+        method: 'POST',
+        body: params,
+        ...options,
+      }),
+  }
+
+  /** Jobs: poll async work (builds, imports) to a terminal state. */
+  jobs = {
+    get: (params: {jobId: string}, options?: RequestOptions) =>
+      this.#request<Job>(`/jobs/${params.jobId}`, options),
+  }
+
+  /** Issues: findings from builds awaiting triage. */
+  issues = {
+    list: (params?: {status?: 'open' | 'accepted' | 'rejected'} & ListOptions) =>
+      this.#list<IssuesResponse>('/issues', params, {
+        status: params?.status,
+      }),
+    get: (params: {issueId: string}, options?: RequestOptions) =>
+      this.#request<IssueDetail>(`/issues/${params.issueId}`, options),
+    /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
+    resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
+      const {issueId, ...body} = params
+      return this.#request<ResolveIssueResponse>(`/issues/${issueId}/resolve`, {
+        method: 'POST',
+        body,
+        ...options,
+      })
+    },
+    dismiss: (params: {issueId: string}, options?: RequestOptions) =>
+      this.#request<DismissIssueResponse>(`/issues/${params.issueId}/dismiss`, {
+        method: 'POST',
+        ...options,
+      }),
+    reopen: (params: {issueId: string}, options?: RequestOptions) =>
+      this.#request<ReopenIssueResponse>(`/issues/${params.issueId}/reopen`, {
+        method: 'POST',
+        ...options,
+      }),
+    /** Apply already-accepted issues to the knowledge base in one batch. */
+    apply: (params: ApplyIssuesParams, options?: RequestOptions) =>
+      this.#request<ApplyIssuesResponse>('/issues/apply', {
+        method: 'POST',
+        body: params,
+        ...options,
+      }),
+  }
+
+  /** Instructions: standing decisions that steer every build. */
+  instructions = {
+    create: (params: CreateInstructionParams, options?: RequestOptions) =>
+      this.#request<Instruction>('/instructions', {
+        method: 'POST',
+        body: params,
+        ...options,
+      }),
+    list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
+    edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
+      const {instructionId, ...body} = params
+      return this.#request<Instruction>(`/instructions/${instructionId}`, {
+        method: 'PATCH',
+        body,
+        ...options,
+      })
+    },
+    delete: async (params: {instructionId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/instructions/${params.instructionId}`, {
+        method: 'DELETE',
+        ...options,
+      })
+    },
+  }
+
+  /** Entries: the built outline, one entry per node. */
+  entries = {
+    /** List entries, optionally filtered by status or searched (`q`). */
+    list: (
+      params?: {
+        status?: EntryStatus
+        q?: string
+        mode?: 'keyword' | 'hybrid'
+        include?: 'metadata' | 'body'
+        paths?: string
+      } & ListOptions,
+    ) =>
+      this.#list<EntriesResponse>('/entries', params, {
+        status: params?.status,
+        q: params?.q,
+        mode: params?.mode,
+        include: params?.include,
+        paths: params?.paths,
+      }),
+    /**
+     * One entry with its full body, by outline path (e.g. `billing/refunds`).
+     * The default `json` format resolves to {@link EntryDetail};
+     * `markdown` and `plain` resolve to a string.
+     */
+    get: <const F extends RenderFormat = 'json'>(
+      params: {path: string; format?: F},
+      options?: RequestOptions,
+    ) =>
+      this.#request<F extends 'json' ? EntryDetail : string>(
+        `/entries/${encodeURIComponent(params.path)}`,
+        {
+          query: params.format ? {format: params.format} : {},
+          ...options,
+        },
+      ),
+  }
+
+  /** Sources: the distilled units builds cite. */
+  sources = {
+    list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
+    get: (params: {sourceId: string}, options?: RequestOptions) =>
+      this.#request<SourceDetail>(`/sources/${params.sourceId}`, options),
+    /**
+     * Distilled source content, optionally a line range: the evidence behind
+     * a citation or an issue.
+     */
+    content: (
+      params: {sourceId: string; startLine?: number; endLine?: number},
+      options?: RequestOptions,
+    ) =>
+      this.#request<SourceContentResponse>(`/sources/${params.sourceId}/content`, {
+        query: _query({
+          startLine: params.startLine,
+          endLine: params.endLine,
+        }),
+        ...options,
+      }),
+    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/sources/${params.sourceId}`, {
+        method: 'DELETE',
+        ...options,
+      })
+    },
+  }
+
+  /** The audit feed: who did what, when. */
+  activity = {
+    list: (params?: ListOptions) => this.#list<ActivityResponse>('/activity', params),
+  }
+
+  /** Revisions: one per build, with an accounting report per revision. */
+  revisions = {
+    list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
+    report: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionReport>(`/revisions/${params.revisionId}/report`, options),
+    /** The outline as it was at a past build revision. */
+    outline: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
+  }
+
+  /** Crawl options for the knowledge base's web source. */
+  crawlOptions = {
+    edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
+      this.#request<CrawlOptions>('/crawl-options', {
+        method: 'PATCH',
+        body: params,
+        ...options,
+      }),
+  }
+
+  /**
+   * An ordinary `@sanity/client` bound to the knowledge base's dataset, for
+   * GROQ reads, listeners, and anything else the platform ships for
+   * documents. Not a wrapper: the returned client is a plain client.
+   */
+  async contentClient(options?: RequestOptions): Promise<SanityClient> {
+    const kb = await this.get(options)
+    if (!kb.sanityProjectId || !kb.sanityDatasetId) {
+      throw new Error(`Knowledge base "${this.#knowledgeBaseId}" has no dataset binding`)
+    }
+    return this.#client.withConfig({
+      projectId: kb.sanityProjectId,
+      dataset: kb.sanityDatasetId,
+      useCdn: false,
+    })
+  }
+}
+
+/**
+ * `client.context` — knowledge bases and everything scoped to them.
+ *
+ * @example Zero to knowledge base
+ * ```ts
+ * const created = await client.context.knowledgeBases.create({
+ *   organizationId: 'org123',
+ *   name: 'Support docs',
+ *   description: 'Product docs and troubleshooting guides',
+ *   sanityProjectId: 'abc123',
+ *   sanityDatasetId: 'production',
+ * })
+ * const kb = client.context.knowledgeBase(created.publicId)
+ * await kb.imports.create({type: 'text', title: 'Refund policy', content: refundMd})
+ * const {jobId} = await kb.build()
+ * ```
+ *
+ * @beta
+ */
+export class ContextClient {
+  #client: SanityClient
+  #httpRequest: HttpRequest
+
+  constructor(client: SanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /** The knowledge base collection. */
+  knowledgeBases = {
+    /** Create a knowledge base. Requires provisioning access to the target project. */
+    create: (
+      params: CreateKnowledgeBaseParams & {organizationId: string},
+      options?: RequestOptions,
+    ): Promise<KnowledgeBase> => {
+      const {organizationId, ...body} = params
+      return _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+        url: _collectionUrl(organizationId),
+        method: 'POST',
+        body,
+        ...options,
+      })
+    },
+    /** List the organization's knowledge bases. */
+    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
+      _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
+        url: _collectionUrl(params.organizationId),
+        query: _query({cursor: params.cursor, limit: params.limit}),
+        signal: params.signal,
+        tag: params.tag,
+      }),
+  }
+
+  /**
+   * A handle carrying everything scoped to one knowledge base, addressed by
+   * id alone. Synchronous: the id-to-address resolution happens lazily on
+   * the first request and is reused after that.
+   */
+  knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
+    return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
+  }
+}
+
+/**
+ * Observable counterpart of {@link ContextClient}. Collection-level methods
+ * only; the per-knowledge-base handle is promise-based, so use the promise
+ * client (`client.context.knowledgeBase(id)`) for handle operations.
+ *
+ * @beta
+ */
+export class ObservableContextClient {
+  #client: ObservableSanityClient
+  #httpRequest: HttpRequest
+
+  constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /** The knowledge base collection. */
+  knowledgeBases = {
+    /** Create a knowledge base. Requires provisioning access to the target project. */
+    create: (
+      params: CreateKnowledgeBaseParams & {organizationId: string},
+      options?: RequestOptions,
+    ): Observable<KnowledgeBase> => {
+      const {organizationId, ...body} = params
+      return _observe(options?.signal, (signal) =>
+        _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+          url: _collectionUrl(organizationId),
+          method: 'POST',
+          body,
+          tag: options?.tag,
+          signal,
+        }),
+      )
+    },
+    /** List the organization's knowledge bases. */
+    list: (params: {organizationId: string} & ListOptions): Observable<KnowledgeBasesResponse> =>
+      _observe(params.signal, (signal) =>
+        _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
+          url: _collectionUrl(params.organizationId),
+          query: _query({cursor: params.cursor, limit: params.limit}),
+          tag: params.tag,
+          signal,
+        }),
+      ),
+  }
+}

--- a/src/context/reads.ts
+++ b/src/context/reads.ts
@@ -1,0 +1,206 @@
+import {lastValueFrom} from 'rxjs'
+
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest, QueryParams} from '../types'
+import {_fetch, _organizationId} from './store'
+import type {
+  ContextRequestOptions,
+  ConversationDoc,
+  Entry,
+  EntryDoc,
+  InstructionDoc,
+  IssueDoc,
+  McpDoc,
+} from './types'
+
+type Client = SanityClient | ObservableSanityClient
+
+const ENTRY_TYPE = 'sanity.context.entry'
+const ISSUE_TYPE = 'sanity.context.issue'
+const INSTRUCTION_TYPE = 'sanity.context.instruction'
+const MCP_TYPE = 'sanity.context.mcp'
+const CONVERSATION_TYPE = 'sanity.context.conversation'
+
+/** Documents per page while a list read drains the store to completion. */
+const PAGE_SIZE = 200
+
+/** MCP endpoint configurations are few; one capped page covers them all. */
+const MCP_LIST_LIMIT = 500
+
+/** Keyset cursor over the `| order(_createdAt asc, _id asc)` total order. */
+const CREATED_AT_KEYSET = '(_createdAt > $c || (_createdAt == $c && _id > $i))'
+
+function _one<R>(
+  client: Client,
+  httpRequest: HttpRequest,
+  query: string,
+  params: QueryParams,
+  options?: ContextRequestOptions,
+): Promise<R | null> {
+  return lastValueFrom(_fetch<R | null>(client, httpRequest, query, params, options))
+}
+
+/**
+ * Drain every page of a `(_createdAt, _id)`-keyset read. Termination keys on
+ * the raw page length before anything looks at the rows: a short page means
+ * the store had nothing more to give, and filtering must never shorten a
+ * full page into a false stop.
+ */
+async function _drainByCreatedAt<T extends {_createdAt: string; _id: string}>(
+  client: Client,
+  httpRequest: HttpRequest,
+  filter: string,
+  params: QueryParams,
+  options?: ContextRequestOptions,
+): Promise<T[]> {
+  const all: T[] = []
+  let cursor: {c: string; i: string} | undefined
+  for (;;) {
+    const pagedFilter = cursor ? `${filter} && ${CREATED_AT_KEYSET}` : filter
+    const query = `*[${pagedFilter}] | order(_createdAt asc, _id asc) [0...${PAGE_SIZE}]`
+    const page = await lastValueFrom(
+      _fetch<T[]>(client, httpRequest, query, cursor ? {...params, ...cursor} : params, options),
+    )
+    all.push(...page)
+    if (page.length < PAGE_SIZE) return all
+    const last = page[page.length - 1]
+    cursor = {c: last._createdAt, i: last._id}
+  }
+}
+
+/** @internal */
+export function _readEntry(
+  client: Client,
+  httpRequest: HttpRequest,
+  knowledgeBaseId: string,
+  path: string,
+  options?: ContextRequestOptions,
+): Promise<EntryDoc | null> {
+  return _one<EntryDoc>(
+    client,
+    httpRequest,
+    `*[_type == "${ENTRY_TYPE}" && knowledgeBaseId == $kb && path == $path][0]`,
+    {kb: knowledgeBaseId, path},
+    options,
+  )
+}
+
+/** @internal */
+export async function _listEntries(
+  client: Client,
+  httpRequest: HttpRequest,
+  knowledgeBaseId: string,
+  options?: ContextRequestOptions,
+): Promise<Entry[]> {
+  const all: Entry[] = []
+  let after = ''
+  for (;;) {
+    const query = `*[_type == "${ENTRY_TYPE}" && knowledgeBaseId == $kb && path > $after] | order(path asc) [0...${PAGE_SIZE}] {_id, path, title, tldr, status}`
+    const page = await lastValueFrom(
+      _fetch<Entry[]>(client, httpRequest, query, {kb: knowledgeBaseId, after}, options),
+    )
+    all.push(...page)
+    if (page.length < PAGE_SIZE) return all
+    after = page[page.length - 1].path
+  }
+}
+
+/** @internal */
+export function _listIssues(
+  client: Client,
+  httpRequest: HttpRequest,
+  knowledgeBaseId: string,
+  status: 'open' | 'accepted' | 'rejected' | undefined,
+  options?: ContextRequestOptions,
+): Promise<IssueDoc[]> {
+  const statusFilter = status === undefined ? '' : ' && status == $status'
+  return _drainByCreatedAt<IssueDoc>(
+    client,
+    httpRequest,
+    `_type == "${ISSUE_TYPE}" && knowledgeBaseId == $kb${statusFilter}`,
+    status === undefined ? {kb: knowledgeBaseId} : {kb: knowledgeBaseId, status},
+    options,
+  )
+}
+
+/** @internal */
+export function _readIssue(
+  client: Client,
+  httpRequest: HttpRequest,
+  knowledgeBaseId: string,
+  issueId: string,
+  options?: ContextRequestOptions,
+): Promise<IssueDoc | null> {
+  return _one<IssueDoc>(
+    client,
+    httpRequest,
+    `*[_type == "${ISSUE_TYPE}" && knowledgeBaseId == $kb && _id == $id][0]`,
+    {kb: knowledgeBaseId, id: issueId},
+    options,
+  )
+}
+
+/** @internal */
+export function _listInstructions(
+  client: Client,
+  httpRequest: HttpRequest,
+  knowledgeBaseId: string,
+  options?: ContextRequestOptions,
+): Promise<InstructionDoc[]> {
+  return _drainByCreatedAt<InstructionDoc>(
+    client,
+    httpRequest,
+    `_type == "${INSTRUCTION_TYPE}" && knowledgeBaseId == $kb && schemaVersion == 1`,
+    {kb: knowledgeBaseId},
+    options,
+  )
+}
+
+/** @internal */
+export function _listMcpEndpoints(
+  client: Client,
+  httpRequest: HttpRequest,
+  options?: ContextRequestOptions,
+): Promise<McpDoc[]> {
+  return lastValueFrom(
+    _fetch<McpDoc[]>(
+      client,
+      httpRequest,
+      `*[_type == "${MCP_TYPE}" && organizationId == $org] | order(_createdAt asc, _id asc) [0...${MCP_LIST_LIMIT}]`,
+      {org: _organizationId(client)},
+      options,
+    ),
+  )
+}
+
+/** @internal */
+export function _readMcpEndpoint(
+  client: Client,
+  httpRequest: HttpRequest,
+  name: string,
+  options?: ContextRequestOptions,
+): Promise<McpDoc | null> {
+  return _one<McpDoc>(
+    client,
+    httpRequest,
+    `*[_type == "${MCP_TYPE}" && organizationId == $org && name == $name][0]`,
+    {org: _organizationId(client), name},
+    options,
+  )
+}
+
+/** @internal */
+export function _readConversation(
+  client: Client,
+  httpRequest: HttpRequest,
+  threadId: string,
+  options?: ContextRequestOptions,
+): Promise<ConversationDoc | null> {
+  return _one<ConversationDoc>(
+    client,
+    httpRequest,
+    `*[_type == "${CONVERSATION_TYPE}" && organizationId == $org && threadId == $threadId][0]`,
+    {org: _organizationId(client), threadId},
+    options,
+  )
+}

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -1,0 +1,95 @@
+import {type Observable, throwError} from 'rxjs'
+import {map} from 'rxjs/operators'
+
+import {_requestObservable, getQuerySizeLimit} from '../data/dataMethods'
+import {encodeQueryString} from '../data/encodeQueryString'
+import {
+  _connectListenEventSource,
+  defaultOptions as defaultListenOptions,
+  type ListenEventFromOptions,
+  MAX_URL_LENGTH,
+  possibleOptions as possibleListenOptions,
+} from '../data/listen'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest, QueryParams, ResumableListenEventNames, SanityDocument} from '../types'
+import defaults from '../util/defaults'
+import {pick} from '../util/pick'
+import {
+  type ContextListenOptions,
+  type ContextRequestOptions,
+  possibleStoreRequestOptions,
+} from './types'
+
+type Client = SanityClient | ObservableSanityClient
+
+function storeUrl(client: Client, suffix: 'query' | 'listen'): string {
+  const organizationId = client.config().context?.organizationId
+
+  if (!organizationId) {
+    throw new Error('`context.organizationId` must be configured to query Context documents')
+  }
+
+  return `/context/organizations/${encodeURIComponent(organizationId)}/${suffix}`
+}
+
+/** @internal */
+export function _fetch<R>(
+  client: Client,
+  httpRequest: HttpRequest,
+  query: string,
+  params?: QueryParams,
+  options?: ContextRequestOptions,
+): Observable<R> {
+  const url = storeUrl(client, 'query')
+
+  // Mirrors `client.fetch`: GET while the query fits in the URL, POST beyond that.
+  const useGet = encodeQueryString({query, params}).length < getQuerySizeLimit
+  const request = useGet
+    ? {
+        method: 'GET',
+        url: `${url}${encodeQueryString({query, params})}`,
+      }
+    : {
+        method: 'POST',
+        url,
+        body: {query, params: params ?? {}},
+      }
+
+  return _requestObservable<{result: R}>(client, httpRequest, {
+    ...request,
+    ...pick(options || {}, possibleStoreRequestOptions),
+  }).pipe(map((response) => response.result))
+}
+
+/** @internal */
+export function _listen<Opts extends ContextListenOptions | undefined = undefined>(
+  client: Client,
+  query: string,
+  params?: QueryParams,
+  options?: Opts,
+): Observable<ListenEventFromOptions<SanityDocument, Opts>> {
+  const opts: ContextListenOptions = options ?? {}
+
+  // Mirrors `_listen` in data/listen.ts, but against the Context store's listen endpoint
+  const {requestTagPrefix} = client.config()
+  const tag = opts.tag && requestTagPrefix ? [requestTagPrefix, opts.tag].join('.') : opts.tag
+  const listenOpts = pick({...defaults(opts, defaultListenOptions), tag}, possibleListenOptions)
+  const qs = encodeQueryString({
+    query,
+    params,
+    options: listenOpts,
+  })
+
+  const uri = `${client.getUrl(storeUrl(client, 'listen'))}${qs}`
+  if (uri.length > MAX_URL_LENGTH) {
+    return throwError(() => new Error('Query too large for listener'))
+  }
+
+  const events: ResumableListenEventNames[] = opts.events ? opts.events : ['mutation']
+
+  return _connectListenEventSource<ListenEventFromOptions<SanityDocument, Opts>>(
+    client,
+    uri,
+    events,
+  )
+}

--- a/src/context/store.ts
+++ b/src/context/store.ts
@@ -22,14 +22,19 @@ import {
 
 type Client = SanityClient | ObservableSanityClient
 
-function storeUrl(client: Client, suffix: 'query' | 'listen'): string {
+/** @internal */
+export function _organizationId(client: Client): string {
   const organizationId = client.config().context?.organizationId
 
   if (!organizationId) {
     throw new Error('`context.organizationId` must be configured to query Context documents')
   }
 
-  return `/context/organizations/${encodeURIComponent(organizationId)}/${suffix}`
+  return organizationId
+}
+
+function storeUrl(client: Client, suffix: 'query' | 'listen'): string {
+  return `/context/organizations/${encodeURIComponent(_organizationId(client))}/${suffix}`
 }
 
 /** @internal */

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -36,13 +36,6 @@ export type ContextListenOptions =
   | Omit<ResumableListenOptions, 'includeAllVersions'>
 
 /**
- * Render format for outline and entry reads. `json` returns the typed
- * shape; `markdown` and `plain` return the rendered text as a string.
- * @beta
- */
-export type RenderFormat = 'json' | 'markdown' | 'plain'
-
-/**
  * A file import. The client stages the upload, PUTs the bytes straight to
  * storage with a signed URL, and confirms. The Context API never holds the
  * file content.
@@ -64,28 +57,17 @@ type KnowledgeBasePath = '/{apiVersion}/context/knowledge-bases/{knowledgeBaseId
 type ImportsPath = `${KnowledgeBasePath}/imports`
 type ImportPath = `${KnowledgeBasePath}/imports/{importId}`
 type UploadsPath = `${KnowledgeBasePath}/imports/uploads`
-type CrawlPreviewPath = `${KnowledgeBasePath}/imports/crawl-preview`
-type OutlinePath = `${KnowledgeBasePath}/outline`
-type EntryPath = `${KnowledgeBasePath}/entries/{entryPath}`
+type EntryRebuildPath = `${KnowledgeBasePath}/entries/{entryPath}/rebuild`
 type SourcesPath = `${KnowledgeBasePath}/sources`
 type SourcePath = `${KnowledgeBasePath}/sources/{sourceId}`
 type SourceContentPath = `${KnowledgeBasePath}/sources/{sourceId}/content`
-type ChangesPath = `${KnowledgeBasePath}/changes`
-type ActivityPath = `${KnowledgeBasePath}/activity`
-type RevisionsPath = `${KnowledgeBasePath}/revisions`
-type RevisionReportPath = `${KnowledgeBasePath}/revisions/{revisionId}/report`
-type RevisionOutlinePath = `${KnowledgeBasePath}/revisions/{revisionId}/outline`
-type IssuePath = `${KnowledgeBasePath}/issues/{issueId}`
 type IssuesApplyPath = `${KnowledgeBasePath}/issues/apply`
 type InstructionPath = `${KnowledgeBasePath}/instructions/{instructionId}`
-type CrawlOptionsPath = `${KnowledgeBasePath}/crawl-options`
 type JobPath = `${KnowledgeBasePath}/jobs/{jobId}`
-type IssuesPath = `${KnowledgeBasePath}/issues`
 type IssueResolvePath = `${KnowledgeBasePath}/issues/{issueId}/resolve`
 type IssueDismissPath = `${KnowledgeBasePath}/issues/{issueId}/dismiss`
 type IssueReopenPath = `${KnowledgeBasePath}/issues/{issueId}/reopen`
 type InstructionsPath = `${KnowledgeBasePath}/instructions`
-type EntriesPath = `${KnowledgeBasePath}/entries`
 
 type JsonResponse<T> = T extends {content: {'application/json': infer R}} ? R : never
 type JsonBody<T> = T extends {
@@ -127,12 +109,13 @@ export type JobAccepted = JsonResponse<
 /** @beta */
 export type Job = JsonResponse<paths[JobPath]['get']['responses']['200']>
 
-/** @beta */
-export type IssuesResponse = JsonResponse<paths[IssuesPath]['get']['responses']['200']>
-/** @beta */
-export type Issue = IssuesResponse['data'][number]
-/** @beta */
-export type IssueDetail = JsonResponse<paths[IssuePath]['get']['responses']['200']>
+/**
+ * Accepted entry rebuild: the job to poll plus every entry the rebuild
+ * touches.
+ * @beta
+ */
+export type RebuildEntryResponse = JsonResponse<paths[EntryRebuildPath]['post']['responses']['202']>
+
 /** @beta */
 export type ApplyIssuesParams = JsonBody<paths[IssuesApplyPath]['post']>
 /** @beta */
@@ -148,17 +131,17 @@ export type ReopenIssueResponse = JsonResponse<paths[IssueReopenPath]['post']['r
 
 /** @beta */
 export type CreateInstructionParams = JsonBody<paths[InstructionsPath]['post']>
-/** @beta */
-export type InstructionsResponse = JsonResponse<paths[InstructionsPath]['get']['responses']['200']>
-/** @beta */
-export type Instruction = InstructionsResponse['data'][number]
+/**
+ * A standing instruction, as the instruction endpoints return it.
+ * @beta
+ */
+export type Instruction = JsonResponse<paths[InstructionPath]['patch']['responses']['200']>
+/** The created instruction, wrapped the way the create endpoint returns it. @beta */
+export type CreateInstructionResponse = JsonResponse<
+  paths[InstructionsPath]['post']['responses']['201']
+>
 /** @beta */
 export type EditInstructionParams = JsonBody<paths[InstructionPath]['patch']>
-
-/** @beta */
-export type EntriesResponse = JsonResponse<paths[EntriesPath]['get']['responses']['200']>
-/** @beta */
-export type Entry = EntriesResponse['data'][number]
 
 /** @beta */
 export type KnowledgeBasesResponse = JsonResponse<
@@ -185,16 +168,6 @@ export type ImportDownloadResponse = JsonResponse<
 export type StagedUpload = JsonResponse<paths[UploadsPath]['post']['responses']['201']>
 
 /** @beta */
-export type CrawlPreviewParams = JsonBody<paths[CrawlPreviewPath]['post']>
-/** @beta */
-export type CrawlPreviewResponse = JsonResponse<paths[CrawlPreviewPath]['post']['responses']['200']>
-
-/** @beta */
-export type Outline = JsonResponse<paths[OutlinePath]['get']['responses']['200']>
-/** @beta */
-export type EntryDetail = JsonResponse<paths[EntryPath]['get']['responses']['200']>
-
-/** @beta */
 export type SourcesResponse = JsonResponse<paths[SourcesPath]['get']['responses']['200']>
 /** @beta */
 export type Source = SourcesResponse['data'][number]
@@ -204,29 +177,6 @@ export type SourceDetail = JsonResponse<paths[SourcePath]['get']['responses']['2
 export type SourceContentResponse = JsonResponse<
   paths[SourceContentPath]['get']['responses']['200']
 >
-
-/** @beta */
-export type Changes = JsonResponse<paths[ChangesPath]['get']['responses']['200']>
-/** @beta */
-export type ActivityResponse = JsonResponse<paths[ActivityPath]['get']['responses']['200']>
-/** @beta */
-export type ActivityEvent = ActivityResponse['data'][number]
-
-/** @beta */
-export type RevisionsResponse = JsonResponse<paths[RevisionsPath]['get']['responses']['200']>
-/** @beta */
-export type Revision = RevisionsResponse['data'][number]
-/** @beta */
-export type RevisionReport = JsonResponse<paths[RevisionReportPath]['get']['responses']['200']>
-/** @beta */
-export type RevisionOutline = JsonResponse<paths[RevisionOutlinePath]['get']['responses']['200']>
-
-/** @beta */
-export type EditCrawlOptionsParams = JsonBody<paths[CrawlOptionsPath]['patch']>
-/** @beta */
-export type CrawlOptions = JsonResponse<paths[CrawlOptionsPath]['patch']['responses']['200']>
-/** @beta */
-export type EntryStatus = 'virtual' | 'outlined' | 'filled' | 'stale' | 'generation_failed'
 
 /**
  * A recorded conversation: one agent thread's transcript plus the
@@ -255,3 +205,24 @@ export type EntryDoc = components['schemas']['EntryDoc']
 export type IssueDoc = components['schemas']['IssueDoc']
 /** @beta */
 export type InstructionDoc = components['schemas']['InstructionDoc']
+/**
+ * The raw `sanity.context.mcp` document shape (an MCP endpoint
+ * configuration), as stored in the organization's document store. For
+ * typing GROQ reads.
+ * @beta
+ */
+export type McpDoc = components['schemas']['McpDoc']
+
+/**
+ * The metadata view of an entry, as `entries.list` projects it. Bodies stay
+ * behind `entries.get` (or a GROQ read through `context.fetch`).
+ * @beta
+ */
+export type Entry = Pick<EntryDoc, '_id' | 'path' | 'title' | 'tldr' | 'status'>
+
+/**
+ * The raw `sanity.context.conversation` document shape, as stored in the
+ * organization's document store. For typing GROQ reads.
+ * @beta
+ */
+export type ConversationDoc = components['schemas']['ConversationDoc']

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -58,6 +58,8 @@ export type CreateFileImportParams = {
 }
 
 type KnowledgeBasesPath = '/{apiVersion}/context/knowledge-bases'
+type ConversationPath =
+  '/{apiVersion}/context/organizations/{organizationId}/conversations/{threadId}'
 type KnowledgeBasePath = '/{apiVersion}/context/knowledge-bases/{knowledgeBaseId}'
 type ImportsPath = `${KnowledgeBasePath}/imports`
 type ImportPath = `${KnowledgeBasePath}/imports/{importId}`
@@ -225,6 +227,23 @@ export type EditCrawlOptionsParams = JsonBody<paths[CrawlOptionsPath]['patch']>
 export type CrawlOptions = JsonResponse<paths[CrawlOptionsPath]['patch']['responses']['200']>
 /** @beta */
 export type EntryStatus = 'virtual' | 'outlined' | 'filled' | 'stale' | 'generation_failed'
+
+/**
+ * A recorded conversation: one agent thread's transcript plus the
+ * classification recorded on it. Standalone org-level telemetry — dimensions
+ * (MCP endpoints, app, the customer's own keys) live in the `metadata` bag.
+ * @beta
+ */
+export type Conversation = JsonResponse<paths[ConversationPath]['put']['responses']['200']>
+/**
+ * Body for the conversation ingest upsert. Messages replace the stored
+ * transcript wholesale; `metadata` and model fields only overwrite when
+ * present.
+ * @beta
+ */
+export type SaveConversationParams = JsonBody<paths[ConversationPath]['put']>
+/** Exactly one of a verdict (`coreMetrics`) or a failure (`classificationError`). @beta */
+export type ClassifyConversationParams = JsonBody<paths[ConversationPath]['patch']>
 
 /**
  * The raw `sanity.context.entry` document shape, as stored in the

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,8 +1,39 @@
-import type {UploadBody} from '../types'
+import type {
+  ListenOptions,
+  RequestOptions as MainRequestOptions,
+  ResumableListenOptions,
+  UploadBody,
+} from '../types'
 import type {components, paths} from './types.gen'
 
 /** Options accepted by every Context method. @beta */
 export type RequestOptions = {signal?: AbortSignal; tag?: string}
+
+/** @internal */
+export const possibleStoreRequestOptions = ['headers', 'signal', 'tag', 'timeout', 'token'] as const
+
+/**
+ * Request options honored by `context.fetch`.
+ *
+ * @beta
+ */
+export type ContextRequestOptions = Pick<
+  MainRequestOptions,
+  (typeof possibleStoreRequestOptions)[number]
+>
+
+/**
+ * Listener options for `context.listen`.
+ *
+ * `includeAllVersions` is left out: Context documents are written by the
+ * Context API with no drafts or versions, so it would never make a
+ * difference.
+ *
+ * @beta
+ */
+export type ContextListenOptions =
+  | Omit<ListenOptions, 'includeAllVersions'>
+  | Omit<ResumableListenOptions, 'includeAllVersions'>
 
 /**
  * Render format for outline and entry reads. `json` returns the typed

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -26,10 +26,8 @@ export type CreateFileImportParams = {
   contentType?: string
 }
 
-type KnowledgeBasesPath = '/{apiVersion}/context/organizations/{organizationId}/knowledge-bases'
-type KnowledgeBasePath =
-  '/{apiVersion}/context/organizations/{organizationId}/knowledge-bases/{knowledgeBaseSlug}'
-type KnowledgeBaseByIdPath = '/{apiVersion}/context/knowledge-bases/{knowledgeBaseId}'
+type KnowledgeBasesPath = '/{apiVersion}/context/knowledge-bases'
+type KnowledgeBasePath = '/{apiVersion}/context/knowledge-bases/{knowledgeBaseId}'
 type ImportsPath = `${KnowledgeBasePath}/imports`
 type ImportPath = `${KnowledgeBasePath}/imports/{importId}`
 type UploadsPath = `${KnowledgeBasePath}/imports/uploads`
@@ -67,7 +65,7 @@ type JsonBody<T> = T extends {
  * A knowledge base: one buildable body of knowledge inside Context.
  * @beta
  */
-export type KnowledgeBase = JsonResponse<paths[KnowledgeBaseByIdPath]['get']['responses']['200']>
+export type KnowledgeBase = JsonResponse<paths[KnowledgeBasePath]['get']['responses']['200']>
 
 /**
  * Parameters for creating a knowledge base.
@@ -200,8 +198,8 @@ export type CrawlOptions = JsonResponse<paths[CrawlOptionsPath]['patch']['respon
 export type EntryStatus = 'virtual' | 'outlined' | 'filled' | 'stale' | 'generation_failed'
 
 /**
- * The raw `sanity.context.entry` document shape, as stored in the bound
- * dataset. For typing GROQ reads made with a regular dataset client.
+ * The raw `sanity.context.entry` document shape, as stored in the
+ * organization's document store. For typing GROQ reads.
  * @beta
  */
 export type EntryDoc = components['schemas']['EntryDoc']

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,0 +1,211 @@
+import type {UploadBody} from '../types'
+import type {components, paths} from './types.gen'
+
+/** Options accepted by every Context method. @beta */
+export type RequestOptions = {signal?: AbortSignal; tag?: string}
+
+/**
+ * Render format for outline and entry reads. `json` returns the typed
+ * shape; `markdown` and `plain` return the rendered text as a string.
+ * @beta
+ */
+export type RenderFormat = 'json' | 'markdown' | 'plain'
+
+/**
+ * A file import. The client stages the upload, PUTs the bytes straight to
+ * storage with a signed URL, and confirms. The Context API never holds the
+ * file content.
+ * @beta
+ */
+export type CreateFileImportParams = {
+  type: 'file'
+  /** Same shapes `assets.upload` accepts, minus node streams: the bytes go
+   * out through `fetch`, which has no portable stream support. */
+  file: Exclude<UploadBody, NodeJS.ReadableStream>
+  filename: string
+  contentType?: string
+}
+
+type KnowledgeBasesPath = '/{apiVersion}/context/organizations/{organizationId}/knowledge-bases'
+type KnowledgeBasePath =
+  '/{apiVersion}/context/organizations/{organizationId}/knowledge-bases/{knowledgeBaseSlug}'
+type KnowledgeBaseByIdPath = '/{apiVersion}/context/knowledge-bases/{knowledgeBaseId}'
+type ImportsPath = `${KnowledgeBasePath}/imports`
+type ImportPath = `${KnowledgeBasePath}/imports/{importId}`
+type UploadsPath = `${KnowledgeBasePath}/imports/uploads`
+type CrawlPreviewPath = `${KnowledgeBasePath}/imports/crawl-preview`
+type OutlinePath = `${KnowledgeBasePath}/outline`
+type EntryPath = `${KnowledgeBasePath}/entries/{entryPath}`
+type SourcesPath = `${KnowledgeBasePath}/sources`
+type SourcePath = `${KnowledgeBasePath}/sources/{sourceId}`
+type SourceContentPath = `${KnowledgeBasePath}/sources/{sourceId}/content`
+type ChangesPath = `${KnowledgeBasePath}/changes`
+type ActivityPath = `${KnowledgeBasePath}/activity`
+type RevisionsPath = `${KnowledgeBasePath}/revisions`
+type RevisionReportPath = `${KnowledgeBasePath}/revisions/{revisionId}/report`
+type RevisionOutlinePath = `${KnowledgeBasePath}/revisions/{revisionId}/outline`
+type IssuePath = `${KnowledgeBasePath}/issues/{issueId}`
+type IssuesApplyPath = `${KnowledgeBasePath}/issues/apply`
+type InstructionPath = `${KnowledgeBasePath}/instructions/{instructionId}`
+type CrawlOptionsPath = `${KnowledgeBasePath}/crawl-options`
+type JobPath = `${KnowledgeBasePath}/jobs/{jobId}`
+type IssuesPath = `${KnowledgeBasePath}/issues`
+type IssueResolvePath = `${KnowledgeBasePath}/issues/{issueId}/resolve`
+type IssueDismissPath = `${KnowledgeBasePath}/issues/{issueId}/dismiss`
+type IssueReopenPath = `${KnowledgeBasePath}/issues/{issueId}/reopen`
+type InstructionsPath = `${KnowledgeBasePath}/instructions`
+type EntriesPath = `${KnowledgeBasePath}/entries`
+
+type JsonResponse<T> = T extends {content: {'application/json': infer R}} ? R : never
+type JsonBody<T> = T extends {
+  requestBody: {content: {'application/json': infer R}}
+}
+  ? R
+  : never
+
+/**
+ * A knowledge base: one buildable body of knowledge inside Context.
+ * @beta
+ */
+export type KnowledgeBase = JsonResponse<paths[KnowledgeBaseByIdPath]['get']['responses']['200']>
+
+/**
+ * Parameters for creating a knowledge base.
+ * @beta
+ */
+export type CreateKnowledgeBaseParams = JsonBody<paths[KnowledgeBasesPath]['post']>
+/** @beta */
+export type EditKnowledgeBaseParams = JsonBody<paths[KnowledgeBasePath]['patch']>
+
+/**
+ * Parameters for importing content. Discriminated on `type`:
+ * inline text, a website crawl, or a Sanity dataset bind.
+ * @beta
+ */
+export type CreateImportParams = JsonBody<paths[ImportsPath]['post']>
+
+/**
+ * Accepted async work. Poll the job with `jobs.get` until it reaches a
+ * terminal state.
+ * @beta
+ */
+export type JobAccepted = JsonResponse<
+  paths[`${KnowledgeBasePath}/build`]['post']['responses']['202']
+>
+
+/** @beta */
+export type Job = JsonResponse<paths[JobPath]['get']['responses']['200']>
+
+/** @beta */
+export type IssuesResponse = JsonResponse<paths[IssuesPath]['get']['responses']['200']>
+/** @beta */
+export type Issue = IssuesResponse['data'][number]
+/** @beta */
+export type IssueDetail = JsonResponse<paths[IssuePath]['get']['responses']['200']>
+/** @beta */
+export type ApplyIssuesParams = JsonBody<paths[IssuesApplyPath]['post']>
+/** @beta */
+export type ApplyIssuesResponse = JsonResponse<paths[IssuesApplyPath]['post']['responses']['202']>
+/** @beta */
+export type ResolveIssueParams = JsonBody<paths[IssueResolvePath]['post']>
+/** @beta */
+export type ResolveIssueResponse = JsonResponse<paths[IssueResolvePath]['post']['responses']['200']>
+/** @beta */
+export type DismissIssueResponse = JsonResponse<paths[IssueDismissPath]['post']['responses']['200']>
+/** @beta */
+export type ReopenIssueResponse = JsonResponse<paths[IssueReopenPath]['post']['responses']['200']>
+
+/** @beta */
+export type CreateInstructionParams = JsonBody<paths[InstructionsPath]['post']>
+/** @beta */
+export type InstructionsResponse = JsonResponse<paths[InstructionsPath]['get']['responses']['200']>
+/** @beta */
+export type Instruction = InstructionsResponse['data'][number]
+/** @beta */
+export type EditInstructionParams = JsonBody<paths[InstructionPath]['patch']>
+
+/** @beta */
+export type EntriesResponse = JsonResponse<paths[EntriesPath]['get']['responses']['200']>
+/** @beta */
+export type Entry = EntriesResponse['data'][number]
+
+/** @beta */
+export type KnowledgeBasesResponse = JsonResponse<
+  paths[KnowledgeBasesPath]['get']['responses']['200']
+>
+
+/** @beta */
+export type ImportsResponse = JsonResponse<paths[ImportsPath]['get']['responses']['200']>
+/** @beta */
+export type Import = ImportsResponse['data'][number]
+/** @beta */
+export type ImportDetail = JsonResponse<paths[ImportPath]['get']['responses']['200']>
+/** @beta */
+export type ImportDownloadResponse = JsonResponse<
+  paths[`${ImportPath}/download`]['get']['responses']['200']
+>
+
+/**
+ * The staged half of a file upload: PUT the bytes to `uploadUrl`, then
+ * confirm with the complete endpoint. `imports.create({type: 'file'})` does
+ * all of this in one call.
+ * @beta
+ */
+export type StagedUpload = JsonResponse<paths[UploadsPath]['post']['responses']['201']>
+/** @beta */
+export type StageUploadParams = JsonBody<paths[UploadsPath]['post']>
+
+/** @beta */
+export type CrawlPreviewParams = JsonBody<paths[CrawlPreviewPath]['post']>
+/** @beta */
+export type CrawlPreviewResponse = JsonResponse<paths[CrawlPreviewPath]['post']['responses']['200']>
+
+/** @beta */
+export type Outline = JsonResponse<paths[OutlinePath]['get']['responses']['200']>
+/** @beta */
+export type EntryDetail = JsonResponse<paths[EntryPath]['get']['responses']['200']>
+
+/** @beta */
+export type SourcesResponse = JsonResponse<paths[SourcesPath]['get']['responses']['200']>
+/** @beta */
+export type Source = SourcesResponse['data'][number]
+/** @beta */
+export type SourceDetail = JsonResponse<paths[SourcePath]['get']['responses']['200']>
+/** @beta */
+export type SourceContentResponse = JsonResponse<
+  paths[SourceContentPath]['get']['responses']['200']
+>
+
+/** @beta */
+export type Changes = JsonResponse<paths[ChangesPath]['get']['responses']['200']>
+/** @beta */
+export type ActivityResponse = JsonResponse<paths[ActivityPath]['get']['responses']['200']>
+/** @beta */
+export type ActivityEvent = ActivityResponse['data'][number]
+
+/** @beta */
+export type RevisionsResponse = JsonResponse<paths[RevisionsPath]['get']['responses']['200']>
+/** @beta */
+export type Revision = RevisionsResponse['data'][number]
+/** @beta */
+export type RevisionReport = JsonResponse<paths[RevisionReportPath]['get']['responses']['200']>
+/** @beta */
+export type RevisionOutline = JsonResponse<paths[RevisionOutlinePath]['get']['responses']['200']>
+
+/** @beta */
+export type EditCrawlOptionsParams = JsonBody<paths[CrawlOptionsPath]['patch']>
+/** @beta */
+export type CrawlOptions = JsonResponse<paths[CrawlOptionsPath]['patch']['responses']['200']>
+/** @beta */
+export type EntryStatus = 'virtual' | 'outlined' | 'filled' | 'stale' | 'generation_failed'
+
+/**
+ * The raw `sanity.context.entry` document shape, as stored in the bound
+ * dataset. For typing GROQ reads made with a regular dataset client.
+ * @beta
+ */
+export type EntryDoc = components['schemas']['EntryDoc']
+/** @beta */
+export type IssueDoc = components['schemas']['IssueDoc']
+/** @beta */
+export type InstructionDoc = components['schemas']['InstructionDoc']

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -172,6 +172,8 @@ export type Source = SourcesResponse['data'][number]
 /** @beta */
 export type SourceDetail = JsonResponse<paths[SourcePath]['get']['responses']['200']>
 /** @beta */
+export type DeleteSourceResponse = JsonResponse<paths[SourcePath]['delete']['responses']['202']>
+/** @beta */
 export type SourceContentResponse = JsonResponse<
   paths[SourceContentPath]['get']['responses']['200']
 >

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -150,8 +150,6 @@ export type ImportDownloadResponse = JsonResponse<
  * @beta
  */
 export type StagedUpload = JsonResponse<paths[UploadsPath]['post']['responses']['201']>
-/** @beta */
-export type StageUploadParams = JsonBody<paths[UploadsPath]['post']>
 
 /** @beta */
 export type CrawlPreviewParams = JsonBody<paths[CrawlPreviewPath]['post']>

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -172,8 +172,6 @@ export type Source = SourcesResponse['data'][number]
 /** @beta */
 export type SourceDetail = JsonResponse<paths[SourcePath]['get']['responses']['200']>
 /** @beta */
-export type DeleteSourceResponse = JsonResponse<paths[SourcePath]['delete']['responses']['202']>
-/** @beta */
 export type SourceContentResponse = JsonResponse<
   paths[SourceContentPath]['get']['responses']['200']
 >

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -1291,6 +1291,9 @@ const resourceDataBase = (config: InitializedClientConfig): string => {
     case 'canvas': {
       return `/canvases/${id}`
     }
+    case 'knowledge-base': {
+      return `/knowledge-bases/${id}`
+    }
     case 'media-library': {
       return `/media-libraries/${id}`
     }

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -1128,7 +1128,7 @@ export function _prepareRequest(client: Client, options: RequestObservableOption
  *
  * @internal
  */
-function _observe<R>(
+export function _observe<R>(
   userSignal: AbortSignal | undefined,
   run: (signal: AbortSignal) => Promise<R>,
 ): Observable<R> {

--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -26,6 +26,7 @@ export {
   isQueryParseError,
   ServerError,
 } from './http/errors'
+export * as Context from './context/types'
 export * from './SanityClient'
 export * from './types'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,10 @@ type ClientConfigResource =
       id: string
     }
   | {
+      type: 'knowledge-base'
+      id: string
+    }
+  | {
       type: 'media-library'
       id: string
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,17 @@ export interface ClientConfig {
   collaboration?: {
     organizationId?: string
   }
+
+  /**
+   * Organization-scoped configuration for Context APIs.
+   *
+   * Currently this is used by `context.insights` methods.
+   *
+   * @beta
+   */
+  context?: {
+    organizationId?: string
+  }
 }
 
 /** @public */

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -128,6 +128,7 @@ export const resourceConfig = (config: InitializedClientConfig): void => {
       return
     }
     case 'dashboard':
+    case 'knowledge-base':
     case 'media-library':
     case 'canvas': {
       return

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -1,4 +1,5 @@
-import {type Context, createClient} from '@sanity/client'
+import {type Context, createClient, type MutationEvent, type SanityDocument} from '@sanity/client'
+import {type Observable} from 'rxjs'
 import {describe, expectTypeOf, test} from 'vitest'
 
 describe('client.context format-dependent return types', () => {
@@ -26,6 +27,12 @@ describe('client.context format-dependent return types', () => {
     void kb.imports.create({type: 'file', file: new Blob(['x'])})
     // @ts-expect-error -- should fail: text imports carry content, not a file
     void kb.imports.create({type: 'text', title: 't', file: new Blob(['x'])})
+  })
+
+  test('context.listen emits mutation events by default', () => {
+    expectTypeOf(client.context.listen('*')).toEqualTypeOf<
+      Observable<MutationEvent<SanityDocument>>
+    >()
   })
 
   test('knowledgeBases.create requires the organizationId alongside the wire fields', async () => {

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -17,10 +17,8 @@ describe('client.context format-dependent return types', () => {
     expectTypeOf(await kb.entries.get({path: 'a/b', format: 'markdown'})).toEqualTypeOf<string>()
   })
 
-  test('sources.delete resolves to the accepted job', async () => {
-    expectTypeOf(
-      await kb.sources.delete({sourceId: 'source1'}),
-    ).toEqualTypeOf<Context.DeleteSourceResponse>()
+  test('sources.delete resolves to void', async () => {
+    expectTypeOf(await kb.sources.delete({sourceId: 'source1'})).toEqualTypeOf<void>()
   })
 
   test('the file import variant is only valid with file fields', async () => {

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -2,24 +2,31 @@ import {type Context, createClient, type MutationEvent, type SanityDocument} fro
 import {type Observable} from 'rxjs'
 import {describe, expectTypeOf, test} from 'vitest'
 
-describe('client.context format-dependent return types', () => {
-  const client = createClient({resource: {type: 'knowledge-base', id: 'kb123'}})
+describe('client.context return types', () => {
+  const client = createClient({
+    resource: {type: 'knowledge-base', id: 'kb123'},
+  })
   const kb = client.context
 
-  test('outline resolves to the typed shape by default and to a string for text formats', async () => {
-    expectTypeOf(await kb.outline()).toEqualTypeOf<Context.Outline>()
-    expectTypeOf(await kb.outline({format: 'json'})).toEqualTypeOf<Context.Outline>()
-    expectTypeOf(await kb.outline({format: 'markdown'})).toEqualTypeOf<string>()
-    expectTypeOf(await kb.outline({format: 'plain'})).toEqualTypeOf<string>()
-  })
-
-  test('entries.get resolves to the typed shape by default and to a string for text formats', async () => {
-    expectTypeOf(await kb.entries.get({path: 'a/b'})).toEqualTypeOf<Context.EntryDetail>()
-    expectTypeOf(await kb.entries.get({path: 'a/b', format: 'markdown'})).toEqualTypeOf<string>()
+  test('the GROQ read helpers resolve to the published document shapes', async () => {
+    expectTypeOf(await kb.entries.get({path: 'a/b'})).toEqualTypeOf<Context.EntryDoc | null>()
+    expectTypeOf(await kb.entries.list()).toEqualTypeOf<Context.Entry[]>()
+    expectTypeOf(await kb.issues.list()).toEqualTypeOf<Context.IssueDoc[]>()
+    expectTypeOf(await kb.issues.get({issueId: 'i'})).toEqualTypeOf<Context.IssueDoc | null>()
+    expectTypeOf(await kb.instructions.list()).toEqualTypeOf<Context.InstructionDoc[]>()
+    expectTypeOf(await kb.mcpEndpoints.list()).toEqualTypeOf<Context.McpDoc[]>()
+    expectTypeOf(await kb.mcpEndpoints.get({name: 'n'})).toEqualTypeOf<Context.McpDoc | null>()
+    expectTypeOf(
+      await kb.conversations.get({threadId: 't'}),
+    ).toEqualTypeOf<Context.ConversationDoc | null>()
   })
 
   test('sources.delete resolves to void', async () => {
     expectTypeOf(await kb.sources.delete({sourceId: 'source1'})).toEqualTypeOf<void>()
+  })
+
+  test('imports.delete resolves to void', async () => {
+    expectTypeOf(await kb.imports.delete({importId: 'imp1'})).toEqualTypeOf<void>()
   })
 
   test('the file import variant is only valid with file fields', async () => {

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -34,16 +34,12 @@ describe('client.context format-dependent return types', () => {
         organizationId: 'org',
         name: 'n',
         description: 'd',
-        sanityProjectId: 'p',
-        sanityDatasetId: 'ds',
       }),
     ).toEqualTypeOf<Context.KnowledgeBase>()
     // @ts-expect-error -- should fail: organizationId is required
     void client.context.knowledgeBases.create({
       name: 'n',
       description: 'd',
-      sanityProjectId: 'p',
-      sanityDatasetId: 'ds',
     })
   })
 })

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -1,0 +1,45 @@
+import {type Context, createClient} from '@sanity/client'
+import {describe, expectTypeOf, test} from 'vitest'
+
+describe('client.context format-dependent return types', () => {
+  const client = createClient({})
+  const kb = client.context.knowledgeBase('kb123')
+
+  test('outline resolves to the typed shape by default and to a string for text formats', async () => {
+    expectTypeOf(await kb.outline()).toEqualTypeOf<Context.Outline>()
+    expectTypeOf(await kb.outline({format: 'json'})).toEqualTypeOf<Context.Outline>()
+    expectTypeOf(await kb.outline({format: 'markdown'})).toEqualTypeOf<string>()
+    expectTypeOf(await kb.outline({format: 'plain'})).toEqualTypeOf<string>()
+  })
+
+  test('entries.get resolves to the typed shape by default and to a string for text formats', async () => {
+    expectTypeOf(await kb.entries.get({path: 'a/b'})).toEqualTypeOf<Context.EntryDetail>()
+    expectTypeOf(await kb.entries.get({path: 'a/b', format: 'markdown'})).toEqualTypeOf<string>()
+  })
+
+  test('the file import variant is only valid with file fields', async () => {
+    // @ts-expect-error -- should fail: file imports require a filename
+    void kb.imports.create({type: 'file', file: new Blob(['x'])})
+    // @ts-expect-error -- should fail: text imports carry content, not a file
+    void kb.imports.create({type: 'text', title: 't', file: new Blob(['x'])})
+  })
+
+  test('knowledgeBases.create requires the organizationId alongside the wire fields', async () => {
+    expectTypeOf(
+      await client.context.knowledgeBases.create({
+        organizationId: 'org',
+        name: 'n',
+        description: 'd',
+        sanityProjectId: 'p',
+        sanityDatasetId: 'ds',
+      }),
+    ).toEqualTypeOf<Context.KnowledgeBase>()
+    // @ts-expect-error -- should fail: organizationId is required
+    void client.context.knowledgeBases.create({
+      name: 'n',
+      description: 'd',
+      sanityProjectId: 'p',
+      sanityDatasetId: 'ds',
+    })
+  })
+})

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -2,8 +2,8 @@ import {type Context, createClient} from '@sanity/client'
 import {describe, expectTypeOf, test} from 'vitest'
 
 describe('client.context format-dependent return types', () => {
-  const client = createClient({})
-  const kb = client.context.knowledgeBase('kb123')
+  const client = createClient({resource: {type: 'knowledge-base', id: 'kb123'}})
+  const kb = client.context
 
   test('outline resolves to the typed shape by default and to a string for text formats', async () => {
     expectTypeOf(await kb.outline()).toEqualTypeOf<Context.Outline>()
@@ -41,5 +41,11 @@ describe('client.context format-dependent return types', () => {
       title: 't',
       description: 'd',
     })
+  })
+
+  test('knowledge-base is a valid resource config type', () => {
+    expectTypeOf(createClient({resource: {type: 'knowledge-base', id: 'kb123'}})).not.toBeNever()
+    // @ts-expect-error -- should fail: unknown resource types are rejected
+    void createClient({resource: {type: 'knowledge-bases', id: 'kb123'}})
   })
 })

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -32,13 +32,13 @@ describe('client.context format-dependent return types', () => {
     expectTypeOf(
       await client.context.knowledgeBases.create({
         organizationId: 'org',
-        name: 'n',
+        title: 't',
         description: 'd',
       }),
     ).toEqualTypeOf<Context.KnowledgeBase>()
     // @ts-expect-error -- should fail: organizationId is required
     void client.context.knowledgeBases.create({
-      name: 'n',
+      title: 't',
       description: 'd',
     })
   })

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -17,6 +17,12 @@ describe('client.context format-dependent return types', () => {
     expectTypeOf(await kb.entries.get({path: 'a/b', format: 'markdown'})).toEqualTypeOf<string>()
   })
 
+  test('sources.delete resolves to the accepted job', async () => {
+    expectTypeOf(
+      await kb.sources.delete({sourceId: 'source1'}),
+    ).toEqualTypeOf<Context.DeleteSourceResponse>()
+  })
+
   test('the file import variant is only valid with file fields', async () => {
     // @ts-expect-error -- should fail: file imports require a filename
     void kb.imports.create({type: 'file', file: new Blob(['x'])})

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -216,4 +216,16 @@ describe('ContextClient', () => {
       endLine: '10',
     })
   })
+
+  test('sources.delete returns the accepted job', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+
+    const result = await context.knowledgeBase(TEST_KB_ID).sources.delete({sourceId: 'source1'})
+
+    expect(httpRequest.mock.calls[1][0]).toMatchObject({
+      method: 'DELETE',
+      url: expect.stringContaining('/sources/source1'),
+    })
+    expect(result).toEqual({jobId: 'job1'})
+  })
 })

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -217,8 +217,8 @@ describe('ContextClient', () => {
     })
   })
 
-  test('sources.delete returns the accepted job', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+  test('sources.delete issues a DELETE and resolves to nothing', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce(undefined)
 
     const result = await context.knowledgeBase(TEST_KB_ID).sources.delete({sourceId: 'source1'})
 
@@ -226,6 +226,6 @@ describe('ContextClient', () => {
       method: 'DELETE',
       url: expect.stringContaining('/sources/source1'),
     })
-    expect(result).toEqual({jobId: 'job1'})
+    expect(result).toBeUndefined()
   })
 })

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -1,0 +1,229 @@
+import {createClient} from '@sanity/client'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {ContextClient} from '../src/context/ContextClient'
+import type {SanityClient} from '../src/SanityClient'
+
+const TEST_ORG_ID = 'orgAbc123'
+const TEST_KB_ID = 'kb3do82whm'
+const TEST_KB = {
+  id: 'c0ffee00-0000-4000-8000-000000000000',
+  publicId: TEST_KB_ID,
+  slug: 'support-docs',
+  organizationId: TEST_ORG_ID,
+  name: 'Support docs',
+  sanityProjectId: 'proj123',
+  sanityDatasetId: 'production',
+}
+
+const httpRequest = vi.fn()
+
+describe('ContextClient', () => {
+  let client: SanityClient
+  let context: ContextClient
+
+  beforeEach(() => {
+    client = createClient({
+      projectId: 'proj123',
+      dataset: 'production',
+      apiVersion: '2026-05-26',
+      useCdn: false,
+    })
+    httpRequest.mockReset()
+    context = new ContextClient(client, httpRequest)
+  })
+
+  test('knowledgeBases.create posts to the org-scoped collection', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB)
+
+    const created = await context.knowledgeBases.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Support docs',
+      description: 'Docs and guides',
+      sanityProjectId: 'proj123',
+      sanityDatasetId: 'production',
+    })
+
+    expect(httpRequest).toHaveBeenCalledTimes(1)
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.method).toBe('POST')
+    // organizationId addresses the request, it is not part of the body
+    expect(req.body.organizationId).toBeUndefined()
+    expect(req.body.name).toBe('Support docs')
+    expect(created.publicId).toBe(TEST_KB_ID)
+  })
+
+  test('knowledgeBases.list forwards pagination as query params', async () => {
+    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
+
+    await context.knowledgeBases.list({
+      organizationId: TEST_ORG_ID,
+      limit: 5,
+      cursor: 'abc',
+    })
+
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.query).toMatchObject({limit: '5', cursor: 'abc'})
+  })
+
+  test('handle resolves the org/slug address once and reuses it', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB) // by-id resolution
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.issues.list()
+    await kb.entries.list()
+
+    expect(httpRequest).toHaveBeenCalledTimes(3)
+    expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
+    expect(httpRequest.mock.calls[1][0].url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
+    )
+    expect(httpRequest.mock.calls[2][0].url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/entries`,
+    )
+  })
+
+  test('address resolution never carries a caller abort signal', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+
+    const controller = new AbortController()
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.build({signal: controller.signal})
+
+    // The by-id resolution is shared by every method on the handle; a
+    // caller's signal on it would abort concurrent callers too.
+    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined()
+    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal)
+  })
+
+  test('a failed resolution does not poison the handle', async () => {
+    httpRequest
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(TEST_KB)
+      .mockResolvedValueOnce({jobId: 'job1'})
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await expect(kb.build()).rejects.toThrow('network down')
+    await expect(kb.build()).resolves.toEqual({jobId: 'job1'})
+  })
+
+  test('issues.resolve posts the resolution with the issueId in the path', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+      issue: {status: 'accepted'},
+      entry: null,
+      jobId: null,
+    })
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    const result = await kb.issues.resolve({
+      issueId: 'issue.abc',
+      resolution: 'keep_existing',
+    })
+
+    const req = httpRequest.mock.calls[1][0]
+    expect(req.url).toContain('/issues/issue.abc/resolve')
+    expect(req.body).toEqual({resolution: 'keep_existing'})
+    expect(result.issue.status).toBe('accepted')
+  })
+
+  test('imports.create with type file stages, PUTs to the signed URL, and confirms', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB) // address resolution
+      .mockResolvedValueOnce({
+        importId: 'imp1',
+        uploadUrl: 'https://storage.example/signed',
+      })
+      .mockResolvedValueOnce({jobId: 'job9'}) // complete
+    // The PUT rides the client's fetch resolution (so proxy config applies),
+    // injected the same way the transport tests inject theirs.
+    const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
+
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
+    const result = await kb.imports.create({
+      type: 'file',
+      file: new Blob(['hello']),
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
+
+    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads')
+    expect(httpRequest.mock.calls[1][0].body).toEqual({
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
+    expect(uploadFetch).toHaveBeenCalledWith(
+      'https://storage.example/signed',
+      expect.objectContaining({method: 'PUT'}),
+    )
+    expect(httpRequest.mock.calls[2][0].url).toContain('/imports/uploads/imp1/complete')
+    expect(result).toEqual({jobId: 'job9'})
+  })
+
+  test('a failed signed-URL PUT surfaces as an error and never confirms', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+      importId: 'imp1',
+      uploadUrl: 'https://storage.example/signed',
+    })
+    const uploadFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
+
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
+    await expect(
+      kb.imports.create({
+        type: 'file',
+        file: new Blob(['x']),
+        filename: 'x.txt',
+      }),
+    ).rejects.toThrow('File upload failed: 403')
+    // stage + resolution only; the confirm call must not have fired
+    expect(httpRequest).toHaveBeenCalledTimes(2)
+  })
+
+  test('entry paths are encoded and read endpoints hit their routes', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB)
+      .mockResolvedValueOnce({id: 'e1'}) // entries.get
+      .mockResolvedValueOnce({entries: [], stats: {}}) // outline
+      .mockResolvedValueOnce({
+        content: '',
+        slice: null,
+        sourceId: 's1',
+        totalLines: 1,
+      }) // sources.content
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.entries.get({path: 'billing/refunds', format: 'markdown'})
+    await kb.outline()
+    await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
+
+    expect(httpRequest.mock.calls[1][0].url).toContain('/entries/billing%2Frefunds')
+    expect(httpRequest.mock.calls[1][0].query).toMatchObject({
+      format: 'markdown',
+    })
+    expect(httpRequest.mock.calls[2][0].url).toContain('/outline')
+    expect(httpRequest.mock.calls[3][0].query).toMatchObject({
+      startLine: '4',
+      endLine: '10',
+    })
+  })
+
+  test('contentClient returns a native client bound to the dataset', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB)
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    const content = await kb.contentClient()
+
+    expect(content.config().projectId).toBe('proj123')
+    expect(content.config().dataset).toBe('production')
+  })
+})

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -9,9 +9,8 @@ const TEST_KB_ID = 'kb3do82whm'
 const TEST_KB = {
   id: 'c0ffee00-0000-4000-8000-000000000000',
   publicId: TEST_KB_ID,
-  slug: 'support-docs',
   organizationId: TEST_ORG_ID,
-  name: 'Support docs',
+  title: 'Support docs',
 }
 
 const httpRequest = vi.fn()
@@ -31,26 +30,25 @@ describe('ContextClient', () => {
     context = new ContextClient(client, httpRequest)
   })
 
-  test('knowledgeBases.create posts to the org-scoped collection', async () => {
+  test('knowledgeBases.create posts to the collection with the organization in the body', async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB)
 
     const created = await context.knowledgeBases.create({
       organizationId: TEST_ORG_ID,
-      name: 'Support docs',
+      title: 'Support docs',
       description: 'Docs and guides',
     })
 
     expect(httpRequest).toHaveBeenCalledTimes(1)
     const req = httpRequest.mock.calls[0][0]
-    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.url).toContain('/context/knowledge-bases')
     expect(req.method).toBe('POST')
-    // organizationId addresses the request, it is not part of the body
-    expect(req.body.organizationId).toBeUndefined()
-    expect(req.body.name).toBe('Support docs')
+    expect(req.body.organizationId).toBe(TEST_ORG_ID)
+    expect(req.body.title).toBe('Support docs')
     expect(created.publicId).toBe(TEST_KB_ID)
   })
 
-  test('knowledgeBases.list forwards pagination as query params', async () => {
+  test('knowledgeBases.list scopes by organization and forwards pagination as query params', async () => {
     httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
 
     await context.knowledgeBases.list({
@@ -60,72 +58,43 @@ describe('ContextClient', () => {
     })
 
     const req = httpRequest.mock.calls[0][0]
-    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
-    expect(req.query).toMatchObject({limit: '5', cursor: 'abc'})
+    expect(req.url).toContain('/context/knowledge-bases')
+    expect(req.query).toMatchObject({organizationId: TEST_ORG_ID, limit: '5', cursor: 'abc'})
   })
 
-  test('handle resolves the org/slug address once and reuses it', async () => {
+  test('handle methods address the knowledge base by id directly', async () => {
     httpRequest
-      .mockResolvedValueOnce(TEST_KB) // by-id resolution
+      .mockResolvedValueOnce(TEST_KB) // get
       .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
       .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
 
     const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.get()
     await kb.issues.list()
     await kb.entries.list()
 
     expect(httpRequest).toHaveBeenCalledTimes(3)
     expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
     expect(httpRequest.mock.calls[1][0].url).toContain(
-      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
+      `/context/knowledge-bases/${TEST_KB_ID}/issues`,
     )
     expect(httpRequest.mock.calls[2][0].url).toContain(
-      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/entries`,
+      `/context/knowledge-bases/${TEST_KB_ID}/entries`,
     )
   })
 
-  test('get() seeds the address cache for follow-up scoped calls', async () => {
-    httpRequest
-      .mockResolvedValueOnce(TEST_KB) // get() by-id fetch
-      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
-
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.get()
-    await kb.issues.list()
-
-    // No second by-id resolve: get() already carried the org and slug.
-    expect(httpRequest).toHaveBeenCalledTimes(2)
-    expect(httpRequest.mock.calls[1][0].url).toContain(
-      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
-    )
-  })
-
-  test('address resolution never carries a caller abort signal', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+  test('a caller abort signal rides the request', async () => {
+    httpRequest.mockResolvedValueOnce({jobId: 'job1'})
 
     const controller = new AbortController()
     const kb = context.knowledgeBase(TEST_KB_ID)
     await kb.build({signal: controller.signal})
 
-    // The by-id resolution is shared by every method on the handle; a
-    // caller's signal on it would abort concurrent callers too.
-    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined()
-    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal)
-  })
-
-  test('a failed resolution does not poison the handle', async () => {
-    httpRequest
-      .mockRejectedValueOnce(new Error('network down'))
-      .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({jobId: 'job1'})
-
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await expect(kb.build()).rejects.toThrow('network down')
-    await expect(kb.build()).resolves.toEqual({jobId: 'job1'})
+    expect(httpRequest.mock.calls[0][0].signal).toBe(controller.signal)
   })
 
   test('issues.resolve posts the resolution with the issueId in the path', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+    httpRequest.mockResolvedValueOnce({
       issue: {status: 'accepted'},
       entry: null,
       jobId: null,
@@ -137,7 +106,7 @@ describe('ContextClient', () => {
       resolution: 'keep_existing',
     })
 
-    const req = httpRequest.mock.calls[1][0]
+    const req = httpRequest.mock.calls[0][0]
     expect(req.url).toContain('/issues/issue.abc/resolve')
     expect(req.body).toEqual({resolution: 'keep_existing'})
     expect(result.issue.status).toBe('accepted')
@@ -145,7 +114,6 @@ describe('ContextClient', () => {
 
   test('imports.create with type file stages, PUTs to the signed URL, and confirms', async () => {
     httpRequest
-      .mockResolvedValueOnce(TEST_KB) // address resolution
       .mockResolvedValueOnce({
         importId: 'imp1',
         uploadUrl: 'https://storage.example/signed',
@@ -165,8 +133,8 @@ describe('ContextClient', () => {
       contentType: 'text/plain',
     })
 
-    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads')
-    expect(httpRequest.mock.calls[1][0].body).toEqual({
+    expect(httpRequest.mock.calls[0][0].url).toContain('/imports/uploads')
+    expect(httpRequest.mock.calls[0][0].body).toEqual({
       filename: 'hello.txt',
       contentType: 'text/plain',
     })
@@ -174,12 +142,12 @@ describe('ContextClient', () => {
       'https://storage.example/signed',
       expect.objectContaining({method: 'PUT'}),
     )
-    expect(httpRequest.mock.calls[2][0].url).toContain('/imports/uploads/imp1/complete')
+    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads/imp1/complete')
     expect(result).toEqual({jobId: 'job9'})
   })
 
   test('a failed signed-URL PUT surfaces as an error and never confirms', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+    httpRequest.mockResolvedValueOnce({
       importId: 'imp1',
       uploadUrl: 'https://storage.example/signed',
     })
@@ -197,13 +165,12 @@ describe('ContextClient', () => {
         filename: 'x.txt',
       }),
     ).rejects.toThrow('File upload failed: 403')
-    // stage + resolution only; the confirm call must not have fired
-    expect(httpRequest).toHaveBeenCalledTimes(2)
+    // stage only; the confirm call must not have fired
+    expect(httpRequest).toHaveBeenCalledTimes(1)
   })
 
   test('entry paths are encoded and read endpoints hit their routes', async () => {
     httpRequest
-      .mockResolvedValueOnce(TEST_KB)
       .mockResolvedValueOnce({id: 'e1'}) // entries.get
       .mockResolvedValueOnce({entries: [], stats: {}}) // outline
       .mockResolvedValueOnce({
@@ -218,23 +185,23 @@ describe('ContextClient', () => {
     await kb.outline()
     await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
 
-    expect(httpRequest.mock.calls[1][0].url).toContain('/entries/billing%2Frefunds')
-    expect(httpRequest.mock.calls[1][0].query).toMatchObject({
+    expect(httpRequest.mock.calls[0][0].url).toContain('/entries/billing%2Frefunds')
+    expect(httpRequest.mock.calls[0][0].query).toMatchObject({
       format: 'markdown',
     })
-    expect(httpRequest.mock.calls[2][0].url).toContain('/outline')
-    expect(httpRequest.mock.calls[3][0].query).toMatchObject({
+    expect(httpRequest.mock.calls[1][0].url).toContain('/outline')
+    expect(httpRequest.mock.calls[2][0].query).toMatchObject({
       startLine: '4',
       endLine: '10',
     })
   })
 
   test('sources.delete issues a DELETE and resolves to nothing', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce(undefined)
+    httpRequest.mockResolvedValueOnce(undefined)
 
     const result = await context.knowledgeBase(TEST_KB_ID).sources.delete({sourceId: 'source1'})
 
-    expect(httpRequest.mock.calls[1][0]).toMatchObject({
+    expect(httpRequest.mock.calls[0][0]).toMatchObject({
       method: 'DELETE',
       url: expect.stringContaining('/sources/source1'),
     })

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -12,8 +12,6 @@ const TEST_KB = {
   slug: 'support-docs',
   organizationId: TEST_ORG_ID,
   name: 'Support docs',
-  sanityProjectId: 'proj123',
-  sanityDatasetId: 'production',
 }
 
 const httpRequest = vi.fn()
@@ -40,8 +38,6 @@ describe('ContextClient', () => {
       organizationId: TEST_ORG_ID,
       name: 'Support docs',
       description: 'Docs and guides',
-      sanityProjectId: 'proj123',
-      sanityDatasetId: 'production',
     })
 
     expect(httpRequest).toHaveBeenCalledTimes(1)

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -88,6 +88,22 @@ describe('ContextClient', () => {
     )
   })
 
+  test('get() seeds the address cache for follow-up scoped calls', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB) // get() by-id fetch
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.get()
+    await kb.issues.list()
+
+    // No second by-id resolve: get() already carried the org and slug.
+    expect(httpRequest).toHaveBeenCalledTimes(2)
+    expect(httpRequest.mock.calls[1][0].url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
+    )
+  })
+
   test('address resolution never carries a caller abort signal', async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
 

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -1,235 +1,219 @@
-import { createClient } from "@sanity/client";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import {createClient} from '@sanity/client'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
-import { ContextClient } from "../src/context/ContextClient";
-import type { SanityClient } from "../src/SanityClient";
+import {ContextClient} from '../src/context/ContextClient'
+import type {SanityClient} from '../src/SanityClient'
 
-const TEST_ORG_ID = "orgAbc123";
-const TEST_KB_ID = "kb3do82whm";
+const TEST_ORG_ID = 'orgAbc123'
+const TEST_KB_ID = 'kb3do82whm'
 const TEST_KB = {
-  id: "c0ffee00-0000-4000-8000-000000000000",
+  id: 'c0ffee00-0000-4000-8000-000000000000',
   publicId: TEST_KB_ID,
-  slug: "support-docs",
+  slug: 'support-docs',
   organizationId: TEST_ORG_ID,
-  name: "Support docs",
-  sanityProjectId: "proj123",
-  sanityDatasetId: "production",
-};
+  name: 'Support docs',
+  sanityProjectId: 'proj123',
+  sanityDatasetId: 'production',
+}
 
-const httpRequest = vi.fn();
+const httpRequest = vi.fn()
 
-describe("ContextClient", () => {
-  let client: SanityClient;
-  let context: ContextClient;
+describe('ContextClient', () => {
+  let client: SanityClient
+  let context: ContextClient
 
   beforeEach(() => {
     client = createClient({
-      projectId: "proj123",
-      dataset: "production",
-      apiVersion: "2026-05-26",
+      projectId: 'proj123',
+      dataset: 'production',
+      apiVersion: '2026-05-26',
       useCdn: false,
-    });
-    httpRequest.mockReset();
-    context = new ContextClient(client, httpRequest);
-  });
+    })
+    httpRequest.mockReset()
+    context = new ContextClient(client, httpRequest)
+  })
 
-  test("knowledgeBases.create posts to the org-scoped collection", async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB);
+  test('knowledgeBases.create posts to the org-scoped collection', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB)
 
     const created = await context.knowledgeBases.create({
       organizationId: TEST_ORG_ID,
-      name: "Support docs",
-      description: "Docs and guides",
-      sanityProjectId: "proj123",
-      sanityDatasetId: "production",
-    });
+      name: 'Support docs',
+      description: 'Docs and guides',
+      sanityProjectId: 'proj123',
+      sanityDatasetId: 'production',
+    })
 
-    expect(httpRequest).toHaveBeenCalledTimes(1);
-    const req = httpRequest.mock.calls[0][0];
-    expect(req.url).toContain(
-      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
-    );
-    expect(req.method).toBe("POST");
+    expect(httpRequest).toHaveBeenCalledTimes(1)
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.method).toBe('POST')
     // organizationId addresses the request, it is not part of the body
-    expect(req.body.organizationId).toBeUndefined();
-    expect(req.body.name).toBe("Support docs");
-    expect(created.publicId).toBe(TEST_KB_ID);
-  });
+    expect(req.body.organizationId).toBeUndefined()
+    expect(req.body.name).toBe('Support docs')
+    expect(created.publicId).toBe(TEST_KB_ID)
+  })
 
-  test("knowledgeBases.list forwards pagination as query params", async () => {
-    httpRequest.mockResolvedValueOnce({ data: [], nextCursor: null });
+  test('knowledgeBases.list forwards pagination as query params', async () => {
+    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
 
     await context.knowledgeBases.list({
       organizationId: TEST_ORG_ID,
       limit: 5,
-      cursor: "abc",
-    });
+      cursor: 'abc',
+    })
 
-    const req = httpRequest.mock.calls[0][0];
-    expect(req.url).toContain(
-      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
-    );
-    expect(req.query).toMatchObject({ limit: "5", cursor: "abc" });
-  });
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.query).toMatchObject({limit: '5', cursor: 'abc'})
+  })
 
-  test("handle resolves the org/slug address once and reuses it", async () => {
+  test('handle resolves the org/slug address once and reuses it', async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // by-id resolution
-      .mockResolvedValueOnce({ data: [], nextCursor: null }) // issues.list
-      .mockResolvedValueOnce({ data: [], nextCursor: null }); // entries.list
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await kb.issues.list();
-    await kb.entries.list();
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.issues.list()
+    await kb.entries.list()
 
-    expect(httpRequest).toHaveBeenCalledTimes(3);
-    expect(httpRequest.mock.calls[0][0].url).toContain(
-      `/context/knowledge-bases/${TEST_KB_ID}`,
-    );
+    expect(httpRequest).toHaveBeenCalledTimes(3)
+    expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
     expect(httpRequest.mock.calls[1][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
-    );
+    )
     expect(httpRequest.mock.calls[2][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/entries`,
-    );
-  });
+    )
+  })
 
-  test("address resolution never carries a caller abort signal", async () => {
-    httpRequest
-      .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({ jobId: "job1" });
+  test('address resolution never carries a caller abort signal', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
 
-    const controller = new AbortController();
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await kb.build({ signal: controller.signal });
+    const controller = new AbortController()
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.build({signal: controller.signal})
 
     // The by-id resolution is shared by every method on the handle; a
     // caller's signal on it would abort concurrent callers too.
-    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined();
-    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal);
-  });
+    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined()
+    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal)
+  })
 
-  test("a failed resolution does not poison the handle", async () => {
+  test('a failed resolution does not poison the handle', async () => {
     httpRequest
-      .mockRejectedValueOnce(new Error("network down"))
+      .mockRejectedValueOnce(new Error('network down'))
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({ jobId: "job1" });
+      .mockResolvedValueOnce({jobId: 'job1'})
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await expect(kb.build()).rejects.toThrow("network down");
-    await expect(kb.build()).resolves.toEqual({ jobId: "job1" });
-  });
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await expect(kb.build()).rejects.toThrow('network down')
+    await expect(kb.build()).resolves.toEqual({jobId: 'job1'})
+  })
 
-  test("issues.resolve posts the resolution with the issueId in the path", async () => {
+  test('issues.resolve posts the resolution with the issueId in the path', async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      issue: { status: "accepted" },
+      issue: {status: 'accepted'},
       entry: null,
       jobId: null,
-    });
+    })
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
+    const kb = context.knowledgeBase(TEST_KB_ID)
     const result = await kb.issues.resolve({
-      issueId: "issue.abc",
-      resolution: "keep_existing",
-    });
+      issueId: 'issue.abc',
+      resolution: 'keep_existing',
+    })
 
-    const req = httpRequest.mock.calls[1][0];
-    expect(req.url).toContain("/issues/issue.abc/resolve");
-    expect(req.body).toEqual({ resolution: "keep_existing" });
-    expect(result.issue.status).toBe("accepted");
-  });
+    const req = httpRequest.mock.calls[1][0]
+    expect(req.url).toContain('/issues/issue.abc/resolve')
+    expect(req.body).toEqual({resolution: 'keep_existing'})
+    expect(result.issue.status).toBe('accepted')
+  })
 
-  test("imports.create with type file stages, PUTs to the signed URL, and confirms", async () => {
+  test('imports.create with type file stages, PUTs to the signed URL, and confirms', async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // address resolution
       .mockResolvedValueOnce({
-        importId: "imp1",
-        uploadUrl: "https://storage.example/signed",
+        importId: 'imp1',
+        uploadUrl: 'https://storage.example/signed',
       })
-      .mockResolvedValueOnce({ jobId: "job9" }); // complete
+      .mockResolvedValueOnce({jobId: 'job9'}) // complete
     // The PUT rides the client's fetch resolution (so proxy config applies),
     // injected the same way the transport tests inject theirs.
-    const uploadFetch = vi
-      .fn()
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
-    const uploadContext = new ContextClient(uploadClient, httpRequest);
+    const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
     const result = await kb.imports.create({
-      type: "file",
-      file: new Blob(["hello"]),
-      filename: "hello.txt",
-      contentType: "text/plain",
-    });
+      type: 'file',
+      file: new Blob(['hello']),
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
 
-    expect(httpRequest.mock.calls[1][0].url).toContain("/imports/uploads");
+    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads')
     expect(httpRequest.mock.calls[1][0].body).toEqual({
-      filename: "hello.txt",
-      contentType: "text/plain",
-    });
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
     expect(uploadFetch).toHaveBeenCalledWith(
-      "https://storage.example/signed",
-      expect.objectContaining({ method: "PUT" }),
-    );
-    expect(httpRequest.mock.calls[2][0].url).toContain(
-      "/imports/uploads/imp1/complete",
-    );
-    expect(result).toEqual({ jobId: "job9" });
-  });
+      'https://storage.example/signed',
+      expect.objectContaining({method: 'PUT'}),
+    )
+    expect(httpRequest.mock.calls[2][0].url).toContain('/imports/uploads/imp1/complete')
+    expect(result).toEqual({jobId: 'job9'})
+  })
 
-  test("a failed signed-URL PUT surfaces as an error and never confirms", async () => {
+  test('a failed signed-URL PUT surfaces as an error and never confirms', async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      importId: "imp1",
-      uploadUrl: "https://storage.example/signed",
-    });
+      importId: 'imp1',
+      uploadUrl: 'https://storage.example/signed',
+    })
     const uploadFetch = vi
       .fn()
-      .mockResolvedValueOnce(
-        new Response(null, { status: 403, statusText: "Forbidden" }),
-      );
-    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
-    const uploadContext = new ContextClient(uploadClient, httpRequest);
+      .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
     await expect(
       kb.imports.create({
-        type: "file",
-        file: new Blob(["x"]),
-        filename: "x.txt",
+        type: 'file',
+        file: new Blob(['x']),
+        filename: 'x.txt',
       }),
-    ).rejects.toThrow("File upload failed: 403");
+    ).rejects.toThrow('File upload failed: 403')
     // stage + resolution only; the confirm call must not have fired
-    expect(httpRequest).toHaveBeenCalledTimes(2);
-  });
+    expect(httpRequest).toHaveBeenCalledTimes(2)
+  })
 
-  test("entry paths are encoded and read endpoints hit their routes", async () => {
+  test('entry paths are encoded and read endpoints hit their routes', async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({ id: "e1" }) // entries.get
-      .mockResolvedValueOnce({ entries: [], stats: {} }) // outline
+      .mockResolvedValueOnce({id: 'e1'}) // entries.get
+      .mockResolvedValueOnce({entries: [], stats: {}}) // outline
       .mockResolvedValueOnce({
-        content: "",
+        content: '',
         slice: null,
-        sourceId: "s1",
+        sourceId: 's1',
         totalLines: 1,
-      }); // sources.content
+      }) // sources.content
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await kb.entries.get({ path: "billing/refunds", format: "markdown" });
-    await kb.outline();
-    await kb.sources.content({ sourceId: "s1", startLine: 4, endLine: 10 });
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.entries.get({path: 'billing/refunds', format: 'markdown'})
+    await kb.outline()
+    await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
 
-    expect(httpRequest.mock.calls[1][0].url).toContain(
-      "/entries/billing%2Frefunds",
-    );
+    expect(httpRequest.mock.calls[1][0].url).toContain('/entries/billing%2Frefunds')
     expect(httpRequest.mock.calls[1][0].query).toMatchObject({
-      format: "markdown",
-    });
-    expect(httpRequest.mock.calls[2][0].url).toContain("/outline");
+      format: 'markdown',
+    })
+    expect(httpRequest.mock.calls[2][0].url).toContain('/outline')
     expect(httpRequest.mock.calls[3][0].query).toMatchObject({
-      startLine: "4",
-      endLine: "10",
-    });
-  });
-});
+      startLine: '4',
+      endLine: '10',
+    })
+  })
+})

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -71,9 +71,15 @@ describe('ContextClient', () => {
     })
     const context = new ContextClient(client, httpRequest)
 
-    await context.knowledgeBases.list({organizationId: TEST_ORG_ID, limit: 5, cursor: 'abc'})
+    await context.knowledgeBases.list({
+      organizationId: TEST_ORG_ID,
+      limit: 5,
+      cursor: 'abc',
+    })
     await context.knowledgeBases.get(TEST_KB_ID)
-    await context.knowledgeBases.edit(TEST_KB_ID, {title: 'Support docs (EU)'})
+    await context.knowledgeBases.edit(TEST_KB_ID, {
+      title: 'Support docs (EU)',
+    })
     const deleted = await context.knowledgeBases.delete(TEST_KB_ID)
 
     expect(httpRequest.mock.calls[0][0].query).toMatchObject({
@@ -92,17 +98,17 @@ describe('ContextClient', () => {
 
   test('scoped methods address the configured knowledge-base resource', async () => {
     httpRequest
-      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
-      .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // imports.list
+      .mockResolvedValueOnce({jobId: 'job1', status: 'running'}) // jobs.get
 
-    await kbContext.issues.list()
-    await kbContext.entries.list()
+    await kbContext.imports.list()
+    await kbContext.jobs.get({jobId: 'job1'})
 
     expect(httpRequest.mock.calls[0][0].url).toContain(
-      `/context/knowledge-bases/${TEST_KB_ID}/issues`,
+      `/context/knowledge-bases/${TEST_KB_ID}/imports`,
     )
     expect(httpRequest.mock.calls[1][0].url).toContain(
-      `/context/knowledge-bases/${TEST_KB_ID}/entries`,
+      `/context/knowledge-bases/${TEST_KB_ID}/jobs/job1`,
     )
   })
 
@@ -129,7 +135,7 @@ describe('ContextClient', () => {
       }),
       httpRequest,
     )
-    expect(() => wrongResource.issues.list()).toThrow(resourceError)
+    expect(() => wrongResource.imports.list()).toThrow(resourceError)
     expect(httpRequest).not.toHaveBeenCalled()
   })
 
@@ -176,7 +182,9 @@ describe('ContextClient', () => {
     // The PUT rides the client's fetch resolution (so proxy config applies),
     // injected the same way the transport tests inject theirs.
     const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
-    const uploadClient = createKbClient().withConfig({resolveFetch: () => uploadFetch})
+    const uploadClient = createKbClient().withConfig({
+      resolveFetch: () => uploadFetch,
+    })
     const uploadContext = new ContextClient(uploadClient, httpRequest)
 
     const result = await uploadContext.imports.create({
@@ -207,7 +215,9 @@ describe('ContextClient', () => {
     const uploadFetch = vi
       .fn()
       .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
-    const uploadClient = createKbClient().withConfig({resolveFetch: () => uploadFetch})
+    const uploadClient = createKbClient().withConfig({
+      resolveFetch: () => uploadFetch,
+    })
     const uploadContext = new ContextClient(uploadClient, httpRequest)
 
     await expect(
@@ -221,27 +231,30 @@ describe('ContextClient', () => {
     expect(httpRequest).toHaveBeenCalledTimes(1)
   })
 
-  test('entry paths are encoded and read endpoints hit their routes', async () => {
-    httpRequest
-      .mockResolvedValueOnce({id: 'e1'}) // entries.get
-      .mockResolvedValueOnce({entries: [], stats: {}}) // outline
-      .mockResolvedValueOnce({
-        content: '',
-        slice: null,
-        sourceId: 's1',
-        totalLines: 1,
-      }) // sources.content
+  test('path parameters are encoded on their way into the URL', async () => {
+    httpRequest.mockResolvedValueOnce({id: 'imp1'})
 
-    await kbContext.entries.get({path: 'billing/refunds', format: 'markdown'})
-    await kbContext.outline()
-    await kbContext.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
+    await kbContext.imports.get({importId: 'imports/../sneaky'})
 
-    expect(httpRequest.mock.calls[0][0].url).toContain('/entries/billing%2Frefunds')
-    expect(httpRequest.mock.calls[0][0].query).toMatchObject({
-      format: 'markdown',
+    expect(httpRequest.mock.calls[0][0].url).toContain('/imports/imports%2F..%2Fsneaky')
+  })
+
+  test('sources.content encodes the sourceId and passes the line range as query params', async () => {
+    httpRequest.mockResolvedValueOnce({
+      content: '',
+      slice: null,
+      sourceId: 's1',
+      totalLines: 1,
     })
-    expect(httpRequest.mock.calls[1][0].url).toContain('/outline')
-    expect(httpRequest.mock.calls[2][0].query).toMatchObject({
+
+    await kbContext.sources.content({
+      sourceId: 's/1',
+      startLine: 4,
+      endLine: 10,
+    })
+
+    expect(httpRequest.mock.calls[0][0].url).toContain('/sources/s%2F1/content')
+    expect(httpRequest.mock.calls[0][0].query).toMatchObject({
       startLine: '4',
       endLine: '10',
     })
@@ -255,6 +268,18 @@ describe('ContextClient', () => {
     expect(httpRequest.mock.calls[0][0]).toMatchObject({
       method: 'DELETE',
       url: expect.stringContaining('/sources/source1'),
+    })
+    expect(result).toBeUndefined()
+  })
+
+  test('imports.delete issues a DELETE and resolves to nothing', async () => {
+    httpRequest.mockResolvedValueOnce(undefined)
+
+    const result = await kbContext.imports.delete({importId: 'imp1'})
+
+    expect(httpRequest.mock.calls[0][0]).toMatchObject({
+      method: 'DELETE',
+      url: expect.stringContaining('/imports/imp1'),
     })
     expect(result).toBeUndefined()
   })

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -1,229 +1,235 @@
-import {createClient} from '@sanity/client'
-import {beforeEach, describe, expect, test, vi} from 'vitest'
+import { createClient } from "@sanity/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import {ContextClient} from '../src/context/ContextClient'
-import type {SanityClient} from '../src/SanityClient'
+import { ContextClient } from "../src/context/ContextClient";
+import type { SanityClient } from "../src/SanityClient";
 
-const TEST_ORG_ID = 'orgAbc123'
-const TEST_KB_ID = 'kb3do82whm'
+const TEST_ORG_ID = "orgAbc123";
+const TEST_KB_ID = "kb3do82whm";
 const TEST_KB = {
-  id: 'c0ffee00-0000-4000-8000-000000000000',
+  id: "c0ffee00-0000-4000-8000-000000000000",
   publicId: TEST_KB_ID,
-  slug: 'support-docs',
+  slug: "support-docs",
   organizationId: TEST_ORG_ID,
-  name: 'Support docs',
-  sanityProjectId: 'proj123',
-  sanityDatasetId: 'production',
-}
+  name: "Support docs",
+  sanityProjectId: "proj123",
+  sanityDatasetId: "production",
+};
 
-const httpRequest = vi.fn()
+const httpRequest = vi.fn();
 
-describe('ContextClient', () => {
-  let client: SanityClient
-  let context: ContextClient
+describe("ContextClient", () => {
+  let client: SanityClient;
+  let context: ContextClient;
 
   beforeEach(() => {
     client = createClient({
-      projectId: 'proj123',
-      dataset: 'production',
-      apiVersion: '2026-05-26',
+      projectId: "proj123",
+      dataset: "production",
+      apiVersion: "2026-05-26",
       useCdn: false,
-    })
-    httpRequest.mockReset()
-    context = new ContextClient(client, httpRequest)
-  })
+    });
+    httpRequest.mockReset();
+    context = new ContextClient(client, httpRequest);
+  });
 
-  test('knowledgeBases.create posts to the org-scoped collection', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB)
+  test("knowledgeBases.create posts to the org-scoped collection", async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB);
 
     const created = await context.knowledgeBases.create({
       organizationId: TEST_ORG_ID,
-      name: 'Support docs',
-      description: 'Docs and guides',
-      sanityProjectId: 'proj123',
-      sanityDatasetId: 'production',
-    })
+      name: "Support docs",
+      description: "Docs and guides",
+      sanityProjectId: "proj123",
+      sanityDatasetId: "production",
+    });
 
-    expect(httpRequest).toHaveBeenCalledTimes(1)
-    const req = httpRequest.mock.calls[0][0]
-    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
-    expect(req.method).toBe('POST')
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+    const req = httpRequest.mock.calls[0][0];
+    expect(req.url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
+    );
+    expect(req.method).toBe("POST");
     // organizationId addresses the request, it is not part of the body
-    expect(req.body.organizationId).toBeUndefined()
-    expect(req.body.name).toBe('Support docs')
-    expect(created.publicId).toBe(TEST_KB_ID)
-  })
+    expect(req.body.organizationId).toBeUndefined();
+    expect(req.body.name).toBe("Support docs");
+    expect(created.publicId).toBe(TEST_KB_ID);
+  });
 
-  test('knowledgeBases.list forwards pagination as query params', async () => {
-    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
+  test("knowledgeBases.list forwards pagination as query params", async () => {
+    httpRequest.mockResolvedValueOnce({ data: [], nextCursor: null });
 
     await context.knowledgeBases.list({
       organizationId: TEST_ORG_ID,
       limit: 5,
-      cursor: 'abc',
-    })
+      cursor: "abc",
+    });
 
-    const req = httpRequest.mock.calls[0][0]
-    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
-    expect(req.query).toMatchObject({limit: '5', cursor: 'abc'})
-  })
+    const req = httpRequest.mock.calls[0][0];
+    expect(req.url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
+    );
+    expect(req.query).toMatchObject({ limit: "5", cursor: "abc" });
+  });
 
-  test('handle resolves the org/slug address once and reuses it', async () => {
+  test("handle resolves the org/slug address once and reuses it", async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // by-id resolution
-      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
-      .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
+      .mockResolvedValueOnce({ data: [], nextCursor: null }) // issues.list
+      .mockResolvedValueOnce({ data: [], nextCursor: null }); // entries.list
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.issues.list()
-    await kb.entries.list()
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await kb.issues.list();
+    await kb.entries.list();
 
-    expect(httpRequest).toHaveBeenCalledTimes(3)
-    expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
+    expect(httpRequest).toHaveBeenCalledTimes(3);
+    expect(httpRequest.mock.calls[0][0].url).toContain(
+      `/context/knowledge-bases/${TEST_KB_ID}`,
+    );
     expect(httpRequest.mock.calls[1][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
-    )
+    );
     expect(httpRequest.mock.calls[2][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/entries`,
-    )
-  })
+    );
+  });
 
-  test('address resolution never carries a caller abort signal', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+  test("address resolution never carries a caller abort signal", async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB)
+      .mockResolvedValueOnce({ jobId: "job1" });
 
-    const controller = new AbortController()
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.build({signal: controller.signal})
+    const controller = new AbortController();
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await kb.build({ signal: controller.signal });
 
     // The by-id resolution is shared by every method on the handle; a
     // caller's signal on it would abort concurrent callers too.
-    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined()
-    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal)
-  })
+    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined();
+    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal);
+  });
 
-  test('a failed resolution does not poison the handle', async () => {
+  test("a failed resolution does not poison the handle", async () => {
     httpRequest
-      .mockRejectedValueOnce(new Error('network down'))
+      .mockRejectedValueOnce(new Error("network down"))
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({jobId: 'job1'})
+      .mockResolvedValueOnce({ jobId: "job1" });
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await expect(kb.build()).rejects.toThrow('network down')
-    await expect(kb.build()).resolves.toEqual({jobId: 'job1'})
-  })
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await expect(kb.build()).rejects.toThrow("network down");
+    await expect(kb.build()).resolves.toEqual({ jobId: "job1" });
+  });
 
-  test('issues.resolve posts the resolution with the issueId in the path', async () => {
+  test("issues.resolve posts the resolution with the issueId in the path", async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      issue: {status: 'accepted'},
+      issue: { status: "accepted" },
       entry: null,
       jobId: null,
-    })
+    });
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
+    const kb = context.knowledgeBase(TEST_KB_ID);
     const result = await kb.issues.resolve({
-      issueId: 'issue.abc',
-      resolution: 'keep_existing',
-    })
+      issueId: "issue.abc",
+      resolution: "keep_existing",
+    });
 
-    const req = httpRequest.mock.calls[1][0]
-    expect(req.url).toContain('/issues/issue.abc/resolve')
-    expect(req.body).toEqual({resolution: 'keep_existing'})
-    expect(result.issue.status).toBe('accepted')
-  })
+    const req = httpRequest.mock.calls[1][0];
+    expect(req.url).toContain("/issues/issue.abc/resolve");
+    expect(req.body).toEqual({ resolution: "keep_existing" });
+    expect(result.issue.status).toBe("accepted");
+  });
 
-  test('imports.create with type file stages, PUTs to the signed URL, and confirms', async () => {
+  test("imports.create with type file stages, PUTs to the signed URL, and confirms", async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // address resolution
       .mockResolvedValueOnce({
-        importId: 'imp1',
-        uploadUrl: 'https://storage.example/signed',
+        importId: "imp1",
+        uploadUrl: "https://storage.example/signed",
       })
-      .mockResolvedValueOnce({jobId: 'job9'}) // complete
+      .mockResolvedValueOnce({ jobId: "job9" }); // complete
     // The PUT rides the client's fetch resolution (so proxy config applies),
     // injected the same way the transport tests inject theirs.
-    const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
-    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
-    const uploadContext = new ContextClient(uploadClient, httpRequest)
-
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
-    const result = await kb.imports.create({
-      type: 'file',
-      file: new Blob(['hello']),
-      filename: 'hello.txt',
-      contentType: 'text/plain',
-    })
-
-    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads')
-    expect(httpRequest.mock.calls[1][0].body).toEqual({
-      filename: 'hello.txt',
-      contentType: 'text/plain',
-    })
-    expect(uploadFetch).toHaveBeenCalledWith(
-      'https://storage.example/signed',
-      expect.objectContaining({method: 'PUT'}),
-    )
-    expect(httpRequest.mock.calls[2][0].url).toContain('/imports/uploads/imp1/complete')
-    expect(result).toEqual({jobId: 'job9'})
-  })
-
-  test('a failed signed-URL PUT surfaces as an error and never confirms', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      importId: 'imp1',
-      uploadUrl: 'https://storage.example/signed',
-    })
     const uploadFetch = vi
       .fn()
-      .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
-    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
-    const uploadContext = new ContextClient(uploadClient, httpRequest)
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
+    const uploadContext = new ContextClient(uploadClient, httpRequest);
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
+    const result = await kb.imports.create({
+      type: "file",
+      file: new Blob(["hello"]),
+      filename: "hello.txt",
+      contentType: "text/plain",
+    });
+
+    expect(httpRequest.mock.calls[1][0].url).toContain("/imports/uploads");
+    expect(httpRequest.mock.calls[1][0].body).toEqual({
+      filename: "hello.txt",
+      contentType: "text/plain",
+    });
+    expect(uploadFetch).toHaveBeenCalledWith(
+      "https://storage.example/signed",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(httpRequest.mock.calls[2][0].url).toContain(
+      "/imports/uploads/imp1/complete",
+    );
+    expect(result).toEqual({ jobId: "job9" });
+  });
+
+  test("a failed signed-URL PUT surfaces as an error and never confirms", async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+      importId: "imp1",
+      uploadUrl: "https://storage.example/signed",
+    });
+    const uploadFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, { status: 403, statusText: "Forbidden" }),
+      );
+    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
+    const uploadContext = new ContextClient(uploadClient, httpRequest);
+
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
     await expect(
       kb.imports.create({
-        type: 'file',
-        file: new Blob(['x']),
-        filename: 'x.txt',
+        type: "file",
+        file: new Blob(["x"]),
+        filename: "x.txt",
       }),
-    ).rejects.toThrow('File upload failed: 403')
+    ).rejects.toThrow("File upload failed: 403");
     // stage + resolution only; the confirm call must not have fired
-    expect(httpRequest).toHaveBeenCalledTimes(2)
-  })
+    expect(httpRequest).toHaveBeenCalledTimes(2);
+  });
 
-  test('entry paths are encoded and read endpoints hit their routes', async () => {
+  test("entry paths are encoded and read endpoints hit their routes", async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({id: 'e1'}) // entries.get
-      .mockResolvedValueOnce({entries: [], stats: {}}) // outline
+      .mockResolvedValueOnce({ id: "e1" }) // entries.get
+      .mockResolvedValueOnce({ entries: [], stats: {} }) // outline
       .mockResolvedValueOnce({
-        content: '',
+        content: "",
         slice: null,
-        sourceId: 's1',
+        sourceId: "s1",
         totalLines: 1,
-      }) // sources.content
+      }); // sources.content
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.entries.get({path: 'billing/refunds', format: 'markdown'})
-    await kb.outline()
-    await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await kb.entries.get({ path: "billing/refunds", format: "markdown" });
+    await kb.outline();
+    await kb.sources.content({ sourceId: "s1", startLine: 4, endLine: 10 });
 
-    expect(httpRequest.mock.calls[1][0].url).toContain('/entries/billing%2Frefunds')
+    expect(httpRequest.mock.calls[1][0].url).toContain(
+      "/entries/billing%2Frefunds",
+    );
     expect(httpRequest.mock.calls[1][0].query).toMatchObject({
-      format: 'markdown',
-    })
-    expect(httpRequest.mock.calls[2][0].url).toContain('/outline')
+      format: "markdown",
+    });
+    expect(httpRequest.mock.calls[2][0].url).toContain("/outline");
     expect(httpRequest.mock.calls[3][0].query).toMatchObject({
-      startLine: '4',
-      endLine: '10',
-    })
-  })
-
-  test('contentClient returns a native client bound to the dataset', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB)
-
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    const content = await kb.contentClient()
-
-    expect(content.config().projectId).toBe('proj123')
-    expect(content.config().dataset).toBe('production')
-  })
-})
+      startLine: "4",
+      endLine: "10",
+    });
+  });
+});

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -15,23 +15,32 @@ const TEST_KB = {
 
 const httpRequest = vi.fn()
 
+/** A client configured the way scoped context methods require: with the knowledge base as its resource. */
+function createKbClient(): SanityClient {
+  return createClient({
+    apiVersion: '2026-05-26',
+    useCdn: false,
+    resource: {type: 'knowledge-base', id: TEST_KB_ID},
+  })
+}
+
 describe('ContextClient', () => {
-  let client: SanityClient
-  let context: ContextClient
+  let kbContext: ContextClient
 
   beforeEach(() => {
-    client = createClient({
+    httpRequest.mockReset()
+    kbContext = new ContextClient(createKbClient(), httpRequest)
+  })
+
+  test('knowledgeBases.create posts to the collection with the organization in the body', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB)
+    const client = createClient({
       projectId: 'proj123',
       dataset: 'production',
       apiVersion: '2026-05-26',
       useCdn: false,
     })
-    httpRequest.mockReset()
-    context = new ContextClient(client, httpRequest)
-  })
-
-  test('knowledgeBases.create posts to the collection with the organization in the body', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB)
+    const context = new ContextClient(client, httpRequest)
 
     const created = await context.knowledgeBases.create({
       organizationId: TEST_ORG_ID,
@@ -48,47 +57,93 @@ describe('ContextClient', () => {
     expect(created.publicId).toBe(TEST_KB_ID)
   })
 
-  test('knowledgeBases.list scopes by organization and forwards pagination as query params', async () => {
-    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
+  test('knowledgeBases management addresses per call: list, get, edit, delete', async () => {
+    httpRequest
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // list
+      .mockResolvedValueOnce(TEST_KB) // get
+      .mockResolvedValueOnce(TEST_KB) // edit
+      .mockResolvedValueOnce(undefined) // delete
+    const client = createClient({
+      projectId: 'proj123',
+      dataset: 'production',
+      apiVersion: '2026-05-26',
+      useCdn: false,
+    })
+    const context = new ContextClient(client, httpRequest)
 
-    await context.knowledgeBases.list({
+    await context.knowledgeBases.list({organizationId: TEST_ORG_ID, limit: 5, cursor: 'abc'})
+    await context.knowledgeBases.get(TEST_KB_ID)
+    await context.knowledgeBases.edit(TEST_KB_ID, {title: 'Support docs (EU)'})
+    const deleted = await context.knowledgeBases.delete(TEST_KB_ID)
+
+    expect(httpRequest.mock.calls[0][0].query).toMatchObject({
       organizationId: TEST_ORG_ID,
-      limit: 5,
+      limit: '5',
       cursor: 'abc',
     })
-
-    const req = httpRequest.mock.calls[0][0]
-    expect(req.url).toContain('/context/knowledge-bases')
-    expect(req.query).toMatchObject({organizationId: TEST_ORG_ID, limit: '5', cursor: 'abc'})
+    expect(httpRequest.mock.calls[1][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
+    expect(httpRequest.mock.calls[2][0]).toMatchObject({
+      method: 'PATCH',
+      body: {title: 'Support docs (EU)'},
+    })
+    expect(httpRequest.mock.calls[3][0].method).toBe('DELETE')
+    expect(deleted).toBeUndefined()
   })
 
-  test('handle methods address the knowledge base by id directly', async () => {
+  test('scoped methods address the configured knowledge-base resource', async () => {
     httpRequest
-      .mockResolvedValueOnce(TEST_KB) // get
       .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
       .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.get()
-    await kb.issues.list()
-    await kb.entries.list()
+    await kbContext.issues.list()
+    await kbContext.entries.list()
 
-    expect(httpRequest).toHaveBeenCalledTimes(3)
-    expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
-    expect(httpRequest.mock.calls[1][0].url).toContain(
+    expect(httpRequest.mock.calls[0][0].url).toContain(
       `/context/knowledge-bases/${TEST_KB_ID}/issues`,
     )
-    expect(httpRequest.mock.calls[2][0].url).toContain(
+    expect(httpRequest.mock.calls[1][0].url).toContain(
       `/context/knowledge-bases/${TEST_KB_ID}/entries`,
     )
+  })
+
+  test('scoped methods require a knowledge-base resource in the client configuration', () => {
+    const resourceError =
+      '`resource` of type `knowledge-base` must be configured to use knowledge-base methods'
+
+    const noResource = new ContextClient(
+      createClient({
+        projectId: 'proj123',
+        dataset: 'production',
+        apiVersion: '2026-05-26',
+        useCdn: false,
+      }),
+      httpRequest,
+    )
+    expect(() => noResource.build()).toThrow(resourceError)
+
+    const wrongResource = new ContextClient(
+      createClient({
+        apiVersion: '2026-05-26',
+        useCdn: false,
+        resource: {type: 'media-library', id: 'ml123'},
+      }),
+      httpRequest,
+    )
+    expect(() => wrongResource.issues.list()).toThrow(resourceError)
+    expect(httpRequest).not.toHaveBeenCalled()
+  })
+
+  test('data URLs on a knowledge-base resource follow the platform resource grammar', () => {
+    // Pins the query surface's address shape ahead of it going live, the
+    // same way media libraries resolve to /media-libraries/{id}/query.
+    expect(createKbClient().getDataUrl('query')).toBe(`/knowledge-bases/${TEST_KB_ID}/query`)
   })
 
   test('a caller abort signal rides the request', async () => {
     httpRequest.mockResolvedValueOnce({jobId: 'job1'})
 
     const controller = new AbortController()
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.build({signal: controller.signal})
+    await kbContext.build({signal: controller.signal})
 
     expect(httpRequest.mock.calls[0][0].signal).toBe(controller.signal)
   })
@@ -100,8 +155,7 @@ describe('ContextClient', () => {
       jobId: null,
     })
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    const result = await kb.issues.resolve({
+    const result = await kbContext.issues.resolve({
       issueId: 'issue.abc',
       resolution: 'keep_existing',
     })
@@ -122,11 +176,10 @@ describe('ContextClient', () => {
     // The PUT rides the client's fetch resolution (so proxy config applies),
     // injected the same way the transport tests inject theirs.
     const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
-    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadClient = createKbClient().withConfig({resolveFetch: () => uploadFetch})
     const uploadContext = new ContextClient(uploadClient, httpRequest)
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
-    const result = await kb.imports.create({
+    const result = await uploadContext.imports.create({
       type: 'file',
       file: new Blob(['hello']),
       filename: 'hello.txt',
@@ -154,12 +207,11 @@ describe('ContextClient', () => {
     const uploadFetch = vi
       .fn()
       .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
-    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadClient = createKbClient().withConfig({resolveFetch: () => uploadFetch})
     const uploadContext = new ContextClient(uploadClient, httpRequest)
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
     await expect(
-      kb.imports.create({
+      uploadContext.imports.create({
         type: 'file',
         file: new Blob(['x']),
         filename: 'x.txt',
@@ -180,10 +232,9 @@ describe('ContextClient', () => {
         totalLines: 1,
       }) // sources.content
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.entries.get({path: 'billing/refunds', format: 'markdown'})
-    await kb.outline()
-    await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
+    await kbContext.entries.get({path: 'billing/refunds', format: 'markdown'})
+    await kbContext.outline()
+    await kbContext.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
 
     expect(httpRequest.mock.calls[0][0].url).toContain('/entries/billing%2Frefunds')
     expect(httpRequest.mock.calls[0][0].query).toMatchObject({
@@ -199,7 +250,7 @@ describe('ContextClient', () => {
   test('sources.delete issues a DELETE and resolves to nothing', async () => {
     httpRequest.mockResolvedValueOnce(undefined)
 
-    const result = await context.knowledgeBase(TEST_KB_ID).sources.delete({sourceId: 'source1'})
+    const result = await kbContext.sources.delete({sourceId: 'source1'})
 
     expect(httpRequest.mock.calls[0][0]).toMatchObject({
       method: 'DELETE',

--- a/test/contextReads.test.ts
+++ b/test/contextReads.test.ts
@@ -1,0 +1,327 @@
+import {type ClientConfig, createClient} from '@sanity/client'
+import {firstValueFrom} from 'rxjs'
+import {describe, expect, test} from 'vitest'
+
+import {getActiveMock, testResolveFetch} from './helpers/mockFetch'
+
+const apiHost = 'https://api.sanity.url'
+const organizationId = 'org-123'
+const knowledgeBaseId = 'kb3do82whm'
+const queryPath = `/v2026-08-25/context/organizations/${organizationId}/query`
+
+const PAGE_SIZE = 200
+
+const baseConfig = {
+  apiHost,
+  apiVersion: '2026-08-25',
+  context: {organizationId},
+  resource: {type: 'knowledge-base', id: knowledgeBaseId},
+  useCdn: false,
+  useProjectHostname: false,
+} satisfies Partial<ClientConfig>
+
+const getMockClient = (config: Partial<ClientConfig> = {}) =>
+  createClient({...baseConfig, resolveFetch: testResolveFetch, ...config})
+
+/** The canned reads always pass values as GROQ params, JSON-encoded on the wire. */
+const params = (values: Record<string, unknown>) =>
+  Object.fromEntries(
+    Object.entries(values).map(([key, value]) => [`$${key}`, JSON.stringify(value)]),
+  )
+
+describe('context GROQ read helpers', () => {
+  test('entries.get reads one entry by path, knowledge-base scoped', async () => {
+    const entry = {
+      _id: 'entry-1',
+      _type: 'sanity.context.entry',
+      knowledgeBaseId,
+      path: 'billing/refunds',
+      title: 'Refunds',
+      body: 'Refunds are processed within 5 days.',
+      citations: [],
+      status: 'filled',
+    }
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', queryPath, {
+        query: {
+          query: '*[_type == "sanity.context.entry" && knowledgeBaseId == $kb && path == $path][0]',
+          ...params({kb: knowledgeBaseId, path: 'billing/refunds'}),
+        },
+      })
+      .respond({status: 200, body: {result: entry}})
+
+    await expect(getMockClient().context.entries.get({path: 'billing/refunds'})).resolves.toEqual(
+      entry,
+    )
+  })
+
+  test('entries.get resolves null when no entry sits at the path', async () => {
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', queryPath)
+      .respond({status: 200, body: {result: null}})
+
+    await expect(getMockClient().context.entries.get({path: 'no/such'})).resolves.toBeNull()
+  })
+
+  test('entries.list drains keyset pages on path and terminates on a short raw page', async () => {
+    const entryAt = (index: number) => ({
+      _id: `entry-${index}`,
+      path: `topics/${`${index}`.padStart(4, '0')}`,
+      title: `Topic ${index}`,
+      status: 'filled',
+    })
+    const fullPage = Array.from({length: PAGE_SIZE}, (_, index) => entryAt(index))
+    const shortPage = [entryAt(PAGE_SIZE), entryAt(PAGE_SIZE + 1)]
+    const pageQuery = `*[_type == "sanity.context.entry" && knowledgeBaseId == $kb && path > $after] | order(path asc) [0...${PAGE_SIZE}] {_id, path, title, tldr, status}`
+
+    const scope = getActiveMock().scope(apiHost)
+    scope
+      .on('GET', queryPath, {
+        query: {
+          query: pageQuery,
+          ...params({kb: knowledgeBaseId, after: ''}),
+        },
+      })
+      .respond({status: 200, body: {result: fullPage}})
+    scope
+      .on('GET', queryPath, {
+        query: {
+          query: pageQuery,
+          ...params({
+            kb: knowledgeBaseId,
+            after: fullPage[fullPage.length - 1].path,
+          }),
+        },
+      })
+      .respond({status: 200, body: {result: shortPage}})
+
+    const entries = await getMockClient().context.entries.list()
+
+    expect(entries).toHaveLength(PAGE_SIZE + shortPage.length)
+    expect(entries[0]).toEqual(entryAt(0))
+    expect(entries[entries.length - 1]).toEqual(entryAt(PAGE_SIZE + 1))
+    // Two requests: the full page demanded another, the short page ended it.
+    expect(getActiveMock().getRequests()).toHaveLength(2)
+  })
+
+  test('issues.list drains (_createdAt, _id) keyset pages and terminates on a short raw page', async () => {
+    const issueAt = (index: number) => ({
+      _id: `issue-${`${index}`.padStart(4, '0')}`,
+      _type: 'sanity.context.issue',
+      _createdAt: '2026-08-26T00:00:00.000Z',
+      knowledgeBaseId,
+      status: 'open',
+    })
+    const fullPage = Array.from({length: PAGE_SIZE}, (_, index) => issueAt(index))
+    const shortPage = [issueAt(PAGE_SIZE)]
+    const last = fullPage[fullPage.length - 1]
+
+    const scope = getActiveMock().scope(apiHost)
+    scope
+      .on('GET', queryPath, {
+        query: {
+          query: `*[_type == "sanity.context.issue" && knowledgeBaseId == $kb] | order(_createdAt asc, _id asc) [0...${PAGE_SIZE}]`,
+          ...params({kb: knowledgeBaseId}),
+        },
+      })
+      .respond({status: 200, body: {result: fullPage}})
+    scope
+      .on('GET', queryPath, {
+        query: {
+          query: `*[_type == "sanity.context.issue" && knowledgeBaseId == $kb && (_createdAt > $c || (_createdAt == $c && _id > $i))] | order(_createdAt asc, _id asc) [0...${PAGE_SIZE}]`,
+          ...params({kb: knowledgeBaseId, c: last._createdAt, i: last._id}),
+        },
+      })
+      .respond({status: 200, body: {result: shortPage}})
+
+    const issues = await getMockClient().context.issues.list()
+
+    expect(issues).toHaveLength(PAGE_SIZE + 1)
+    expect(issues[issues.length - 1]._id).toBe(shortPage[0]._id)
+  })
+
+  test('issues.list({status}) narrows the query with the status as a param', async () => {
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', queryPath, {
+        query: {
+          query: `*[_type == "sanity.context.issue" && knowledgeBaseId == $kb && status == $status] | order(_createdAt asc, _id asc) [0...${PAGE_SIZE}]`,
+          ...params({kb: knowledgeBaseId, status: 'open'}),
+        },
+      })
+      .respond({status: 200, body: {result: []}})
+
+    await expect(getMockClient().context.issues.list({status: 'open'})).resolves.toEqual([])
+  })
+
+  test('issues.get reads one issue by document id, knowledge-base scoped', async () => {
+    const issue = {
+      _id: 'issue-1',
+      _type: 'sanity.context.issue',
+      _createdAt: '2026-08-26T00:00:00.000Z',
+      knowledgeBaseId,
+      status: 'open',
+    }
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', queryPath, {
+        query: {
+          query: '*[_type == "sanity.context.issue" && knowledgeBaseId == $kb && _id == $id][0]',
+          ...params({kb: knowledgeBaseId, id: 'issue-1'}),
+        },
+      })
+      .respond({status: 200, body: {result: issue}})
+
+    await expect(getMockClient().context.issues.get({issueId: 'issue-1'})).resolves.toEqual(issue)
+  })
+
+  test('instructions.list reads current-schema instructions, oldest first', async () => {
+    const instruction = {
+      _id: 'instruction-1',
+      _type: 'sanity.context.instruction',
+      _createdAt: '2026-08-26T00:00:00.000Z',
+      knowledgeBaseId,
+      schemaVersion: 1,
+      statement: 'Prefer the EU refund policy.',
+      status: 'active',
+    }
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', queryPath, {
+        query: {
+          query: `*[_type == "sanity.context.instruction" && knowledgeBaseId == $kb && schemaVersion == 1] | order(_createdAt asc, _id asc) [0...${PAGE_SIZE}]`,
+          ...params({kb: knowledgeBaseId}),
+        },
+      })
+      .respond({status: 200, body: {result: [instruction]}})
+
+    await expect(getMockClient().context.instructions.list()).resolves.toEqual([instruction])
+  })
+
+  test('mcpEndpoints.list and get read org-scoped endpoint configurations', async () => {
+    const endpoint = {
+      _id: 'mcp-1',
+      _type: 'sanity.context.mcp',
+      organizationId,
+      name: 'support-agent',
+      title: 'Support agent',
+    }
+    const scope = getActiveMock().scope(apiHost)
+    scope
+      .on('GET', queryPath, {
+        query: {
+          query:
+            '*[_type == "sanity.context.mcp" && organizationId == $org] | order(_createdAt asc, _id asc) [0...500]',
+          ...params({org: organizationId}),
+        },
+      })
+      .respond({status: 200, body: {result: [endpoint]}})
+    scope
+      .on('GET', queryPath, {
+        query: {
+          query: '*[_type == "sanity.context.mcp" && organizationId == $org && name == $name][0]',
+          ...params({org: organizationId, name: 'support-agent'}),
+        },
+      })
+      .respond({status: 200, body: {result: endpoint}})
+
+    await expect(getMockClient().context.mcpEndpoints.list()).resolves.toEqual([endpoint])
+    await expect(
+      getMockClient().context.mcpEndpoints.get({name: 'support-agent'}),
+    ).resolves.toEqual(endpoint)
+  })
+
+  test('conversations.get reads one recorded conversation by thread id', async () => {
+    const conversation = {
+      _id: 'conversation-1',
+      _type: 'sanity.context.conversation',
+      organizationId,
+      threadId: 'thread-1',
+      messages: [],
+    }
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', queryPath, {
+        query: {
+          query:
+            '*[_type == "sanity.context.conversation" && organizationId == $org && threadId == $threadId][0]',
+          ...params({org: organizationId, threadId: 'thread-1'}),
+        },
+      })
+      .respond({status: 200, body: {result: conversation}})
+
+    await expect(
+      getMockClient().context.conversations.get({threadId: 'thread-1'}),
+    ).resolves.toEqual(conversation)
+  })
+
+  test('entries.rebuild POSTs to the encoded entry path and resolves the accepted job', async () => {
+    const accepted = {
+      jobId: 'job-1',
+      affectedEntries: [{id: 'entry-1', path: 'billing/refunds', title: 'Refunds'}],
+    }
+    getActiveMock()
+      .scope(apiHost)
+      .on(
+        'POST',
+        `/v2026-08-25/context/knowledge-bases/${knowledgeBaseId}/entries/billing%2Frefunds/rebuild`,
+      )
+      .respond({status: 202, body: accepted})
+
+    await expect(
+      getMockClient().context.entries.rebuild({path: 'billing/refunds'}),
+    ).resolves.toEqual(accepted)
+  })
+
+  test('the observable client mirrors the read helpers over the same plumbing', async () => {
+    const entry = {
+      _id: 'entry-1',
+      _type: 'sanity.context.entry',
+      knowledgeBaseId,
+      path: 'billing/refunds',
+      title: 'Refunds',
+      status: 'filled',
+    }
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', queryPath, {
+        query: {
+          query: '*[_type == "sanity.context.entry" && knowledgeBaseId == $kb && path == $path][0]',
+          ...params({kb: knowledgeBaseId, path: 'billing/refunds'}),
+        },
+      })
+      .respond({status: 200, body: {result: entry}})
+
+    await expect(
+      firstValueFrom(
+        getMockClient().observable.context.entries.get({
+          path: 'billing/refunds',
+        }),
+      ),
+    ).resolves.toEqual(entry)
+  })
+
+  test('knowledge-base scoped reads require the knowledge-base resource', () => {
+    const noResource = getMockClient({
+      resource: undefined,
+      '~experimental_resource': undefined,
+    })
+    const resourceError =
+      '`resource` of type `knowledge-base` must be configured to use knowledge-base methods'
+
+    expect(() => noResource.context.entries.list()).toThrow(resourceError)
+    expect(() => noResource.context.issues.list()).toThrow(resourceError)
+    expect(() => noResource.context.instructions.list()).toThrow(resourceError)
+  })
+
+  test('org-scoped reads require context.organizationId', () => {
+    const withoutOrg = getMockClient({context: undefined})
+    const orgError = '`context.organizationId` must be configured to query Context documents'
+
+    expect(() => withoutOrg.context.mcpEndpoints.list()).toThrow(orgError)
+    expect(() => withoutOrg.context.mcpEndpoints.get({name: 'a'})).toThrow(orgError)
+    expect(() => withoutOrg.context.conversations.get({threadId: 't'})).toThrow(orgError)
+  })
+})

--- a/test/contextStore.test.ts
+++ b/test/contextStore.test.ts
@@ -75,6 +75,46 @@ describe('context GROQ reads', () => {
     expect(() => withoutOrg.context.listen(query)).toThrow(orgError)
   })
 
+  test('conversations.save PUTs the transcript and classify PATCHes the verdict', async () => {
+    const conversation = {...conversationDocument, id: 'conversation-1'}
+    const scope = getActiveMock().scope(apiHost)
+    scope
+      .on('PUT', `/v2026-08-25/context/organizations/${organizationId}/conversations/thread-1`, {
+        body: {
+          messages: [{role: 'user', content: 'hi'}],
+          metadata: {mcpEndpoints: ['support-agent'], plan: 'enterprise'},
+        },
+      })
+      .respond({status: 200, body: conversation})
+    scope
+      .on('PATCH', `/v2026-08-25/context/organizations/${organizationId}/conversations/thread-1`, {
+        body: {coreMetrics: {successScore: 9, sentiment: 'positive', contentGaps: []}},
+      })
+      .respond({status: 200, body: conversation})
+
+    await expect(
+      getMockClient().context.conversations.save({
+        threadId: 'thread-1',
+        messages: [{role: 'user', content: 'hi'}],
+        metadata: {mcpEndpoints: ['support-agent'], plan: 'enterprise'},
+      }),
+    ).resolves.toEqual(conversation)
+    await expect(
+      getMockClient().context.conversations.classify({
+        threadId: 'thread-1',
+        coreMetrics: {successScore: 9, sentiment: 'positive', contentGaps: []},
+      }),
+    ).resolves.toEqual(conversation)
+  })
+
+  test('conversations.save requires context.organizationId in the client configuration', () => {
+    const withoutOrg = getMockClient({context: undefined})
+
+    expect(() =>
+      withoutOrg.context.conversations.save({threadId: 'thread-1', messages: []}),
+    ).toThrow('`context.organizationId` must be configured to record conversations')
+  })
+
   test('listen opens an EventSource scoped to the organization and emits mutation events', async () => {
     const mutation = {
       documentId: 'conversation-1',

--- a/test/contextStore.test.ts
+++ b/test/contextStore.test.ts
@@ -1,0 +1,115 @@
+import {type ClientConfig, createClient} from '@sanity/client'
+import {encode} from 'eventsource-encoder'
+import {firstValueFrom} from 'rxjs'
+import {describe, expect, test} from 'vitest'
+
+import {getActiveMock, streamBody, streamStall, testResolveFetch} from './helpers/mockFetch'
+
+const apiHost = 'https://api.sanity.url'
+const organizationId = 'org-123'
+
+const conversationDocument = {
+  _id: 'conversation-1',
+  _type: 'sanity.context.conversation',
+  _createdAt: '2026-08-26T09:58:00.000Z',
+  _updatedAt: '2026-08-26T09:58:00.000Z',
+  _rev: 'rev-1',
+  threadId: 'thread-1',
+  classification: {outcome: 'failed'},
+}
+
+const baseConfig = {
+  apiHost,
+  apiVersion: '2026-08-25',
+  context: {
+    organizationId,
+  },
+  useCdn: false,
+  useProjectHostname: false,
+}
+
+/**
+ * Client whose requests - including the EventSource connection `listen()`
+ * opens - go to the per-test `get-it/mock` transport.
+ */
+const getMockClient = (config: Partial<ClientConfig> = {}) =>
+  createClient({...baseConfig, resolveFetch: testResolveFetch, ...config})
+
+describe('context GROQ reads', () => {
+  const query = '*[_type == "sanity.context.conversation" && classification.outcome == $outcome]'
+
+  test('fetches conversation documents with a GROQ query and params', async () => {
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', `/v2026-08-25/context/organizations/${organizationId}/query`, {
+        query: {
+          $outcome: JSON.stringify('failed'),
+          query,
+        },
+      })
+      .respond({status: 200, body: {result: [conversationDocument]}})
+
+    await expect(getMockClient().context.fetch(query, {outcome: 'failed'})).resolves.toEqual([
+      conversationDocument,
+    ])
+  })
+
+  test('switches to POST past the GET size limit, keeping the organization in the path', async () => {
+    const hugeQuery = `${query} // ${'x'.repeat(12000)}`
+
+    getActiveMock()
+      .scope(apiHost)
+      .on('POST', `/v2026-08-25/context/organizations/${organizationId}/query`, {
+        body: {query: hugeQuery, params: {outcome: 'failed'}},
+      })
+      .respond({status: 200, body: {result: []}})
+
+    await expect(getMockClient().context.fetch(hugeQuery, {outcome: 'failed'})).resolves.toEqual([])
+  })
+
+  test('requires context.organizationId in the client configuration', () => {
+    const withoutOrg = getMockClient({context: undefined})
+    const orgError = '`context.organizationId` must be configured to query Context documents'
+
+    expect(() => withoutOrg.context.fetch(query)).toThrow(orgError)
+    expect(() => withoutOrg.context.listen(query)).toThrow(orgError)
+  })
+
+  test('listen opens an EventSource scoped to the organization and emits mutation events', async () => {
+    const mutation = {
+      documentId: 'conversation-1',
+      eventId: 'event-1',
+      identity: 'user-1',
+      mutations: [],
+      timestamp: '2026-08-26T09:58:00.000Z',
+      transactionCurrentEvent: 0,
+      transactionId: 'txn-1',
+      transactionTotalEvents: 1,
+      transition: 'appear',
+      visibility: 'query',
+    }
+
+    getActiveMock()
+      .scope(apiHost)
+      .on('GET', `/v2026-08-25/context/organizations/${organizationId}/listen`)
+      .respond({
+        status: 200,
+        body: streamBody(
+          encode({event: 'mutation', data: JSON.stringify(mutation)}),
+          streamStall(),
+        ),
+        headers: {'content-type': 'text/event-stream; charset=utf-8'},
+      })
+
+    const event = await firstValueFrom(getMockClient().context.listen(query, {outcome: 'failed'}))
+
+    expect(event).toEqual({type: 'mutation', ...mutation})
+
+    const [request] = getActiveMock().getRequests()
+    expect(request.url).toContain(`/context/organizations/${organizationId}/listen`)
+    expect(request.query).toMatchObject({
+      query,
+      $outcome: JSON.stringify('failed'),
+    })
+  })
+})


### PR DESCRIPTION
Adds a `client.context` namespace for Sanity Context: knowledge bases, builds, ingest, curation, conversation telemetry, and GROQ reads over every Context document, in one place.

The shape follows the Context API's tiering (documents are queried, the control plane is called): every read is GROQ, either free-form or through a canned helper, and every verb is a typed REST method mirroring the published 30-op contract.

```ts
const client = createClient({..., context: {organizationId, resource: {type: 'knowledge-base', id}}})

// Reads: free-form GROQ over any Context document type
await client.context.fetch(groq, params)
client.context.listen(groq, params)

// ...or canned helpers (documented queries, identity + pagination params only)
await client.context.entries.get({path: 'pricing/plans'})
await client.context.issues.list({status: 'open'})

// The automation lifecycle
await client.context.imports.create({type: 'text', title: 'Refund policy', content: md})
const {jobId} = await client.context.build()
await client.context.jobs.get({jobId})

// Robot triage
await client.context.issues.resolve({issueId, resolution: 'accept_new'})

// Conversation telemetry
await client.context.conversations.save(threadId, {messages, metadata})
```

Surface: KB CRUD, build/cancelBuild/refresh + jobs polling, imports (create/list/get/download/delete, file uploads via signed URL), sources (list/get/content/delete), issue transitions (apply/resolve/dismiss/reopen), instruction writes, entries.rebuild, conversations save/classify, plus the eight GROQ read helpers typed from the spec's published doc components (EntryDoc, IssueDoc, InstructionDoc, McpDoc, ConversationDoc). Everything exports under the single `Context` type namespace.

The vendored spec is the Context API's published contract (sanity-io/atlas#385 + #387); reads deliberately have no REST twin, so the helper doc comments show the exact GROQ they run.

Closes SAGE-817, part of SAGE-985

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new beta surface with org-scoped data access, async jobs, and direct signed-URL uploads; mostly additive but mistakes in triage/build calls could affect knowledge-base content.
> 
> **Overview**
> Adds a **beta** `client.context` API on both promise and observable clients, wired like other resource-scoped namespaces (e.g. media libraries).
> 
> **Configuration:** `resource: { type: 'knowledge-base', id }` scopes KB operations; `context.organizationId` scopes org-level GROQ and conversation telemetry. Asset uploads explicitly reject knowledge-base resources and point callers to `context.imports`.
> 
> **Reads:** `context.fetch` / `context.listen` hit the org Context document store (GET/POST query + EventSource listen). Canned helpers (`entries`, `issues`, `instructions`, `mcpEndpoints`, `conversations.get`) drain paginated GROQ internally.
> 
> **Writes (REST):** Knowledge base collection CRUD; per-KB build/cancel/refresh; imports (text/crawl/dataset/file with staged signed-URL upload); jobs; issue triage; instructions; entries rebuild; sources; conversation save/classify.
> 
> Types ship as `Context` from OpenAPI-derived `types.gen`; `_observe` is exported for observable wrappers. Minor version bump in changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93dfef0b0ebbe004b0aac09c877595491dcb63e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->