### PR TITLE
fix(functions): enable sync and async function invokes

### DIFF
--- a/.changeset/functions-invoke-sync.md
+++ b/.changeset/functions-invoke-sync.md
@@ -1,0 +1,30 @@
+---
+'@sanity/client': minor
+---
+
+feat: invoke functions synchronously or asynchronously
+
+`client.functions.invoke()` now takes an `options` argument and accepts `sanity.function.durable`
+and `sanity.function.queue` functions alongside `sanity.function.pubsub`.
+
+By default the invocation is queued: the call resolves with `undefined` as soon as the Functions
+service accepts it, without waiting for the function to run. Pass `{sync: true}` to keep the
+request open until the function finishes and resolve with its return value — that adds a
+`?sync=true` query parameter to the invoke request, and remains limited to
+`sanity.function.pubsub`.
+
+```ts
+// Queued — resolves once accepted, with no return value.
+await client.functions.invoke('my-func', {event: {data: {hello: 'world'}}})
+
+// Inline — resolves with whatever the function returns.
+const result = await client.functions.invoke<Result>(
+  'my-func',
+  {event: {data: {hello: 'world'}}},
+  {sync: true},
+)
+```
+
+The return type follows the option: a call with `{sync: true}` resolves with `R`, while an async
+call resolves with `undefined`. Callers who pass an explicit type argument without `{sync: true}`
+keep the previous `R | undefined` shape.

--- a/.changeset/functions-invoke-sync.md
+++ b/.changeset/functions-invoke-sync.md
@@ -7,17 +7,17 @@ feat: invoke functions synchronously or asynchronously
 `client.functions.invoke()` now takes an `options` argument and accepts `sanity.function.durable`
 and `sanity.function.queue` functions alongside `sanity.function.pubsub`.
 
