### PR TITLE
feat: add variant definition actions

### DIFF
--- a/.changeset/variant-definition-actions.md
+++ b/.changeset/variant-definition-actions.md
@@ -1,0 +1,13 @@
+---
+'@sanity/client': minor
+---
+
+feat: add variant definition actions
+
+Adds `CreateVariantDefinitionAction`, `EditVariantDefinitionAction` and
+`DeleteVariantDefinitionAction`, along with a `VariantDefinitionAction` union, covering the
+`sanity.action.variant.definition.*` actions. They are included in the `Action` union, so
+`client.action()` accepts them.
+
+Note that `Action` widening is a breaking change for code that exhaustively switches on
+`Action['actionType']` with a `never` fallthrough, which will need to handle the new cases.

--- a/src/types.ts
+++ b/src/types.ts
@@ -776,6 +776,15 @@ export type ReleaseAction =
   | DeleteReleaseAction
   | ImportReleaseAction
 
+/**
+ * @public
+ * @beta
+ */
+export type VariantDefinitionAction =
+  | CreateVariantDefinitionAction
+  | EditVariantDefinitionAction
+  | DeleteVariantDefinitionAction
+
 /** @public */
 export type VersionAction =
   | CreateVersionAction
@@ -794,6 +803,7 @@ export type Action =
   | UnpublishAction
   | VersionAction
   | ReleaseAction
+  | VariantDefinitionAction
 
 /** @public */
 export type ImportReleaseAction =
@@ -949,6 +959,88 @@ export interface UnpublishVersionAction {
   actionType: 'sanity.action.document.version.unpublish'
   versionId: string
   publishedId: string
+}
+
+/**
+ * Creates a new `system.variant` definition document.
+ *
+ * @public
+ * @beta
+ */
+export interface CreateVariantDefinitionAction {
+  actionType: 'sanity.action.variant.definition.create'
+
+  /**
+   * Name of the variant definition to create, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Conditions used to select this variant.
+   */
+  conditions?: ClientVariantConditions
+
+  /**
+   * Selection priority. Higher values are preferred when multiple variants
+   * match.
+   *
+   * Defaults to `0`.
+   */
+  priority?: number
+
+  metadata?: Record<string, Any>
+}
+
+/**
+ * Edits an existing variant definition.
+ *
+ * @public
+ * @beta
+ */
+export interface EditVariantDefinitionAction {
+  actionType: 'sanity.action.variant.definition.edit'
+
+  /**
+   * Name of the variant definition to edit, as in `_.variants.{variantName}`.
+   * Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Patch operations to apply.
+   */
+  patch: PatchOperations
+
+  /**
+   * When set, the action fails unless the current revision of the variant
+   * definition matches this value.
+   */
+  ifRevisionId?: string
+}
+
+/**
+ * Deletes a variant definition.
+ *
+ * Deletion fails if any document holds a strong reference to this variant.
+ *
+ * @public
+ * @beta
+ */
+export interface DeleteVariantDefinitionAction {
+  actionType: 'sanity.action.variant.definition.delete'
+
+  /**
+   * Name of the variant definition to delete, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * When set, the action fails unless the current revision of the variant
+   * definition matches this value.
+   */
+  ifRevisionId?: string
 }
 
 /**

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -9,10 +9,13 @@ import {
   type ContentSourceMap,
   type CreateAction,
   createClient as createCoreClient,
+  type CreateVariantDefinitionAction,
   type DatasetsResponse,
   type DeleteAction,
+  type DeleteVariantDefinitionAction,
   type DiscardAction,
   type EditAction,
+  type EditVariantDefinitionAction,
   type EmbeddingsSettings,
   type FilteredResponseQueryOptions,
   Patch,
@@ -3321,6 +3324,45 @@ describe('client', async () => {
       await expect(
         getClient().action([action1, action2, action3, action4, action5, action6, action7]),
       ).resolves.not.toThrow()
+    })
+
+    test.skipIf(isEdge)('action() performs variant definition operations', async () => {
+      const action1: CreateVariantDefinitionAction = {
+        actionType: 'sanity.action.variant.definition.create',
+        variantId: 'variant1',
+        conditions: {locale: 'en-US'},
+        priority: 10,
+        metadata: {title: 'US English'},
+      }
+
+      const action2: EditVariantDefinitionAction = {
+        actionType: 'sanity.action.variant.definition.edit',
+        variantId: 'variant2',
+        patch: {set: {priority: 20}},
+        ifRevisionId: 'rev2',
+      }
+
+      const action3: DeleteVariantDefinitionAction = {
+        actionType: 'sanity.action.variant.definition.delete',
+        variantId: 'variant3',
+        ifRevisionId: 'rev3',
+      }
+
+      getActiveMock()
+        .scope(projectHost())
+        .on('POST', '/v1/data/actions/foo', {
+          body: {
+            actions: [action1, action2, action3],
+          },
+        })
+        .respond({
+          status: 200,
+          body: {
+            transactionId: 'foo',
+          },
+        })
+
+      await expect(getClient().action([action1, action2, action3])).resolves.not.toThrow()
     })
 
     test.skipIf(isEdge)('action() accepts optional parameters', async () => {


### PR DESCRIPTION
### Description

This branch adds `CreateVariantDefinitionAction`, `EditVariantDefinitionAction`, and `DeleteVariantDefinitionAction` support to the client.

These actions target variant definitions.

### What to review

The new action types.

### Testing

Added unit tests, and verified implementation satisfies Studio usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only expansion plus a unit test; no runtime client logic changes, though exhaustive `Action` switches may need new cases.
> 
> **Overview**
> Adds **beta** TypeScript support for managing variant definitions via `client.action()`, aligned with the `sanity.action.variant.definition.*` API.
> 
> New public types include `VariantDefinitionAction` (create / edit / delete) with fields such as bare `variantId`, optional `conditions` and `priority` on create, `patch` on edit, and optional `ifRevisionId` on edit/delete. These are folded into the top-level `Action` union so callers can batch them like other actions.
> 
> A changeset documents this as a **minor** release and calls out that widening `Action` can break consumers that exhaustively switch on `Action['actionType']` with a `never` default. Tests assert the three variant actions serialize correctly in a POST to `/v1/data/actions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71a18969d049eeeda3405781dd7ecc1963f72cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->