### PR TITLE
test: restore variant definition tests

### DIFF
--- a/test/client/data.mutations.test.ts
+++ b/test/client/data.mutations.test.ts
@@ -1,9 +1,12 @@
 import {
   type BaseActionOptions,
   type CreateAction,
+  type CreateVariantDefinitionAction,
   type DeleteAction,
+  type DeleteVariantDefinitionAction,
   type DiscardAction,
   type EditAction,
+  type EditVariantDefinitionAction,
   type PublishAction,
   type ReplaceDraftAction,
   type UnpublishAction,
@@ -656,6 +659,45 @@ describe('mutations', () => {
     await expect(
       getClient().action([action1, action2, action3, action4, action5, action6, action7]),
     ).resolves.not.toThrow()
+  })
+
+  test('action() performs variant definition operations', async () => {
+    const action1: CreateVariantDefinitionAction = {
+      actionType: 'sanity.action.variant.definition.create',
+      variantId: 'variant1',
+      conditions: {locale: 'en-US'},
+      priority: 10,
+      metadata: {title: 'US English'},
+    }
+
+    const action2: EditVariantDefinitionAction = {
+      actionType: 'sanity.action.variant.definition.edit',
+      variantId: 'variant2',
+      patch: {set: {priority: 20}},
+      ifRevisionId: 'rev2',
+    }
+
+    const action3: DeleteVariantDefinitionAction = {
+      actionType: 'sanity.action.variant.definition.delete',
+      variantId: 'variant3',
+      ifRevisionId: 'rev3',
+    }
+
+    getActiveMock()
+      .scope(projectHost())
+      .on('POST', '/v1/data/actions/foo', {
+        body: {
+          actions: [action1, action2, action3],
+        },
+      })
+      .respond({
+        status: 200,
+        body: {
+          transactionId: 'foo',
+        },
+      })
+
+    await expect(getClient().action([action1, action2, action3])).resolves.not.toThrow()
   })
 
   test('action() accepts optional parameters', async () => {


### PR DESCRIPTION
### Description

This branch restores tests that were accidentally removed from `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Re-adds coverage for **`client.action()`** with variant-definition actions that were removed from `main`.
> 
> The restored test asserts a batched `POST` to `/v1/data/actions/foo` sends create, edit, and delete variant-definition payloads (`sanity.action.variant.definition.*`) and completes without error. Imports for the corresponding action types are restored alongside the test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 380f779cc665980cfadd17747e01bc6750f3323a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->