-By default the invocation is queued: the call resolves with `undefined` as soon as the Functions
+By default the invocation is queued: the call resolves with `undefined` as soon as the
 service accepts it, without waiting for the function to run. Pass `{sync: true}` to keep the
 request open until the function finishes and resolve with its return value — that adds a
 `?sync=true` query parameter to the invoke request, and remains limited to
 `sanity.function.pubsub`.
 
 ```ts
-// Queued — resolves once accepted, with no return value.
+// Async — resolves once accepted, with no return value.
 await client.functions.invoke('my-func', {event: {data: {hello: 'world'}}})
 
-// Inline — resolves with whatever the function returns.
+// Sync — resolves with whatever the function returns.
 const result = await client.functions.invoke<Result>(
   'my-func',
   {event: {data: {hello: 'world'}}},

--- a/src/functions/FunctionsClient.ts
+++ b/src/functions/FunctionsClient.ts
@@ -2,7 +2,7 @@ import {lastValueFrom, type Observable} from 'rxjs'
 
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import type {HttpRequest} from '../types'
-import {_invoke, type InvokeFunctionRequest} from './invoke'
+import {_invoke, type InvokeFunctionOptions, type InvokeFunctionRequest} from './invoke'
 
 /** @public */
 export class ObservableFunctionsClient {
@@ -17,16 +17,35 @@ export class ObservableFunctionsClient {
    * Invoke a deployed function by its blueprint name.
    *
    * The name is resolved within the stack given by `stackId` on the request or
-   * the client config. Passes the function's return value once it finishes.
+   * the client config. Queues the invocation and emits `undefined` as soon as
+   * it is accepted; pass `{sync: true}` to wait for the function's return value
+   * instead.
    *
    * @param functionName - name of the function, as declared in the blueprint
    * @param request - payload and request options
+   * @param options - invocation options
    */
+  invoke(
+    functionName: string,
+    request?: InvokeFunctionRequest,
+    options?: InvokeFunctionOptions & {sync?: false},
+  ): Observable<undefined>
+  invoke<R = unknown>(
+    functionName: string,
+    request: InvokeFunctionRequest | undefined,
+    options: InvokeFunctionOptions & {sync: true},
+  ): Observable<R>
   invoke<R = unknown>(
     functionName: string,
     request?: InvokeFunctionRequest,
+    options?: InvokeFunctionOptions,
+  ): Observable<R | undefined>
+  invoke<R = unknown>(
+    functionName: string,
+    request?: InvokeFunctionRequest,
+    options?: InvokeFunctionOptions,
   ): Observable<R | undefined> {
-    return _invoke<R>(this.#client, this.#httpRequest, functionName, request)
+    return _invoke<R>(this.#client, this.#httpRequest, functionName, request, options)
   }
 }
 
@@ -44,23 +63,45 @@ export class FunctionsClient {
    *
    * The name is resolved within the stack given by `stackId` on the request or
    * the client config, which costs one extra request per call. Rejects if the
-   * stack has no function by that name, or if the name resolves to anything
-   * other than a `sanity.function.pubsub` function.
+   * stack has no function by that name, or if the name resolves to a function
+   * type that cannot be invoked the way it was asked for.
    *
    * The lookup is scoped to `projectId`, or to `organizationId` when one is set
    * for a stack deployed at organization scope.
    *
-   * The request stays open until the function finishes, and resolves with its
-   * return value, or `undefined` if it returns nothing. Long-running functions
-   * may need an explicit `timeout`.
+   * The invocation is queued by default: the promise resolves with `undefined`
+   * as soon as the call is accepted, without waiting for the function to run.
+   * Pass `{sync: true}` to keep the request open until the function finishes
+   * and resolve with its return value — long-running functions may then need an
+   * explicit `timeout`. Only `sanity.function.pubsub` functions can be invoked
+   * synchronously.
    *
    * @param functionName - name of the function, as declared in the blueprint
    * @param request - payload and request options
+   * @param options - invocation options
    */
+  invoke(
+    functionName: string,
+    request?: InvokeFunctionRequest,
+    options?: InvokeFunctionOptions & {sync?: false},
+  ): Promise<undefined>
+  invoke<R = unknown>(
+    functionName: string,
+    request: InvokeFunctionRequest | undefined,
+    options: InvokeFunctionOptions & {sync: true},
+  ): Promise<R>
   invoke<R = unknown>(
     functionName: string,
     request?: InvokeFunctionRequest,
+    options?: InvokeFunctionOptions,
+  ): Promise<R | undefined>
+  invoke<R = unknown>(
+    functionName: string,
+    request?: InvokeFunctionRequest,
+    options?: InvokeFunctionOptions,
   ): Promise<R | undefined> {
-    return lastValueFrom(_invoke<R>(this.#client, this.#httpRequest, functionName, request))
+    return lastValueFrom(
+      _invoke<R>(this.#client, this.#httpRequest, functionName, request, options),
+    )
   }
 }

--- a/src/functions/FunctionsClient.ts
+++ b/src/functions/FunctionsClient.ts
@@ -17,7 +17,7 @@ export class ObservableFunctionsClient {
    * Invoke a deployed function by its blueprint name.
    *
    * The name is resolved within the stack given by `stackId` on the request or
-   * the client config. Queues the invocation and emits `undefined` as soon as
+   * the client config. Starts the invocation and emits `undefined` as soon as
    * it is accepted; pass `{sync: true}` to wait for the function's return value
    * instead.
    *
@@ -40,6 +40,7 @@ export class ObservableFunctionsClient {
     request?: InvokeFunctionRequest,
     options?: InvokeFunctionOptions,
   ): Observable<R | undefined>
+  // Implementation signature — not part of the public API.
   invoke<R = unknown>(
     functionName: string,
     request?: InvokeFunctionRequest,
@@ -69,7 +70,7 @@ export class FunctionsClient {
    * The lookup is scoped to `projectId`, or to `organizationId` when one is set
    * for a stack deployed at organization scope.
    *
-   * The invocation is queued by default: the promise resolves with `undefined`
+   * The invocation is started by default: the promise resolves with `undefined`
    * as soon as the call is accepted, without waiting for the function to run.
    * Pass `{sync: true}` to keep the request open until the function finishes
    * and resolve with its return value — long-running functions may then need an
@@ -95,6 +96,7 @@ export class FunctionsClient {
     request?: InvokeFunctionRequest,
     options?: InvokeFunctionOptions,
   ): Promise<R | undefined>
+  // Implementation signature — not part of the public API.
   invoke<R = unknown>(
     functionName: string,
     request?: InvokeFunctionRequest,

--- a/src/functions/invoke.ts
+++ b/src/functions/invoke.ts
@@ -6,7 +6,15 @@ import type {HttpRequest, InitializedClientConfig} from '../types'
 
 /** Function resource types in a blueprint are namespaced under this prefix. */
 const FUNCTION_RESOURCE_PREFIX = 'sanity.function.'
-const INVOKABLE_FUNCTION_TYPE = 'sanity.function.pubsub'
+const SYNC_INVOCABLE_FUNCTION_TYPES = ['sanity.function.pubsub']
+const ASYNC_INVOCABLE_FUNCTION_TYPES = [
+  'sanity.function.durable',
+  'sanity.function.pubsub',
+  'sanity.function.queue',
+]
+const INVOCABLE_FUNCTION_TYPES = [
+  ...new Set([...SYNC_INVOCABLE_FUNCTION_TYPES, ...ASYNC_INVOCABLE_FUNCTION_TYPES]),
+]
 
 /** @public */
 export interface InvokeFunctionEvent {
@@ -35,6 +43,18 @@ export interface InvokeFunctionRequest {
   timeout?: number
   /** Abort the invocation. */
   signal?: AbortSignal
+}
+
+/** @public */
+export interface InvokeFunctionOptions {
+  /**
+   * Wait for the function to finish and resolve with its return value.
+   *
+   * Defaults to `false`: the invocation is queued, the request resolves as soon
+   * as it is accepted, and the value is always `undefined`. Only function types
+   * that support running inline can be invoked synchronously.
+   */
+  sync?: boolean
 }
 
 /**
@@ -109,6 +129,7 @@ function _resolveFunctionId(
   stackId: string,
   headers: Record<string, string>,
   request: InvokeFunctionRequest | undefined,
+  sync: boolean,
 ): Observable<string> {
   return _requestObservable<{resources?: StackResource[]}>(client, httpRequest, {
     method: 'GET',
@@ -132,8 +153,14 @@ function _resolveFunctionId(
         )
       }
 
-      if (match.type !== INVOKABLE_FUNCTION_TYPE) {
+      if (!INVOCABLE_FUNCTION_TYPES.includes(match.type)) {
         throw new Error(`Function invocation is not supported for ${match.type}`)
+      }
+      if (sync && !SYNC_INVOCABLE_FUNCTION_TYPES.includes(match.type)) {
+        throw new Error(`Synchronous function invocation is not supported for ${match.type}`)
+      }
+      if (!sync && !ASYNC_INVOCABLE_FUNCTION_TYPES.includes(match.type)) {
+        throw new Error(`Asynchronous function invocation is not supported for ${match.type}`)
       }
 
       return match.externalId
@@ -147,6 +174,7 @@ export function _invoke<R = unknown>(
   httpRequest: HttpRequest,
   functionName: string,
   request?: InvokeFunctionRequest,
+  options?: InvokeFunctionOptions,
 ): Observable<R | undefined> {
   // Deferred so a bad config surfaces as an error on the returned observable
   // (and so a rejected promise) rather than throwing at the call site.
@@ -154,17 +182,30 @@ export function _invoke<R = unknown>(
     const config = client.config()
     const headers = scopeHeaders(config, request)
     const stackId = resolveStackId(config, request)
+    const sync = options?.sync ?? false
 
-    return _resolveFunctionId(client, httpRequest, functionName, stackId, headers, request).pipe(
-      // A function that returns nothing answers 204, which the transport parses
+    return _resolveFunctionId(
+      client,
+      httpRequest,
+      functionName,
+      stackId,
+      headers,
+      request,
+      sync,
+    ).pipe(
+      // An async invocation is only acknowledged (202, no body), and a sync
+      // function that returns nothing answers 204, which the transport parses
       // to an `undefined` body. The status code is not observable from here —
       // the `HttpRequest` boundary resolves to the body alone — so an empty
       // response and a function that returned nothing both surface as
       // `undefined`.
+      //
+      // The route is async by default, so `sync=false` is left off the wire
+      // rather than spelled out.
       mergeMap((functionId) =>
         _requestObservable<R | undefined>(client, httpRequest, {
           method: 'POST',
-          url: `/functions/${functionId}/invoke`,
+          url: `/functions/${functionId}/invoke${sync ? '?sync=true' : ''}`,
           headers,
           body: {event: {data: request?.event?.data ?? {}}},
           timeout: request?.timeout,

--- a/src/functions/invoke.ts
+++ b/src/functions/invoke.ts
@@ -50,7 +50,7 @@ export interface InvokeFunctionOptions {
   /**
    * Wait for the function to finish and resolve with its return value.
    *
-   * Defaults to `false`: the invocation is queued, the request resolves as soon
+   * Defaults to `false`: the invocation is started, the request resolves as soon
    * as it is accepted, and the value is always `undefined`. Only function types
    * that support running inline can be invoked synchronously.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2297,7 +2297,11 @@ export type {
   TranslateTarget,
   TranslateTargetInclude,
 } from './agent/actions/translate'
-export type {InvokeFunctionEvent, InvokeFunctionRequest} from './functions/invoke'
+export type {
+  InvokeFunctionEvent,
+  InvokeFunctionOptions,
+  InvokeFunctionRequest,
+} from './functions/invoke'
 export type {
   CollaborationCommentCreate,
   CollaborationCommentDocument,

--- a/test/functions/invoke.test-d.ts
+++ b/test/functions/invoke.test-d.ts
@@ -1,0 +1,59 @@
+import {createClient, type InvokeFunctionOptions} from '@sanity/client'
+import type {Observable} from 'rxjs'
+import {describe, expectTypeOf, test} from 'vitest'
+
+const client = createClient({
+  projectId: 'test123',
+  apiVersion: '2025-02-19',
+  useCdn: false,
+  stackId: 'ST-1234567890',
+})
+
+interface Payload {
+  ok: boolean
+}
+
+describe('client.functions.invoke', () => {
+  test('an async invoke never carries a return value', () => {
+    expectTypeOf(client.functions.invoke('my-func')).toEqualTypeOf<Promise<undefined>>()
+    expectTypeOf(client.functions.invoke('my-func', {event: {data: {}}})).toEqualTypeOf<
+      Promise<undefined>
+    >()
+    expectTypeOf(client.functions.invoke('my-func', undefined, {sync: false})).toEqualTypeOf<
+      Promise<undefined>
+    >()
+  })
+
+  test('a sync invoke resolves with the function return value', () => {
+    expectTypeOf(
+      client.functions.invoke<Payload>('my-func', undefined, {sync: true}),
+    ).toEqualTypeOf<Promise<Payload>>()
+    expectTypeOf(client.functions.invoke('my-func', undefined, {sync: true})).toEqualTypeOf<
+      Promise<unknown>
+    >()
+  })
+
+  test('a statically unknown `sync` widens to the union', () => {
+    const options: InvokeFunctionOptions = {sync: Math.random() > 0.5}
+
+    expectTypeOf(client.functions.invoke<Payload>('my-func', undefined, options)).toEqualTypeOf<
+      Promise<Payload | undefined>
+    >()
+  })
+
+  test('an explicit type argument on an async invoke still allows a body', () => {
+    // Callers who name a type opt into the pre-existing `R | undefined` shape.
+    expectTypeOf(client.functions.invoke<Payload>('my-func')).toEqualTypeOf<
+      Promise<Payload | undefined>
+    >()
+  })
+
+  test('the observable client mirrors the promise overloads', () => {
+    expectTypeOf(client.observable.functions.invoke('my-func')).toEqualTypeOf<
+      Observable<undefined>
+    >()
+    expectTypeOf(
+      client.observable.functions.invoke<Payload>('my-func', undefined, {sync: true}),
+    ).toEqualTypeOf<Observable<Payload>>()
+  })
+})

--- a/test/functions/invoke.test-d.ts
+++ b/test/functions/invoke.test-d.ts
@@ -55,5 +55,14 @@ describe('client.functions.invoke', () => {
     expectTypeOf(
       client.observable.functions.invoke<Payload>('my-func', undefined, {sync: true}),
     ).toEqualTypeOf<Observable<Payload>>()
+
+    const options: InvokeFunctionOptions = {sync: Math.random() > 0.5}
+
+    expectTypeOf(
+      client.observable.functions.invoke<Payload>('my-func', undefined, options),
+    ).toEqualTypeOf<Observable<Payload | undefined>>()
+    expectTypeOf(client.observable.functions.invoke<Payload>('my-func')).toEqualTypeOf<
+      Observable<Payload | undefined>
+    >()
   })
 })

--- a/test/functions/invoke.test.ts
+++ b/test/functions/invoke.test.ts
@@ -28,39 +28,117 @@ const getClient = (overrides: {stackId?: string} = {stackId: STACK_ID}) =>
   })
 
 const stackUri = (stackId: string) => `${BASE}/blueprints/stacks/${stackId}`
-const invokeUri = (functionId: string) => `${BASE}/functions/${functionId}/invoke`
+// The route is async by default, so only a sync invoke carries the query param.
+const invokeUri = (functionId: string, sync = false) =>
+  `${BASE}/functions/${functionId}/invoke${sync ? '?sync=true' : ''}`
+
+const SYNC_INVOCABLE_RESOURCES = [
+  {name: 'my-func', type: 'sanity.function.pubsub', externalId: 'fn-abc123'},
+]
+const ASYNC_INVOCABLE_RESOURCES = [
+  ...SYNC_INVOCABLE_RESOURCES,
+  {name: 'my-durable', type: 'sanity.function.durable', externalId: 'fn-durable'},
+  {name: 'my-queue', type: 'sanity.function.queue', externalId: 'fn-queue'},
+]
+// INVOCABLE, but only when queued — asking for a synchronous run must be refused.
+const ASYNC_ONLY_RESOURCES = ASYNC_INVOCABLE_RESOURCES.filter(
+  (resource) => !SYNC_INVOCABLE_RESOURCES.includes(resource),
+)
+const NON_INVOCABLE_RESOURCES = [
+  {name: 'doc-func', type: 'sanity.function.document', externalId: 'fn-def456'},
+  {name: 'cron-func', type: 'sanity.function.cron', externalId: 'fn-ghi789'},
+]
 
 const STACK = {
   id: STACK_ID,
   name: 'my-stack',
   resources: [
-    {name: 'my-func', type: 'sanity.function.pubsub', externalId: 'fn-abc123'},
-    // Only pubsub functions can be invoked on demand.
-    // Other types should be rejected without a request to the Functions service.
-    {name: 'doc-func', type: 'sanity.function.document', externalId: 'fn-def456'},
-    {name: 'cron-func', type: 'sanity.function.cron', externalId: 'fn-ghi789'},
+    ...ASYNC_INVOCABLE_RESOURCES,
+    ...NON_INVOCABLE_RESOURCES,
     // A non-function resource sharing a name must not be picked up.
     {name: 'my-func', type: 'sanity.cors.origin', externalId: 'co-000000'},
   ],
 }
 
 describe('client.functions.invoke', () => {
-  test('resolves the name within the stack and posts the event payload', async () => {
-    const mock = getActiveMock()
-    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
-    mock
-      .scope(HOST)
-      .on('POST', invokeUri('fn-abc123'), {body: {event: {data: {hello: 'world'}}}})
-      .respond({status: 200, body: {ok: true}})
+  for (const resource of ASYNC_INVOCABLE_RESOURCES) {
+    test(`resolves the name within the stack and posts the event payload for ${resource.type}`, async () => {
+      const mock = getActiveMock()
+      mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+      mock
+        .scope(HOST)
+        .on('POST', invokeUri(resource.externalId, false), {
+          body: {event: {data: {hello: 'world'}}},
+        })
+        .respond({status: 202})
 
-    const result = await getClient().functions.invoke('my-func', {
-      event: {data: {hello: 'world'}},
+      const result = await getClient().functions.invoke(resource.name, {
+        event: {data: {hello: 'world'}},
+      })
+
+      expect(result).toEqual(undefined)
+      expect(mock).toHaveReceivedRequest('GET', stackUri(STACK_ID))
+      expect(mock).toHaveReceivedRequest('POST', invokeUri(resource.externalId, false))
     })
 
-    expect(result).toEqual({ok: true})
-    expect(mock).toHaveReceivedRequest('GET', stackUri(STACK_ID))
-    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'))
-  })
+    test(`resolves the name within the stack and posts the event payload for ${resource.type} and async requested`, async () => {
+      const mock = getActiveMock()
+      mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+      mock
+        .scope(HOST)
+        .on('POST', invokeUri(resource.externalId, false), {
+          body: {event: {data: {hello: 'world'}}},
+        })
+        .respond({status: 202})
+
+      const result = await getClient().functions.invoke(
+        resource.name,
+        {
+          event: {data: {hello: 'world'}},
+        },
+        {sync: false},
+      )
+
+      expect(result).toEqual(undefined)
+      expect(mock).toHaveReceivedRequest('GET', stackUri(STACK_ID))
+      expect(mock).toHaveReceivedRequest('POST', invokeUri(resource.externalId, false))
+    })
+  }
+
+  for (const resource of SYNC_INVOCABLE_RESOURCES) {
+    test(`resolves the name within the stack and posts the event payload for ${resource.type} and sync requested`, async () => {
+      const mock = getActiveMock()
+      mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+      mock
+        .scope(HOST)
+        .on('POST', invokeUri(resource.externalId, true), {body: {event: {data: {hello: 'world'}}}})
+        .respond({status: 200, body: {ok: true}})
+
+      const result = await getClient().functions.invoke(
+        resource.name,
+        {
+          event: {data: {hello: 'world'}},
+        },
+        {sync: true},
+      )
+
+      expect(result).toEqual({ok: true})
+      expect(mock).toHaveReceivedRequest('GET', stackUri(STACK_ID))
+      expect(mock).toHaveReceivedRequest('POST', invokeUri(resource.externalId, true))
+    })
+  }
+
+  for (const resource of ASYNC_ONLY_RESOURCES) {
+    test(`rejects a sync invoke of ${resource.type} without calling the Functions service`, async () => {
+      const mock = getActiveMock()
+      mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+
+      await expect(
+        getClient().functions.invoke(resource.name, undefined, {sync: true}),
+      ).rejects.toThrow(`Synchronous function invocation is not supported for ${resource.type}`)
+      expect(mock).toHaveReceivedRequestTimes('POST', invokeUri(resource.externalId, true), 0)
+    })
+  }
 
   test('matches only resources of a function type', async () => {
     const mock = getActiveMock()
@@ -95,25 +173,17 @@ describe('client.functions.invoke', () => {
     await expect(getClient().functions.invoke('pending-func')).rejects.toThrow('is not deployed')
   })
 
-  test('rejects a document function without calling the Functions service', async () => {
-    const mock = getActiveMock()
-    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
+  for (const resource of NON_INVOCABLE_RESOURCES) {
+    test(`rejects a ${resource.type} without calling the Functions service`, async () => {
+      const mock = getActiveMock()
+      mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
 
-    await expect(getClient().functions.invoke('doc-func')).rejects.toThrow(
-      'Function invocation is not supported for sanity.function.document',
-    )
-    expect(mock).toHaveReceivedRequestTimes('POST', invokeUri('fn-def456'), 0)
-  })
-
-  test('rejects a cron function without calling the Functions service', async () => {
-    const mock = getActiveMock()
-    mock.scope(HOST).on('GET', stackUri(STACK_ID)).respond({status: 200, body: STACK})
-
-    await expect(getClient().functions.invoke('cron-func')).rejects.toThrow(
-      'Function invocation is not supported for sanity.function.cron',
-    )
-    expect(mock).toHaveReceivedRequestTimes('POST', invokeUri('fn-ghi789'), 0)
-  })
+      await expect(getClient().functions.invoke(resource.name)).rejects.toThrow(
+        `Function invocation is not supported for ${resource.type}`,
+      )
+      expect(mock).toHaveReceivedRequestTimes('POST', invokeUri(resource.externalId), 0)
+    })
+  }
 
   test('a per-call stackId overrides the client config', async () => {
     const mock = getActiveMock()
@@ -129,12 +199,12 @@ describe('client.functions.invoke', () => {
       })
     mock
       .scope(HOST)
-      .on('POST', invokeUri('fn-other999'))
+      .on('POST', invokeUri('fn-other999', false))
       .respond({status: 200, body: {ok: true}})
 
     await getClient().functions.invoke('my-func', {stackId: OTHER_STACK_ID})
 
-    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-other999'))
+    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-other999', false))
     // The stack from the client config is never consulted.
     expect(mock).toHaveReceivedRequestTimes('GET', stackUri(STACK_ID), 0)
   })
@@ -188,7 +258,9 @@ describe('client.functions.invoke', () => {
 
     await getClient().functions.invoke('my-func')
 
-    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'), {headers: scopeHeaders})
+    expect(mock).toHaveReceivedRequest('POST', invokeUri('fn-abc123'), {
+      headers: scopeHeaders,
+    })
   })
 
   test('scopes to the organization when `organizationId` is configured', async () => {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Now supports async invoke:

```javascript
const result = await client.functions.invoke('invoke-too', {
  event: {data: {_id: 'movie_118340'}}
})
```

and sync invoke:

```javascript
const result = await client.functions.invoke('invoke-too', {
  event: {data: {_id: 'movie_118340'}}
}, {sync: true})
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Please make sure I did the types correctly.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Unit tests updated and manually tested against prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API behavior change: existing callers of `functions.invoke()` no longer wait for a return value unless they pass `{sync: true}`. Not a security-critical path, but it is a silent default-behavior shift.
> 
> **Overview**
> **`client.functions.invoke()` is now async by default.** The call resolves with `undefined` as soon as the service accepts it. Pass `{sync: true}` to wait for a return value (still only `sanity.function.pubsub`).
> 
> Async invoke also works for `sanity.function.durable` and `sanity.function.queue`. Sync on those types is rejected before hitting the Functions service. The invoke URL gets `?sync=true` only when requested.
> 
> Overloads type async as `undefined`, sync as `R`, and a non-literal `sync` as `R | undefined`. An explicit type argument without `{sync: true}` keeps the old `R | undefined` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11cee0a9fa9995ce0b887deeaca80441029c934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->