### PR TITLE
test: restore variant definition tests

### DIFF
--- a/test/client/data.mutations.test.ts
+++ b/test/client/data.mutations.test.ts
@@ -1,9 +1,12 @@
 import {
   type BaseActionOptions,
   type CreateAction,
+  type CreateVariantDefinitionAction,
   type DeleteAction,
+  type DeleteVariantDefinitionAction,
   type DiscardAction,
   type EditAction,
+  type EditVariantDefinitionAction,
   type PublishAction,
   type ReplaceDraftAction,
   type UnpublishAction,
@@ -656,6 +659,45 @@ describe('mutations', () => {
     await expect(
       getClient().action([action1, action2, action3, action4, action5, action6, action7]),
     ).resolves.not.toThrow()
+  })
+
+  test('action() performs variant definition operations', async () => {
+    const action1: CreateVariantDefinitionAction = {
+      actionType: 'sanity.action.variant.definition.create',
+      variantId: 'variant1',
+      conditions: {locale: 'en-US'},
+      priority: 10,
+      metadata: {title: 'US English'},
+    }
+
+    const action2: EditVariantDefinitionAction = {
+      actionType: 'sanity.action.variant.definition.edit',
+      variantId: 'variant2',
+      patch: {set: {priority: 20}},
+      ifRevisionId: 'rev2',
+    }
+
+    const action3: DeleteVariantDefinitionAction = {
+      actionType: 'sanity.action.variant.definition.delete',
+      variantId: 'variant3',
+      ifRevisionId: 'rev3',
+    }
+
+    getActiveMock()
+      .scope(projectHost())
+      .on('POST', '/v1/data/actions/foo', {
+        body: {
+          actions: [action1, action2, action3],
+        },
+      })
+      .respond({
+        status: 200,
+        body: {
+          transactionId: 'foo',
+        },
+      })
+
+    await expect(getClient().action([action1, action2, action3])).resolves.not.toThrow()
   })
 
   test('action() accepts optional parameters', async () => {


### PR DESCRIPTION
### Description

This branch restores tests that were accidentally removed from main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Restores coverage for **variant definition** actions on `getClient().action()` that was accidentally removed from main.
> 
> The new test **`action() performs variant definition operations`** asserts a batched `POST` to `/v1/data/actions/foo` with create (`sanity.action.variant.definition.create`), edit (patch + `ifRevisionId`), and delete (`ifRevisionId`) actions, and adds the corresponding `@sanity/client` action type imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a91826d93bb4818c6383afadde7166cf42fb38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->