### PR TITLE
feat: add variant actions

### DIFF
--- a/.changeset/variant-actions.md
+++ b/.changeset/variant-actions.md
@@ -1,0 +1,16 @@
+---
+'@sanity/client': minor
+---
+
+feat: add variant actions
+
+Adds `CreateVariantAction`, `EditVariantAction`, `DeleteVariantAction`, `PublishVariantAction` and
+`UnpublishVariantAction`, along with a `VariantAction` union, covering the
+`sanity.action.document.variant.*` actions. They are included in the `Action` union, so
+`client.action()` accepts them.
+
+Each action addresses a variant document by the `publishedId`, `variantId` and `bundleId` triple
+rather than by document ID, since the API derives the document ID from those three values.
+
+Note that `Action` widening is a breaking change for code that exhaustively switches on
+`Action['actionType']` with a `never` fallthrough, which will need to handle the new cases.

--- a/src/types.ts
+++ b/src/types.ts
@@ -840,6 +840,17 @@ export type VersionAction =
   | ReplaceVersionAction
   | UnpublishVersionAction
 
+/**
+ * @public
+ * @beta
+ */
+export type VariantAction =
+  | CreateVariantAction
+  | EditVariantAction
+  | DeleteVariantAction
+  | PublishVariantAction
+  | UnpublishVariantAction
+
 /** @public */
 export type Action =
   | CreateAction
@@ -850,6 +861,7 @@ export type Action =
   | PublishAction
   | UnpublishAction
   | VersionAction
+  | VariantAction
   | ReleaseAction
   | VariantDefinitionAction
 
