### PR TITLE
fix: treat nullish apiHost as the default host

### DIFF
--- a/.changeset/pr-1296.md
+++ b/.changeset/pr-1296.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': patch
+---
+
+fix: treat nullish apiHost as the default host

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,7 @@ export const initConfig = (
   const newConfig = {
     ...defaultConfig,
     ...specifiedConfig,
+    apiHost: specifiedConfig.apiHost ?? defaultConfig.apiHost,
   } as InitializedClientConfig
 
   // Normalize resource configuration - prefer `resource` over deprecated `~experimental_resource`

--- a/test/client/config.test.ts
+++ b/test/client/config.test.ts
@@ -136,6 +136,24 @@ describe('base client', () => {
     expect(() => createClient({projectId: 'abc123', stega: undefined})).not.toThrow()
   })
 
+  test('uses default apiHost when it is undefined', () => {
+    const config = createClient({projectId: 'abc123', apiHost: undefined}).config()
+    expect(config.apiHost).toBe('https://api.sanity.io')
+    expect(config.url).toBe('https://abc123.api.sanity.io/v1')
+    expect(config.cdnUrl).toBe('https://abc123.apicdn.sanity.io/v1')
+  })
+
+  test('uses default apiHost when it is null', () => {
+    const config = createClient({
+      projectId: 'abc123',
+      // @ts-expect-error -- apiHost is string | undefined; null still arrives from unset env vars
+      apiHost: null,
+    }).config()
+    expect(config.apiHost).toBe('https://api.sanity.io')
+    expect(config.url).toBe('https://abc123.api.sanity.io/v1')
+    expect(config.cdnUrl).toBe('https://abc123.apicdn.sanity.io/v1')
+  })
+
   test('throws on invalid perspective', () => {
     expect(() => createClient({projectId: 'abc123', perspective: 'published'})).not.toThrow(
       /Invalid API perspective/,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SAPP-1401](https://linear.app/sanity/issue/SAPP-1401/sanityclient-throws-when-apihost-is-explicitly-undefined-or-null).

`createClient({apiHost: undefined})` and `apiHost: null` overwrote the default host via object spread, then `initConfig` called `.split` and threw `TypeError: Cannot read properties of undefined (reading 'split')`. Omitting the key already defaulted to `https://api.sanity.io`.

This change coalesces a nullish `apiHost` back to the factory default at the `initConfig` merge, so the env-var pattern `apiHost: process.env.SANITY_API_HOST` matches omit.

## Contract

- omit `apiHost` → `https://api.sanity.io` (unchanged)
- `apiHost: undefined` → same default, including `url` / `cdnUrl` (`*.apicdn.sanity.io`)
- `apiHost: null` at runtime → same default
- a provided host is unchanged
- `apiHost: ''` is unchanged (still builds a broken URL; separate validation question)

## Out of scope

- Defaulting or validating empty string
- Stripping all `undefined` keys from client config
- Studio `prepareConfig` / plugin workarounds
- Changing `apiVersion` or other options' undefined behaviour

## Verification

Constructor contract and knock-on host/CDN cases were run against unfixed `main` and this branch.

**Before (red):** `apiHost: undefined` and `apiHost: null` throw `TypeError` on `.split`. Omit, custom host, and empty string already behave as documented.

**After (green):** both nullish cases match omit (`https://api.sanity.io` + `*.apicdn.sanity.io`). Custom host still wins and does not flip onto `apicdn`. Empty string is still not defaulted. `withConfig({dataset})` after a custom host still keeps that host. `useProjectHostname: false` + `undefined` defaults without throwing.

[SAPP-1401 before and after red-green contract](https://cursor.com/agents/bc-fe9bde15-0ef0-4174-a037-e896ed6aff81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsapp1401-before-after.png)

[Desktop verification of the same comparison table](https://cursor.com/agents/bc-fe9bde15-0ef0-4174-a037-e896ed6aff81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsapp1401-verification-screenshot.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe9bde15-0ef0-4174-a037-e896ed6aff81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe9bde15-0ef0-4174-a037-e896ed6aff81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

