### PR TITLE
refactor: drop nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
   "dependencies": {
     "eventsource": "^5.1.0",
     "get-it": "^9.5.0",
-    "nanoid": "^6.0.1",
     "obug": "^2.1.4",
     "rxjs": "^7.8.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       get-it:
         specifier: ^9.5.0
         version: 9.5.0(vitest@4.1.10)
-      nanoid:
-        specifier: ^6.0.1
-        version: 6.0.1
       obug:
         specifier: ^2.1.4
         version: 2.1.4
@@ -3428,11 +3425,6 @@ packages:
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@6.0.1:
-    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
-    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   negotiator@1.0.0:
@@ -7437,8 +7429,6 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.18: {}
-
-  nanoid@6.0.1: {}
 
   negotiator@1.0.0: {}
 

--- a/src/util/createVersionId.ts
+++ b/src/util/createVersionId.ts
@@ -5,20 +5,30 @@ import {
   isDraftId,
   isVersionId,
 } from '@sanity/client/csm'
-import {customAlphabet} from 'nanoid'
 
 import type {IdentifiedSanityDocumentStub, SanityDocumentStub} from '../types'
 import {validateVersionIdMatch} from '../validators'
+
+const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
 /**
  * @internal
  *
  * ~24 years (or 7.54e+8 seconds) needed, in order to have a 1% probability of at least one collision if 10 ID's are generated every hour.
  */
-export const generateReleaseId = customAlphabet(
-  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
-  8,
-)
+export function generateReleaseId() {
+  let id = ''
+
+  while (id.length < 8) {
+    const bytes = crypto.getRandomValues(new Uint8Array(8 - id.length))
+    for (const byte of bytes) {
+      const index = byte & 63
+      if (index < alphabet.length) id += alphabet[index]
+    }
+  }
+
+  return id
+}
 
 /** @internal */
 export const getDocumentVersionId = (publishedId: string, releaseId?: string) =>


### PR DESCRIPTION
### Description

`nanoid` was used a single location, to generate release IDs. While the dependency is quite small, it's still a dependency. Since we're only using it to generate a specific, 8-character long ID with a given alphabet, we don't need the configuration of nanoid - so this inlines a variant doing what we need. It takes about ~500ms to generate a _million_ iterations on my macbook pro, and `getRandomValues()` gets executed only once per ID generation in about 78% of cases, otherwise it takes two calls.

### What to review

Looks okay?

### Testing

Relying on existing tests here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency swap with the same ID shape and call sites; behavior change risk is limited to randomness implementation details covered by existing tests.
> 
> **Overview**
> Removes the **`nanoid`** dependency and inlines release ID generation in **`generateReleaseId`** (`createVersionId.ts`).
> 
> **`generateReleaseId`** still returns 8 characters from the same alphanumeric alphabet, but now builds them with **`crypto.getRandomValues()`** (rejecting bytes that map outside the alphabet via `byte & 63`) instead of **`nanoid`’s `customAlphabet`**. **`createRelease`** continues to use this helper for default **`releaseId`** values; lockfile entries for **`nanoid@6.0.1`** are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1922fb6d750d8cbb1b891d03bea0b5b5c65c6459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->