@@ -1007,6 +1019,203 @@ export interface UnpublishVersionAction {
   actionType: 'sanity.action.document.version.unpublish'
   versionId: string
   publishedId: string
+}
+
+/**
+ * Creates a variant of a document, either by supplying the full document
+ * content, or the base ID of a document to copy.
+ *
+ * @public
+ * @beta
+ */
+export type CreateVariantAction = {
+  actionType: 'sanity.action.document.variant.create'
+
+  /**
+   * ID of the document group to create a variant in. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Source bundle: `'drafts'`, or a release id.
+   *
+   * Defaults to the published bundle.
+   */
+  bundleId?: 'drafts' | (string & {})
+} & (
+  | {
+      /**
+       * The full document content. Requires a `_type` property.
+       */
+      document: SanityDocumentStub
+      baseId?: never
+      ifBaseRevisionId?: never
+    }
+  | {
+      /**
+       * ID of an existing document to copy the content from.
+       */
+      baseId: string
+
+      /**
+       * When set, the action fails unless the current revision of the base
+       * document matches this value.
+       */
+      ifBaseRevisionId?: string
+      document?: never
+    }
+)
+
+/**
+ * Modifies a variant version of a document by applying a patch.
+ *
+ * If no such variant document exists it is first created, by copying the
+ * variant's published sibling, or the published document if the variant was
+ * never published.
+ *
+ * @public
+ * @beta
+ */
+export interface EditVariantAction {
+  actionType: 'sanity.action.document.variant.edit'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Source bundle: `'drafts'`, or a release id.
+   *
+   * Defaults to the published bundle.
+   */
+  bundleId?: 'drafts' | (string & {})
+
+  /**
+   * Patch operations to apply.
+   */
+  patch: PatchOperations
+}
+
+/**
+ * Deletes a variant of a document.
+ *
+ * @public
+ * @beta
+ */
+export interface DeleteVariantAction {
+  actionType: 'sanity.action.document.variant.delete'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Source bundle: `'drafts'`, or a release id.
+   *
+   * Defaults to the published bundle.
+   */
+  bundleId?: 'drafts' | (string & {})
+
+  /**
+   * Delete document history.
+   */
+  purge?: boolean
+}
+
+/**
+ * Publishes a variant version of a document, replacing the published variant
+ * and removing the source variant document.
+ *
+ * @public
+ * @beta
+ */
+export interface PublishVariantAction {
+  actionType: 'sanity.action.document.variant.publish'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Bundle to publish from: `'drafts'`, or a release id.
+   */
+  bundleId: 'drafts' | (string & {})
+
+  /**
+   * When set, publishing fails unless the current revision of the source
+   * variant document matches this value.
+   */
+  ifVersionRevisionId?: string
+
+  /**
+   * When set, publishing fails unless the current revision of the published
+   * variant document matches this value.
+   */
+  ifPublishedVariantRevisionId?: string
+}
+
+/**
+ * Unpublishes a variant version of a document.
+ *
+ * By default the published variant is removed and preserved as a draft
+ * variant. When a release id is given as the `bundleId`, the deletion is
+ * instead staged in that release, and takes effect when it is published.
+ *
+ * @public
+ * @beta
+ */
+export interface UnpublishVariantAction {
+  actionType: 'sanity.action.document.variant.unpublish'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * The content release in which to stage the unpublish.
+   *
+   * By default, the currently published document is unpublished immediately.
+   */
+  bundleId?: string
 }
 
 /**

--- a/test/client/data.mutations.test.ts
+++ b/test/client/data.mutations.test.ts
@@ -1,15 +1,20 @@
 import {
   type BaseActionOptions,
   type CreateAction,
+  type CreateVariantAction,
   type CreateVariantDefinitionAction,
   type DeleteAction,
+  type DeleteVariantAction,
   type DeleteVariantDefinitionAction,
   type DiscardAction,
   type EditAction,
+  type EditVariantAction,
   type EditVariantDefinitionAction,
   type PublishAction,
+  type PublishVariantAction,
   type ReplaceDraftAction,
   type UnpublishAction,
+  type UnpublishVariantAction,
 } from '@sanity/client'
 import {describe, expect, test} from 'vitest'
 
@@ -698,6 +703,141 @@ describe('mutations', () => {
       })
 
     await expect(getClient().action([action1, action2, action3])).resolves.not.toThrow()
+  })
+
+  test('action() performs variant document operations', async () => {
+    const action1: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post1',
+      variantId: 'nb-NO',
+      bundleId: 'drafts',
+      document: {_type: 'post', title: 'Norwegian variant'},
+    }
+
+    const action2: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post2',
+      variantId: 'nb-NO',
+      baseId: 'post2',
+      ifBaseRevisionId: 'rev2',
+    }
+
+    const action3: EditVariantAction = {
+      actionType: 'sanity.action.document.variant.edit',
+      publishedId: 'post3',
+      variantId: 'nb-NO',
+      bundleId: 'drafts',
+      patch: {set: {title: 'Updated variant'}},
+    }
+
+    const action4: DeleteVariantAction = {
+      actionType: 'sanity.action.document.variant.delete',
+      publishedId: 'post4',
+      variantId: 'nb-NO',
+      purge: true,
+    }
+
+    const action5: PublishVariantAction = {
+      actionType: 'sanity.action.document.variant.publish',
+      publishedId: 'post5',
+      variantId: 'nb-NO',
+      bundleId: 'drafts',
+      ifVersionRevisionId: 'rev5',
+      ifPublishedVariantRevisionId: 'rev5-published',
+    }
+
+    const action6: UnpublishVariantAction = {
+      actionType: 'sanity.action.document.variant.unpublish',
+      publishedId: 'post6',
+      variantId: 'nb-NO',
+    }
+
+    getActiveMock()
+      .scope(projectHost())
+      .on('POST', '/v1/data/actions/foo', {
+        body: {
+          actions: [action1, action2, action3, action4, action5, action6],
+        },
+      })
+      .respond({
+        status: 200,
+        body: {
+          transactionId: 'foo',
+        },
+      })
+
+    await expect(
+      getClient().action([action1, action2, action3, action4, action5, action6]),
+    ).resolves.not.toThrow()
+  })
+
+  test('action() performs variant document operations in a content release', async () => {
+    const action1: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post1',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      document: {_type: 'post', title: 'Norwegian variant'},
+    }
+
+    const action2: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post2',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      baseId: 'post2',
+      ifBaseRevisionId: 'rev2',
+    }
+
+    const action3: EditVariantAction = {
+      actionType: 'sanity.action.document.variant.edit',
+      publishedId: 'post3',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      patch: {set: {title: 'Updated variant'}},
+    }
+
+    const action4: DeleteVariantAction = {
+      actionType: 'sanity.action.document.variant.delete',
+      publishedId: 'post4',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      purge: true,
+    }
+
+    const action5: PublishVariantAction = {
+      actionType: 'sanity.action.document.variant.publish',
+      publishedId: 'post5',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      ifVersionRevisionId: 'rev5',
+      ifPublishedVariantRevisionId: 'rev5-published',
+    }
+
+    const action6: UnpublishVariantAction = {
+      actionType: 'sanity.action.document.variant.unpublish',
+      publishedId: 'post6',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+    }
+
+    getActiveMock()
+      .scope(projectHost())
+      .on('POST', '/v1/data/actions/foo', {
+        body: {
+          actions: [action1, action2, action3, action4, action5, action6],
+        },
+      })
+      .respond({
+        status: 200,
+        body: {
+          transactionId: 'foo',
+        },
+      })
+
+    await expect(
+      getClient().action([action1, action2, action3, action4, action5, action6]),
+    ).resolves.not.toThrow()
   })
 
   test('action() accepts optional parameters', async () => {


### PR DESCRIPTION
### Description

This branch adds  `CreateVariantAction`, `EditVariantAction`, `DeleteVariantAction`, `PublishVariantAction`, and `UnpublishVariantAction` support to the client.

These actions target document variants.

### What to review

The new action types.

### Testing

Added unit tests, and verified implementation satisfies Studio usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widening `Action` can break compile-time exhaustiveness checks; behavior is type-only plus tests—no new runtime client logic in the diff—but variant publish/delete affects content correctness for consumers.
> 
> **Overview**
> Adds **beta** TypeScript support for five `sanity.action.document.variant.*` actions so `client.action()` can create, edit, delete, publish, and unpublish **document variants** (not variant definitions, which already existed).
> 
> Variants are targeted by **`publishedId`**, **`variantId`**, and optional **`bundleId`** (`drafts` or a release id) instead of a raw document id. `CreateVariantAction` accepts either inline `document` content or `baseId` with optional `ifBaseRevisionId`; publish/unpublish mirror draft flows with revision guards and release staging where applicable.
> 
> The public **`VariantAction`** union is folded into **`Action`**, which is a **type-level breaking change** for exhaustive `switch`es on `actionType` that use a `never` default. Unit tests assert the full action payloads POST to `/v1/data/actions` for both drafts and content-release bundles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af85b0eacff3759fa7327a9c32813a0a3f87bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->