### PR TITLE
feat(collaboration): resolve comment `range` from optional `fieldValue`

### DIFF
--- a/.changeset/pr-1299.md
+++ b/.changeset/pr-1299.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': minor
+---
+
+feat(collaboration): resolve comment `range` from optional `fieldValue`

--- a/README.md
+++ b/README.md
@@ -2604,7 +2604,7 @@ const reply = await client.collaboration.comments.create({
 })
 ```
 
-Field comments pass a `path`. Inline comments also pass a `range` (block `_key` + character offset). An optional `fieldValue` is Portable Text covering that `range` (a slice or the full field); when set, the `range` is resolved from those blocks instead of from the live document:
+Field comments pass a `path`. Inline comments also pass a `range` (block `_key` + character offset). An optional `fieldValue` is Portable Text covering that `range` (a slice or the full field); when set with `range`, the `range` is resolved from those blocks instead of from the live document:
 
 ```js
 await client.collaboration.comments.create({
@@ -2625,7 +2625,7 @@ When querying, the field is stored as `target.path.field`, so filter with `targe
 
 #### Updating and deleting comments
 
-`update()` can change `message`, `status`, and/or `range`. Status changes cascade to replies. A `range` re-anchors an inline comment within the field it already targets; pass `null` to turn a text-level comment into a field-level one. An optional `fieldValue` may be passed with `range` for the same purpose as on create:
+`update()` can change `message`, `status`, and/or `range`. Status changes cascade to replies. A `range` re-anchors an inline comment within the field it already targets; pass `null` to turn a text-level comment into a field-level one. An optional `fieldValue` may be passed with a non-null `range` for the same purpose as on create (not alone or with `range: null`):
 
 ```js
 await client.collaboration.comments.update('comment-1', {status: 'resolved'})

--- a/README.md
+++ b/README.md
@@ -2604,7 +2604,7 @@ const reply = await client.collaboration.comments.create({
 })
 ```
 
-Field comments pass a `path`. Inline comments also pass a `range` (block `_key` + character offset):
+Field comments pass a `path`. Inline comments also pass a `range` (block `_key` + character offset). An optional `fieldValue` is Portable Text covering that `range` (a slice or the full field); when set, the `range` is resolved from those blocks instead of from the live document:
 
 ```js
 await client.collaboration.comments.create({
@@ -2625,7 +2625,7 @@ When querying, the field is stored as `target.path.field`, so filter with `targe
 
 #### Updating and deleting comments
 
-`update()` can change `message`, `status`, and/or `range`. Status changes cascade to replies. A `range` re-anchors an inline comment within the field and source document it already targets; pass `null` to clear the selection:
+`update()` can change `message`, `status`, and/or `range`. Status changes cascade to replies. A `range` re-anchors an inline comment within the field it already targets; pass `null` to turn a text-level comment into a field-level one. An optional `fieldValue` may be passed with `range` for the same purpose as on create:
 
 ```js
 await client.collaboration.comments.update('comment-1', {status: 'resolved'})

--- a/src/collaboration/types.ts
+++ b/src/collaboration/types.ts
@@ -162,12 +162,27 @@ export interface CollaborationCommentRange {
 }
 
 /**
+ * Portable Text covering a comment `range`. Callers can send just the blocks
+ * from the `range` start `_key` through end `_key`, or the full field.
+ *
+ * @alpha
+ */
+export type CollaborationCommentFieldValue = Array<{
+  _type: string
+  _key: string
+  [key: string]: Any
+}>
+
+/**
  * Target for a top-level comment. Inline selections require both `path` and
  * `range`; field-level comments may set `path` alone.
  *
  * The created comment stores this in a different shape: `path` becomes
  * `target.path.field`, and `range` is resolved against the document into
  * `target.path.selection` and `contentSnapshot` rather than being stored.
+ *
+ * An optional `fieldValue` is Portable Text covering the `range`. When set,
+ * the `range` is resolved from those blocks instead of from the live document.
  *
  * @alpha
  */
@@ -180,11 +195,17 @@ export type CollaborationCommentTarget = {
       /** Path to the field containing the inline comment selection */
       path: string
       range: CollaborationCommentRange
+      /**
+       * Portable Text covering the `range`. When set, the `range` is resolved
+       * from these blocks instead of from the live document.
+       */
+      fieldValue?: CollaborationCommentFieldValue
     }
   | {
       /** Path to the commented field */
       path?: string
       range?: never
+      fieldValue?: never
     }
 )
 
@@ -202,6 +223,19 @@ export type CollaborationCommentTarget = {
  * await client.collaboration.comments.create({
  *   message,
  *   target: {documentId: 'doc-1', documentType: 'article'},
+ * })
+ * ```
+ *
+ * #### Inline comment
+ * ```ts
+ * await client.collaboration.comments.create({
+ *   message,
+ *   target: {
+ *     documentId: 'doc-1',
+ *     documentType: 'article',
+ *     path: 'body',
+ *     range: {start: {_key: 'block-1', offset: 0}, end: {_key: 'block-1', offset: 5}},
+ *   },
  * })
  * ```
  *
@@ -236,17 +270,34 @@ export type CollaborationCommentCreate = {
 /**
  * Fields that can be updated on an existing comment.
  *
+ * A `range` re-anchors the comment within the field it already targets.
+ * Pass `null` to remove the selection and leave a field-level comment.
+ * An optional `fieldValue` is Portable Text covering that `range`; when set,
+ * the `range` is resolved from those blocks instead of from the live document.
+ * `fieldValue` cannot be sent alone or together with `range: null`.
+ *
  * @alpha
  */
-export interface CollaborationCommentUpdate {
+export type CollaborationCommentUpdate = {
   /** Replaces the current message */
   message?: CollaborationCommentMessage
   /** Cascades to the comment's replies */
   status?: CollaborationCommentStatus
-  /**
-   * Re-anchors the comment within the field and source document it already
-   * targets. Pass `null` to remove the selection and leave a field-level
-   * comment.
-   */
-  range?: CollaborationCommentRange | null
-}
+} & (
+  | {
+      range: CollaborationCommentRange
+      /**
+       * Portable Text covering the `range`. When set, the `range` is resolved
+       * from these blocks instead of from the live document.
+       */
+      fieldValue?: CollaborationCommentFieldValue
+    }
+  | {
+      range: null
+      fieldValue?: never
+    }
+  | {
+      range?: undefined
+      fieldValue?: never
+    }
+)

--- a/src/types.ts
+++ b/src/types.ts
@@ -2316,6 +2316,7 @@ export type {
   CollaborationCommentTarget,
   CollaborationCommentUpdate,
   CollaborationCommentRange,
+  CollaborationCommentFieldValue,
 } from './collaboration/types'
 export type {
   ContentSourceMapParsedPath,

--- a/test/collaborationComments.test-d.ts
+++ b/test/collaborationComments.test-d.ts
@@ -50,6 +50,26 @@ describe('CollaborationCommentCreate', () => {
         },
       },
     }).toMatchTypeOf<CollaborationCommentCreate>()
+
+    expectTypeOf({
+      message,
+      target: {
+        documentId: 'doc-1',
+        documentType: 'article',
+        path: 'body',
+        range: {
+          start: {_key: 'key-1', offset: 0},
+          end: {_key: 'key-2', offset: 10},
+        },
+        fieldValue: [
+          {
+            _type: 'block',
+            _key: 'key-1',
+            children: [{_type: 'span', text: 'Hello'}],
+          },
+        ],
+      },
+    }).toMatchTypeOf<CollaborationCommentCreate>()
   })
 
   test('requires path when range is provided', () => {
@@ -63,6 +83,40 @@ describe('CollaborationCommentCreate', () => {
           start: {_key: 'key-1', offset: 0},
           end: {_key: 'key-2', offset: 10},
         },
+      },
+    }
+
+    expectTypeOf(comment).toEqualTypeOf<CollaborationCommentCreate>()
+  })
+
+  test('requires range when fieldValue is provided', () => {
+    const comment: CollaborationCommentCreate = {
+      message,
+      // @ts-expect-error - fieldValue requires range
+      target: {
+        documentId: 'doc-1',
+        documentType: 'article',
+        path: 'body',
+        fieldValue: [{_type: 'block', _key: 'key-1', children: [{_type: 'span', text: 'Hello'}]}],
+      },
+    }
+
+    expectTypeOf(comment).toEqualTypeOf<CollaborationCommentCreate>()
+  })
+
+  test('requires `_key` on fieldValue items', () => {
+    const comment: CollaborationCommentCreate = {
+      message,
+      target: {
+        documentId: 'doc-1',
+        documentType: 'article',
+        path: 'body',
+        range: {
+          start: {_key: 'key-1', offset: 0},
+          end: {_key: 'key-1', offset: 5},
+        },
+        // @ts-expect-error - fieldValue items require `_key`
+        fieldValue: [{_type: 'block', children: [{_type: 'span', text: 'Hello'}]}],
       },
     }
 
@@ -131,9 +185,37 @@ describe('collaboration.comments write results', () => {
         range: {start: {_key: 'block-1', offset: 0}, end: {_key: 'block-1', offset: 12}},
       }),
     ).toEqualTypeOf<Promise<CollaborationCommentDocument>>()
+    expectTypeOf(
+      comments.update('comment-1', {
+        range: {start: {_key: 'block-1', offset: 0}, end: {_key: 'block-1', offset: 12}},
+        fieldValue: [{_type: 'block', _key: 'block-1', children: [{_type: 'span', text: 'Hello'}]}],
+      }),
+    ).toEqualTypeOf<Promise<CollaborationCommentDocument>>()
+    expectTypeOf(
+      comments.update('comment-1', {
+        message,
+        range: {start: {_key: 'block-1', offset: 0}, end: {_key: 'block-1', offset: 12}},
+        fieldValue: [{_type: 'block', _key: 'block-1', children: [{_type: 'span', text: 'Hello'}]}],
+      }),
+    ).toEqualTypeOf<Promise<CollaborationCommentDocument>>()
     expectTypeOf(comments.update('comment-1', {range: null})).toEqualTypeOf<
       Promise<CollaborationCommentDocument>
     >()
+    // @ts-expect-error - fieldValue requires a non-null range
+    comments.update('comment-1', {
+      range: null,
+      fieldValue: [{_type: 'block', _key: 'block-1'}],
+    })
+    // @ts-expect-error - fieldValue requires range
+    comments.update('comment-1', {
+      status: 'resolved',
+      fieldValue: [{_type: 'block', _key: 'block-1'}],
+    })
+    comments.update('comment-1', {
+      range: {start: {_key: 'block-1', offset: 0}, end: {_key: 'block-1', offset: 12}},
+      // @ts-expect-error - fieldValue items require `_key`
+      fieldValue: [{_type: 'block', children: [{_type: 'span', text: 'Hello'}]}],
+    })
     expectTypeOf(comments.addReaction('comment-1', ':heart:')).toEqualTypeOf<
       Promise<CollaborationCommentDocument>
     >()

--- a/test/collaborationComments.test-d.ts
+++ b/test/collaborationComments.test-d.ts
@@ -202,16 +202,16 @@ describe('collaboration.comments write results', () => {
       Promise<CollaborationCommentDocument>
     >()
     // @ts-expect-error - fieldValue requires a non-null range
-    comments.update('comment-1', {
+    void comments.update('comment-1', {
       range: null,
       fieldValue: [{_type: 'block', _key: 'block-1'}],
     })
     // @ts-expect-error - fieldValue requires range
-    comments.update('comment-1', {
+    void comments.update('comment-1', {
       status: 'resolved',
       fieldValue: [{_type: 'block', _key: 'block-1'}],
     })
-    comments.update('comment-1', {
+    void comments.update('comment-1', {
       range: {start: {_key: 'block-1', offset: 0}, end: {_key: 'block-1', offset: 12}},
       // @ts-expect-error - fieldValue items require `_key`
       fieldValue: [{_type: 'block', children: [{_type: 'span', text: 'Hello'}]}],

--- a/test/collaborationCommentsClient.test.ts
+++ b/test/collaborationCommentsClient.test.ts
@@ -196,6 +196,25 @@ describe('collaboration.comments', () => {
         },
       },
     }
+    const inlineWithFieldValue = {
+      message,
+      target: {
+        documentId: 'doc-1',
+        documentType: 'article',
+        path: 'body',
+        range: {
+          start: {_key: 'block-1', offset: 6},
+          end: {_key: 'block-1', offset: 11},
+        },
+        fieldValue: [
+          {
+            _type: 'block',
+            _key: 'block-1',
+            children: [{_type: 'span', text: 'Hello World again'}],
+          },
+        ],
+      },
+    }
 
     // The stored target is shaped differently from the created one: `path`
     // becomes `target.path.field`, and `range` is resolved into a selection.
@@ -221,10 +240,22 @@ describe('collaboration.comments', () => {
           {id: 'comment-2', operation: 'create', document: inlineCommentDocument},
         ]),
       })
+    scope
+      .on('POST', '/v2026-07-18/collaboration/comments', {
+        query: commonQuery,
+        body: inlineWithFieldValue,
+      })
+      .respond({
+        status: 200,
+        body: mutationResponse([
+          {id: 'comment-3', operation: 'create', document: inlineCommentDocument},
+        ]),
+      })
 
     const {comments} = getMockClient().collaboration
     const field = await comments.create(fieldComment)
     const inline = await comments.create(inlineComment)
+    const inlineFieldValue = await comments.create(inlineWithFieldValue)
 
     expect(field.target.path, 'a field comment stores the path, and no selection').toEqual({
       field: 'title',
@@ -240,6 +271,7 @@ describe('collaboration.comments', () => {
         children: [{_type: 'span', _key: 'block-1', text: 'World'}],
       },
     ])
+    expect(inlineFieldValue.target.path).toEqual(inline.target.path)
   })
 
   test('updates the message of an existing comment', async () => {
@@ -271,12 +303,30 @@ describe('collaboration.comments', () => {
       start: {_key: 'block-1', offset: 0},
       end: {_key: 'block-1', offset: 12},
     }
+    const fieldValue = [
+      {
+        _type: 'block',
+        _key: 'block-1',
+        children: [{_type: 'span', text: 'Hello World again'}],
+      },
+    ]
 
     const scope = getActiveMock().scope(apiHost)
     scope
       .on('PATCH', '/v2026-07-18/collaboration/comments/comment-1', {
         query: commonQuery,
         body: {range},
+      })
+      .respond({
+        status: 200,
+        body: mutationResponse([
+          {id: 'comment-1', operation: 'update', document: inlineCommentDocument},
+        ]),
+      })
+    scope
+      .on('PATCH', '/v2026-07-18/collaboration/comments/comment-1', {
+        query: commonQuery,
+        body: {range, fieldValue},
       })
       .respond({
         status: 200,
@@ -298,6 +348,9 @@ describe('collaboration.comments', () => {
     await expect(client.collaboration.comments.update('comment-1', {range})).resolves.toEqual(
       inlineCommentDocument,
     )
+    await expect(
+      client.collaboration.comments.update('comment-1', {range, fieldValue}),
+    ).resolves.toEqual(inlineCommentDocument)
     await expect(client.collaboration.comments.update('comment-1', {range: null})).resolves.toEqual(
       commentDocument,
     )


### PR DESCRIPTION
### Description

This pull request updates the collaboration comments client to accept an optional `fieldValue` next to `range` on create and update. When set, the Comments API can resolve the selection from that Portable Text instead of fetching the source document.

```ts
await client.collaboration.comments.update('comment-1', {
  // ...
  range: {
    start: {_key: 'block-1', offset: 0},
    end: {_key: 'block-1', offset: 12},
  },
  fieldValue: [
    {
      _type: 'block',
      _key: 'block-1',
      children: [{_type: 'span', text: 'Hello World again'}],
    },
  ],
})
```