### PR TITLE
docs: variant and variant definition actions

### DIFF
--- a/.changeset/variant-actions.md
+++ b/.changeset/variant-actions.md
@@ -1,0 +1,16 @@
+---
+'@sanity/client': minor
+---
+
+feat: add variant actions
+
+Adds `CreateVariantAction`, `EditVariantAction`, `DeleteVariantAction`, `PublishVariantAction` and
+`UnpublishVariantAction`, along with a `VariantAction` union, covering the
+`sanity.action.document.variant.*` actions. They are included in the `Action` union, so
+`client.action()` accepts them.
+
+Each action addresses a variant document by the `publishedId`, `variantId` and `bundleId` triple
+rather than by document ID, since the API derives the document ID from those three values.
+
+Note that `Action` widening is a breaking change for code that exhaustively switches on
+`Action['actionType']` with a `never` fallthrough, which will need to handle the new cases.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ export async function updateDocumentTitle(_id, title) {
       - [Archive Release Action](#archive-release)
       - [Unarchive Release Action](#unarchive-release)
       - [Delete Release Action](#delete-release)
+    - [Variant actions](#variant-actions)
+      - [Create Variant Action](#create-variant)
+      - [Edit Variant Action](#edit-variant)
+      - [Delete Variant Action](#delete-variant)
+      - [Publish Variant Action](#publish-variant)
+      - [Unpublish Variant Action](#unpublish-variant)
+    - [Variant definition actions](#variant-definition-actions)
+      - [Create Variant Definition Action](#create-variant-definition)
+      - [Edit Variant Definition Action](#edit-variant-definition)
+      - [Delete Variant Definition Action](#delete-variant-definition)
   - [Agent Actions](#agent-actions-api)
     - [Overview](#overview)
     - [Generating Content](#generating-content)
@@ -1759,6 +1769,219 @@ client
   })
   .catch((err) => {
     console.error('Delete release failed: ', err.message)
+  })
+```
+
+## Variant actions
+
+Variant documents are addressed by the `publishedId`, `variantId` and `bundleId` triple, rather than by document ID, as the API derives the document ID from those three values.
+
+### Create variant
+
+Create a variant of a document from full document content.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.document.variant.create',
+    publishedId: 'bike-123',
+    variantId: 'nb-NO',
+    bundleId: 'drafts',
+    document: {
+      _type: 'bike',
+      name: 'Sykkel 123',
+    },
+  })
+  .then(() => {
+    console.log('Norwegian draft variant of `bike-123` created')
+  })
+  .catch((error) => {
+    console.error('Create variant failed: ', error.message)
+  })
+```
+
+> [!NOTE]
+> `bundleId` selects the bundle the variant is created in, and may be `'$published'` (the default), `'drafts'`, or a release id.
+
+Passing `baseId` instead of `document` copies the content from an existing document, optionally only if that document is a given revision.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.document.variant.create',
+    publishedId: 'bike-123',
+    variantId: 'nb-NO',
+    baseId: 'bike-123',
+    ifBaseRevisionId: 'exp29Ru1',
+  })
+  .then(() => {
+    console.log('Norwegian variant of `bike-123` created from the published document')
+  })
+  .catch((error) => {
+    console.error('Create variant failed: ', error.message)
+  })
+```
+
+### Edit variant
+
+Modify a variant of a document by applying a patch. If no such variant document exists it is first created, by copying the variant's published sibling, or the published document if the variant was never published.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.document.variant.edit',
+    publishedId: 'bike-123',
+    variantId: 'nb-NO',
+    bundleId: 'drafts',
+    patch: {
+      set: {name: 'Sykkel 123'},
+    },
+  })
+  .then(() => {
+    console.log('Norwegian draft variant of `bike-123` updated')
+  })
+  .catch((error) => {
+    console.error('Edit variant failed: ', error.message)
+  })
+```
+
+### Delete variant
+
+Delete a variant of a document. Pass `purge: true` to also delete the document history.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.document.variant.delete',
+    publishedId: 'bike-123',
+    variantId: 'nb-NO',
+    bundleId: 'drafts',
+    purge: true,
+  })
+  .then(() => {
+    console.log('Norwegian draft variant of `bike-123` deleted')
+  })
+  .catch((error) => {
+    console.error('Delete variant failed: ', error.message)
+  })
+```
+
+### Publish variant
+
+Publish a variant of a document, replacing the published variant and removing the source variant document.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.document.variant.publish',
+    publishedId: 'bike-123',
+    variantId: 'nb-NO',
+    bundleId: 'drafts',
+    ifVersionRevisionId: 'exp29Ru1',
+    ifPublishedVariantRevisionId: 'exp29Ru0',
+  })
+  .then(() => {
+    console.log('Norwegian variant of `bike-123` published')
+  })
+  .catch((error) => {
+    console.error('Publish variant failed: ', error.message)
+  })
+```
+
+> [!NOTE]
+> `bundleId` is required here, and must be `'drafts'` or a release id, as `'$published'` would make the source and target the same document.
+
+### Unpublish variant
+
+Unpublish a variant of a document. By default the published variant is removed and preserved as a draft variant.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.document.variant.unpublish',
+    publishedId: 'bike-123',
+    variantId: 'nb-NO',
+  })
+  .then(() => {
+    console.log('Norwegian variant of `bike-123` unpublished')
+  })
+  .catch((error) => {
+    console.error('Unpublish variant failed: ', error.message)
+  })
+```
+
+> [!NOTE]
+> Replacing the default `'$published'` `bundleId` with a release id stages the removal in that release instead, so it takes effect when the release is published. `'drafts'` is not accepted.
+
+## Variant definition actions
+
+Variant definitions are `system.variant` documents, addressed by the bare variant name used in `_.variants.{variantName}`, rather than by document ID.
+
+### Create variant definition
+
+Create a new variant definition.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.variant.definition.create',
+    variantId: 'nb-NO',
+    conditions: {locale: 'nb-NO'},
+    priority: 10,
+    metadata: {title: 'Norwegian Bokmål'},
+  })
+  .then(() => {
+    console.log('`nb-NO` variant definition created')
+  })
+  .catch((error) => {
+    console.error('Create variant definition failed: ', error.message)
+  })
+```
+
+> [!NOTE]
+> `conditions` are used to select the variant, and `priority` (`0` by default) decides which variant wins when several of them match.
+
+### Edit variant definition
+
+Edit an existing variant definition by applying a patch.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.variant.definition.edit',
+    variantId: 'nb-NO',
+    patch: {
+      set: {priority: 20},
+    },
+    ifRevisionId: 'exp29Ru1',
+  })
+  .then(() => {
+    console.log('`nb-NO` variant definition changed to priority 20')
+  })
+  .catch((error) => {
+    console.error('Edit variant definition failed: ', error.message)
+  })
+```
+
+> [!NOTE]
+> When `ifRevisionId` is set, the action fails unless the variant definition is that revision.
+
+### Delete variant definition
+
+Delete a variant definition. Deletion fails if any document holds a strong reference to the variant.
+
+```ts
+client
+  .action({
+    actionType: 'sanity.action.variant.definition.delete',
+    variantId: 'nb-NO',
+    ifRevisionId: 'exp29Ru1',
+  })
+  .then(() => {
+    console.log('`nb-NO` variant definition deleted')
+  })
+  .catch((error) => {
+    console.error('Delete variant definition failed: ', error.message)
   })
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -840,6 +840,17 @@ export type VersionAction =
   | ReplaceVersionAction
   | UnpublishVersionAction
 
+/**
+ * @public
+ * @beta
+ */
+export type VariantAction =
+  | CreateVariantAction
+  | EditVariantAction
+  | DeleteVariantAction
+  | PublishVariantAction
+  | UnpublishVariantAction
+
 /** @public */
 export type Action =
   | CreateAction
@@ -850,6 +861,7 @@ export type Action =
   | PublishAction
   | UnpublishAction
   | VersionAction
+  | VariantAction
   | ReleaseAction
   | VariantDefinitionAction
 
@@ -1007,6 +1019,203 @@ export interface UnpublishVersionAction {
   actionType: 'sanity.action.document.version.unpublish'
   versionId: string
   publishedId: string
+}
+
+/**
+ * Creates a variant of a document, either by supplying the full document
+ * content, or the base ID of a document to copy.
+ *
+ * @public
+ * @beta
+ */
+export type CreateVariantAction = {
+  actionType: 'sanity.action.document.variant.create'
+
+  /**
+   * ID of the document group to create a variant in. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Source bundle: `'drafts'`, or a release id.
+   *
+   * Defaults to the published bundle.
+   */
+  bundleId?: 'drafts' | (string & {})
+} & (
+  | {
+      /**
+       * The full document content. Requires a `_type` property.
+       */
+      document: SanityDocumentStub
+      baseId?: never
+      ifBaseRevisionId?: never
+    }
+  | {
+      /**
+       * ID of an existing document to copy the content from.
+       */
+      baseId: string
+
+      /**
+       * When set, the action fails unless the current revision of the base
+       * document matches this value.
+       */
+      ifBaseRevisionId?: string
+      document?: never
+    }
+)
+
+/**
+ * Modifies a variant version of a document by applying a patch.
+ *
+ * If no such variant document exists it is first created, by copying the
+ * variant's published sibling, or the published document if the variant was
+ * never published.
+ *
+ * @public
+ * @beta
+ */
+export interface EditVariantAction {
+  actionType: 'sanity.action.document.variant.edit'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Source bundle: `'drafts'`, or a release id.
+   *
+   * Defaults to the published bundle.
+   */
+  bundleId?: 'drafts' | (string & {})
+
+  /**
+   * Patch operations to apply.
+   */
+  patch: PatchOperations
+}
+
+/**
+ * Deletes a variant of a document.
+ *
+ * @public
+ * @beta
+ */
+export interface DeleteVariantAction {
+  actionType: 'sanity.action.document.variant.delete'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Source bundle: `'drafts'`, or a release id.
+   *
+   * Defaults to the published bundle.
+   */
+  bundleId?: 'drafts' | (string & {})
+
+  /**
+   * Delete document history.
+   */
+  purge?: boolean
+}
+
+/**
+ * Publishes a variant version of a document, replacing the published variant
+ * and removing the source variant document.
+ *
+ * @public
+ * @beta
+ */
+export interface PublishVariantAction {
+  actionType: 'sanity.action.document.variant.publish'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * Bundle to publish from: `'drafts'`, or a release id.
+   */
+  bundleId: 'drafts' | (string & {})
+
+  /**
+   * When set, publishing fails unless the current revision of the source
+   * variant document matches this value.
+   */
+  ifVersionRevisionId?: string
+
+  /**
+   * When set, publishing fails unless the current revision of the published
+   * variant document matches this value.
+   */
+  ifPublishedVariantRevisionId?: string
+}
+
+/**
+ * Unpublishes a variant version of a document.
+ *
+ * By default the published variant is removed and preserved as a draft
+ * variant. When a release id is given as the `bundleId`, the deletion is
+ * instead staged in that release, and takes effect when it is published.
+ *
+ * @public
+ * @beta
+ */
+export interface UnpublishVariantAction {
+  actionType: 'sanity.action.document.variant.unpublish'
+
+  /**
+   * ID of the document group the variant belongs to. Must be a published
+   * document ID, without a `drafts.` or `versions.` prefix.
+   */
+  publishedId: string
+
+  /**
+   * Name of the variant definition this document belongs to, as in
+   * `_.variants.{variantName}`. Must be a bare name, not a full document ID.
+   */
+  variantId: string
+
+  /**
+   * The content release in which to stage the unpublish.
+   *
+   * By default, the currently published document is unpublished immediately.
+   */
+  bundleId?: string
 }
 
 /**

--- a/test/client/data.mutations.test.ts
+++ b/test/client/data.mutations.test.ts
@@ -1,15 +1,20 @@
 import {
   type BaseActionOptions,
   type CreateAction,
+  type CreateVariantAction,
   type CreateVariantDefinitionAction,
   type DeleteAction,
+  type DeleteVariantAction,
   type DeleteVariantDefinitionAction,
   type DiscardAction,
   type EditAction,
+  type EditVariantAction,
   type EditVariantDefinitionAction,
   type PublishAction,
+  type PublishVariantAction,
   type ReplaceDraftAction,
   type UnpublishAction,
+  type UnpublishVariantAction,
 } from '@sanity/client'
 import {describe, expect, test} from 'vitest'
 
@@ -698,6 +703,141 @@ describe('mutations', () => {
       })
 
     await expect(getClient().action([action1, action2, action3])).resolves.not.toThrow()
+  })
+
+  test('action() performs variant document operations', async () => {
+    const action1: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post1',
+      variantId: 'nb-NO',
+      bundleId: 'drafts',
+      document: {_type: 'post', title: 'Norwegian variant'},
+    }
+
+    const action2: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post2',
+      variantId: 'nb-NO',
+      baseId: 'post2',
+      ifBaseRevisionId: 'rev2',
+    }
+
+    const action3: EditVariantAction = {
+      actionType: 'sanity.action.document.variant.edit',
+      publishedId: 'post3',
+      variantId: 'nb-NO',
+      bundleId: 'drafts',
+      patch: {set: {title: 'Updated variant'}},
+    }
+
+    const action4: DeleteVariantAction = {
+      actionType: 'sanity.action.document.variant.delete',
+      publishedId: 'post4',
+      variantId: 'nb-NO',
+      purge: true,
+    }
+
+    const action5: PublishVariantAction = {
+      actionType: 'sanity.action.document.variant.publish',
+      publishedId: 'post5',
+      variantId: 'nb-NO',
+      bundleId: 'drafts',
+      ifVersionRevisionId: 'rev5',
+      ifPublishedVariantRevisionId: 'rev5-published',
+    }
+
+    const action6: UnpublishVariantAction = {
+      actionType: 'sanity.action.document.variant.unpublish',
+      publishedId: 'post6',
+      variantId: 'nb-NO',
+    }
+
+    getActiveMock()
+      .scope(projectHost())
+      .on('POST', '/v1/data/actions/foo', {
+        body: {
+          actions: [action1, action2, action3, action4, action5, action6],
+        },
+      })
+      .respond({
+        status: 200,
+        body: {
+          transactionId: 'foo',
+        },
+      })
+
+    await expect(
+      getClient().action([action1, action2, action3, action4, action5, action6]),
+    ).resolves.not.toThrow()
+  })
+
+  test('action() performs variant document operations in a content release', async () => {
+    const action1: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post1',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      document: {_type: 'post', title: 'Norwegian variant'},
+    }
+
+    const action2: CreateVariantAction = {
+      actionType: 'sanity.action.document.variant.create',
+      publishedId: 'post2',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      baseId: 'post2',
+      ifBaseRevisionId: 'rev2',
+    }
+
+    const action3: EditVariantAction = {
+      actionType: 'sanity.action.document.variant.edit',
+      publishedId: 'post3',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      patch: {set: {title: 'Updated variant'}},
+    }
+
+    const action4: DeleteVariantAction = {
+      actionType: 'sanity.action.document.variant.delete',
+      publishedId: 'post4',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      purge: true,
+    }
+
+    const action5: PublishVariantAction = {
+      actionType: 'sanity.action.document.variant.publish',
+      publishedId: 'post5',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+      ifVersionRevisionId: 'rev5',
+      ifPublishedVariantRevisionId: 'rev5-published',
+    }
+
+    const action6: UnpublishVariantAction = {
+      actionType: 'sanity.action.document.variant.unpublish',
+      publishedId: 'post6',
+      variantId: 'nb-NO',
+      bundleId: 'release456',
+    }
+
+    getActiveMock()
+      .scope(projectHost())
+      .on('POST', '/v1/data/actions/foo', {
+        body: {
+          actions: [action1, action2, action3, action4, action5, action6],
+        },
+      })
+      .respond({
+        status: 200,
+        body: {
+          transactionId: 'foo',
+        },
+      })
+
+    await expect(
+      getClient().action([action1, action2, action3, action4, action5, action6]),
+    ).resolves.not.toThrow()
   })
 
   test('action() accepts optional parameters', async () => {


### PR DESCRIPTION
### Description

This branch adds documentation for variant and variant definition actions.

Note: Content Variant is not yet generally available.