### PR TITLE
feat: knowledge bases lose project/dataset on create and read

### DIFF
--- a/.changeset/pr-1276.md
+++ b/.changeset/pr-1276.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': minor
+---
+
+feat: add client.context namespace for knowledge bases

--- a/.changeset/pr-1300.md
+++ b/.changeset/pr-1300.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': minor
+---
+
+feat: knowledge bases lose project/dataset on create and read

--- a/src/SanityClient.ts
+++ b/src/SanityClient.ts
@@ -8,6 +8,7 @@ import {
   ObservableCollaborationCommentsClient,
 } from './collaboration/CollaborationCommentsClient'
 import {defaultConfig, initConfig} from './config'
+import {ContextClient, ObservableContextClient} from './context/ContextClient'
 import * as dataMethods from './data/dataMethods'
 import {_listen} from './data/listen'
 import {LiveClient} from './data/live'
@@ -94,6 +95,8 @@ export class ObservableSanityClient {
   }
   functions: ObservableFunctionsClient
   releases: ObservableReleasesClient
+  /** @beta */
+  context: ObservableContextClient
 
   /**
    * Private properties
@@ -127,6 +130,7 @@ export class ObservableSanityClient {
     }
     this.functions = new ObservableFunctionsClient(this, this.#httpRequest)
     this.releases = new ObservableReleasesClient(this, this.#httpRequest)
+    this.context = new ObservableContextClient(this, this.#httpRequest)
   }
 
   /**
@@ -1167,6 +1171,8 @@ export class SanityClient {
   }
   functions: FunctionsClient
   releases: ReleasesClient
+  /** @beta */
+  context: ContextClient
 
   /**
    * Observable version of the Sanity client, with the same configuration as the promise-based one
@@ -1205,6 +1211,7 @@ export class SanityClient {
     }
     this.functions = new FunctionsClient(this, this.#httpRequest)
     this.releases = new ReleasesClient(this, this.#httpRequest)
+    this.context = new ContextClient(this, this.#httpRequest)
 
     this.observable = new ObservableSanityClient(httpRequest, config)
   }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -32,7 +32,6 @@ import type {
   CreateImportParams,
   CreateInstructionParams,
   CreateKnowledgeBaseParams,
-  DeleteSourceResponse,
   DismissIssueResponse,
   EditCrawlOptionsParams,
   EditInstructionParams,
@@ -422,11 +421,12 @@ export class KnowledgeBaseHandle {
         }),
         ...options,
       }),
-    delete: (params: {sourceId: string}, options?: RequestOptions) =>
-      this.#request<DeleteSourceResponse>(`/sources/${params.sourceId}`, {
+    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/sources/${params.sourceId}`, {
         method: 'DELETE',
         ...options,
-      }),
+      })
+    },
   }
 
   /** The audit feed: who did what, when. */

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -203,8 +203,17 @@ export class KnowledgeBaseHandle {
   }
 
   /** Fetch the knowledge base. */
-  get(options?: RequestOptions): Promise<KnowledgeBase> {
-    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
+  async get(options?: RequestOptions): Promise<KnowledgeBase> {
+    const kb = await _getKnowledgeBaseById(
+      this.#client,
+      this.#httpRequest,
+      this.#knowledgeBaseId,
+      options,
+    )
+    // Seed the address cache: a follow-up scoped call should not pay for a
+    // second by-id resolve when this fetch already carries org and slug.
+    this.#address ??= Promise.resolve({organizationId: kb.organizationId, slug: kb.slug})
+    return kb
   }
 
   /** Edit the knowledge base's configuration. */
@@ -232,7 +241,7 @@ export class KnowledgeBaseHandle {
   }
 
   /** Run an incremental refresh: re-check sources and apply what changed. */
-  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
+  refresh(options?: RequestOptions): Promise<{jobId: string; started: boolean}> {
     return this.#request('/refresh', {method: 'POST', ...options})
   }
 

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,11 +1,11 @@
-import {type FetchFunction} from 'get-it'
+import { type FetchFunction } from "get-it";
 
-type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
-import {type Observable} from 'rxjs'
+type FetchBody = NonNullable<Parameters<FetchFunction>[1]>["body"];
+import { type Observable } from "rxjs";
 
-import {_observe, _request} from '../data/dataMethods'
-import type {ObservableSanityClient, SanityClient} from '../SanityClient'
-import type {HttpRequest} from '../types'
+import { _observe, _request } from "../data/dataMethods";
+import type { ObservableSanityClient, SanityClient } from "../SanityClient";
+import type { HttpRequest } from "../types";
 import type {
   ApplyIssuesParams,
   ApplyIssuesResponse,
@@ -46,12 +46,16 @@ import type {
   ResolveIssueResponse,
   SourceContentResponse,
   StagedUpload,
-} from './types'
-import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types'
+} from "./types";
+import type {
+  CreateFileImportParams,
+  RenderFormat,
+  RequestOptions,
+} from "./types";
 
-type ListOptions = RequestOptions & {cursor?: string; limit?: number}
+type ListOptions = RequestOptions & { cursor?: string; limit?: number };
 
-type Client = SanityClient | ObservableSanityClient
+type Client = SanityClient | ObservableSanityClient;
 
 /**
  * The knowledge base's org-scoped address. Every operation except the by-id
@@ -59,7 +63,7 @@ type Client = SanityClient | ObservableSanityClient
  * handle is constructed from the id alone, so the address is resolved once
  * through the by-id endpoint and reused.
  */
-type ResolvedAddress = {organizationId: string; slug: string}
+type ResolvedAddress = { organizationId: string; slug: string };
 
 function _getKnowledgeBaseById(
   client: Client,
@@ -70,20 +74,22 @@ function _getKnowledgeBaseById(
   return _request<KnowledgeBase>(client, httpRequest, {
     url: `/context/knowledge-bases/${knowledgeBaseId}`,
     ...options,
-  })
+  });
 }
 
 function _collectionUrl(organizationId: string): string {
-  return `/context/organizations/${organizationId}/knowledge-bases`
+  return `/context/organizations/${organizationId}/knowledge-bases`;
 }
 
 /** Serialize defined values into query params, dropping the undefined ones. */
-function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
+function _query(
+  entries: Record<string, string | number | undefined>,
+): Record<string, string> {
   return Object.fromEntries(
     Object.entries(entries).flatMap(([key, value]) =>
       value === undefined ? [] : [[key, `${value}`]],
     ),
-  )
+  );
 }
 
 /**
@@ -93,20 +99,24 @@ function _query(entries: Record<string, string | number | undefined>): Record<st
  * @beta
  */
 export class KnowledgeBaseHandle {
-  #client: SanityClient
-  #httpRequest: HttpRequest
-  #knowledgeBaseId: string
-  #address: Promise<ResolvedAddress> | undefined
+  #client: SanityClient;
+  #httpRequest: HttpRequest;
+  #knowledgeBaseId: string;
+  #address: Promise<ResolvedAddress> | undefined;
 
-  constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
-    this.#client = client
-    this.#httpRequest = httpRequest
-    this.#knowledgeBaseId = knowledgeBaseId
+  constructor(
+    client: SanityClient,
+    httpRequest: HttpRequest,
+    knowledgeBaseId: string,
+  ) {
+    this.#client = client;
+    this.#httpRequest = httpRequest;
+    this.#knowledgeBaseId = knowledgeBaseId;
   }
 
   /** The knowledge base id this handle was constructed with. */
   get knowledgeBaseId(): string {
-    return this.#knowledgeBaseId
+    return this.#knowledgeBaseId;
   }
 
   // The resolution is shared by every method on the handle, so it must not
@@ -120,29 +130,29 @@ export class KnowledgeBaseHandle {
       this.#httpRequest,
       this.#knowledgeBaseId,
     ).then(
-      (kb) => ({organizationId: kb.organizationId, slug: kb.slug}),
+      (kb) => ({ organizationId: kb.organizationId, slug: kb.slug }),
       (err) => {
         // A failed resolution must not poison the handle for retries.
-        this.#address = undefined
-        throw err
+        this.#address = undefined;
+        throw err;
       },
-    )
-    return this.#address
+    );
+    return this.#address;
   }
 
   async #request<R>(
     suffix: string,
     reqOptions: {
-      method?: string
-      body?: unknown
-      query?: Record<string, string>
+      method?: string;
+      body?: unknown;
+      query?: Record<string, string>;
     } & RequestOptions = {},
   ): Promise<R> {
-    const address = await this.#resolveAddress()
+    const address = await this.#resolveAddress();
     return _request<R>(this.#client, this.#httpRequest, {
       url: `${_collectionUrl(address.organizationId)}/${address.slug}${suffix}`,
       ...reqOptions,
-    })
+    });
   }
 
   /** Shared shape of every paginated list endpoint under the handle. */
@@ -159,59 +169,73 @@ export class KnowledgeBaseHandle {
       }),
       signal: params?.signal,
       tag: params?.tag,
-    })
+    });
   }
 
   async #uploadFile(
     params: CreateFileImportParams,
     options?: RequestOptions,
   ): Promise<JobAccepted> {
-    const staged = await this.#request<StagedUpload>('/imports/uploads', {
-      method: 'POST',
+    const staged = await this.#request<StagedUpload>("/imports/uploads", {
+      method: "POST",
       body: {
         filename: params.filename,
-        ...(params.contentType && {contentType: params.contentType}),
+        ...(params.contentType && { contentType: params.contentType }),
       },
       ...options,
-    })
+    });
     // The signed URL PUT goes straight to storage, outside the API pipeline:
     // no auth header, and the body is raw bytes rather than JSON. Still uses
     // the client's fetch resolution so proxy config applies in Node.
-    const config = this.#client.config()
-    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
+    const config = this.#client.config();
+    const doFetch =
+      config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction);
     const putResponse = await doFetch(staged.uploadUrl, {
-      method: 'PUT',
+      method: "PUT",
       // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
       // bound, even though fetch accepts it at runtime.
       body: params.file as FetchBody,
       ...(params.contentType && {
-        headers: {'content-type': params.contentType},
+        headers: { "content-type": params.contentType },
       }),
       signal: options?.signal,
-    })
+    });
     if (!putResponse.ok) {
-      throw new Error(`File upload failed: ${putResponse.status} ${putResponse.statusText}`)
+      throw new Error(
+        `File upload failed: ${putResponse.status} ${putResponse.statusText}`,
+      );
     }
-    return this.#request<JobAccepted>(`/imports/uploads/${staged.importId}/complete`, {
-      method: 'POST',
-      body: {},
-      ...options,
-    })
+    return this.#request<JobAccepted>(
+      `/imports/uploads/${staged.importId}/complete`,
+      {
+        method: "POST",
+        body: {},
+        ...options,
+      },
+    );
   }
 
   /** Fetch the knowledge base. */
   get(options?: RequestOptions): Promise<KnowledgeBase> {
-    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
+    return _getKnowledgeBaseById(
+      this.#client,
+      this.#httpRequest,
+      this.#knowledgeBaseId,
+      options,
+    );
   }
 
   /** Edit the knowledge base's configuration. */
-  edit(params: EditKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> {
-    return this.#request('', {method: 'PATCH', body: params, ...options})
+  edit(
+    params: EditKnowledgeBaseParams,
+    options?: RequestOptions,
+  ): Promise<KnowledgeBase> {
+    return this.#request("", { method: "PATCH", body: params, ...options });
   }
 
   /** Delete the knowledge base and its generated content. */
   async delete(options?: RequestOptions): Promise<void> {
-    await this.#request('', {method: 'DELETE', ...options})
+    await this.#request("", { method: "DELETE", ...options });
   }
 
   /**
@@ -220,17 +244,19 @@ export class KnowledgeBaseHandle {
    * the returned job with {@link jobs}.
    */
   build(options?: RequestOptions): Promise<JobAccepted> {
-    return this.#request('/build', {method: 'POST', ...options})
+    return this.#request("/build", { method: "POST", ...options });
   }
 
   /** Cancel the running build, if any. */
-  cancelBuild(options?: RequestOptions): Promise<{cancelled: boolean}> {
-    return this.#request('/build/cancel', {method: 'POST', ...options})
+  cancelBuild(options?: RequestOptions): Promise<{ cancelled: boolean }> {
+    return this.#request("/build/cancel", { method: "POST", ...options });
   }
 
   /** Run an incremental refresh: re-check sources and apply what changed. */
-  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
-    return this.#request('/refresh', {method: 'POST', ...options})
+  refresh(
+    options?: RequestOptions,
+  ): Promise<{ jobId: string | null; started: boolean }> {
+    return this.#request("/refresh", { method: "POST", ...options });
   }
 
   /**
@@ -238,19 +264,19 @@ export class KnowledgeBaseHandle {
    * `json` format resolves to {@link Outline}; `markdown` and
    * `plain` resolve to a string.
    */
-  outline<const F extends RenderFormat = 'json'>(
-    params?: {format?: F},
+  outline<const F extends RenderFormat = "json">(
+    params?: { format?: F },
     options?: RequestOptions,
-  ): Promise<F extends 'json' ? Outline : string> {
-    return this.#request('/outline', {
-      query: params?.format ? {format: params.format} : {},
+  ): Promise<F extends "json" ? Outline : string> {
+    return this.#request("/outline", {
+      query: params?.format ? { format: params.format } : {},
       ...options,
-    })
+    });
   }
 
   /** What changed in the corpus since the last build. */
   changes(options?: RequestOptions): Promise<Changes> {
-    return this.#request('/changes', options)
+    return this.#request("/changes", options);
   }
 
   /** Imports: feed content into the knowledge base. */
@@ -266,114 +292,130 @@ export class KnowledgeBaseHandle {
       params: CreateImportParams | CreateFileImportParams,
       options?: RequestOptions,
     ): Promise<JobAccepted> =>
-      params.type === 'file'
+      params.type === "file"
         ? this.#uploadFile(params, options)
-        : this.#request('/imports', {
-            method: 'POST',
+        : this.#request("/imports", {
+            method: "POST",
             body: params,
             ...options,
           }),
-    list: (params?: ListOptions) => this.#list<ImportsResponse>('/imports', params),
-    get: (params: {importId: string}, options?: RequestOptions) =>
+    list: (params?: ListOptions) =>
+      this.#list<ImportsResponse>("/imports", params),
+    get: (params: { importId: string }, options?: RequestOptions) =>
       this.#request<ImportDetail>(`/imports/${params.importId}`, options),
     /** A short-lived signed URL for the original uploaded bytes. */
-    download: (params: {importId: string}, options?: RequestOptions) =>
-      this.#request<ImportDownloadResponse>(`/imports/${params.importId}/download`, options),
-    delete: async (params: {importId: string}, options?: RequestOptions) => {
+    download: (params: { importId: string }, options?: RequestOptions) =>
+      this.#request<ImportDownloadResponse>(
+        `/imports/${params.importId}/download`,
+        options,
+      ),
+    delete: async (params: { importId: string }, options?: RequestOptions) => {
       await this.#request<void>(`/imports/${params.importId}`, {
-        method: 'DELETE',
+        method: "DELETE",
         ...options,
-      })
+      });
     },
     /** Preview which pages a crawl would ingest, before committing to it. */
     crawlPreview: (params: CrawlPreviewParams, options?: RequestOptions) =>
-      this.#request<CrawlPreviewResponse>('/imports/crawl-preview', {
-        method: 'POST',
+      this.#request<CrawlPreviewResponse>("/imports/crawl-preview", {
+        method: "POST",
         body: params,
         ...options,
       }),
-  }
+  };
 
   /** Jobs: poll async work (builds, imports) to a terminal state. */
   jobs = {
-    get: (params: {jobId: string}, options?: RequestOptions) =>
+    get: (params: { jobId: string }, options?: RequestOptions) =>
       this.#request<Job>(`/jobs/${params.jobId}`, options),
-  }
+  };
 
   /** Issues: findings from builds awaiting triage. */
   issues = {
-    list: (params?: {status?: 'open' | 'accepted' | 'rejected'} & ListOptions) =>
-      this.#list<IssuesResponse>('/issues', params, {
+    list: (
+      params?: { status?: "open" | "accepted" | "rejected" } & ListOptions,
+    ) =>
+      this.#list<IssuesResponse>("/issues", params, {
         status: params?.status,
       }),
-    get: (params: {issueId: string}, options?: RequestOptions) =>
+    get: (params: { issueId: string }, options?: RequestOptions) =>
       this.#request<IssueDetail>(`/issues/${params.issueId}`, options),
     /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
-    resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
-      const {issueId, ...body} = params
+    resolve: (
+      params: { issueId: string } & ResolveIssueParams,
+      options?: RequestOptions,
+    ) => {
+      const { issueId, ...body } = params;
       return this.#request<ResolveIssueResponse>(`/issues/${issueId}/resolve`, {
-        method: 'POST',
+        method: "POST",
         body,
         ...options,
-      })
+      });
     },
-    dismiss: (params: {issueId: string}, options?: RequestOptions) =>
+    dismiss: (params: { issueId: string }, options?: RequestOptions) =>
       this.#request<DismissIssueResponse>(`/issues/${params.issueId}/dismiss`, {
-        method: 'POST',
+        method: "POST",
         ...options,
       }),
-    reopen: (params: {issueId: string}, options?: RequestOptions) =>
+    reopen: (params: { issueId: string }, options?: RequestOptions) =>
       this.#request<ReopenIssueResponse>(`/issues/${params.issueId}/reopen`, {
-        method: 'POST',
+        method: "POST",
         ...options,
       }),
     /** Apply already-accepted issues to the knowledge base in one batch. */
     apply: (params: ApplyIssuesParams, options?: RequestOptions) =>
-      this.#request<ApplyIssuesResponse>('/issues/apply', {
-        method: 'POST',
+      this.#request<ApplyIssuesResponse>("/issues/apply", {
+        method: "POST",
         body: params,
         ...options,
       }),
-  }
+  };
 
   /** Instructions: standing decisions that steer every build. */
   instructions = {
     create: (params: CreateInstructionParams, options?: RequestOptions) =>
-      this.#request<Instruction>('/instructions', {
-        method: 'POST',
+      this.#request<Instruction>("/instructions", {
+        method: "POST",
         body: params,
         ...options,
       }),
-    list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
-    edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
-      const {instructionId, ...body} = params
+    list: (params?: ListOptions) =>
+      this.#list<InstructionsResponse>("/instructions", params),
+    edit: (
+      params: { instructionId: string } & EditInstructionParams,
+      options?: RequestOptions,
+    ) => {
+      const { instructionId, ...body } = params;
       return this.#request<Instruction>(`/instructions/${instructionId}`, {
-        method: 'PATCH',
+        method: "PATCH",
         body,
         ...options,
-      })
+      });
     },
-    delete: async (params: {instructionId: string}, options?: RequestOptions) => {
+    delete: async (
+      params: { instructionId: string },
+      options?: RequestOptions,
+    ) => {
       await this.#request<void>(`/instructions/${params.instructionId}`, {
-        method: 'DELETE',
+        method: "DELETE",
         ...options,
-      })
+      });
     },
-  }
+  };
 
   /** Entries: the built outline, one entry per node. */
   entries = {
     /** List entries, optionally filtered by status or searched (`q`). */
     list: (
       params?: {
-        status?: EntryStatus
-        q?: string
-        mode?: 'keyword' | 'hybrid'
-        include?: 'metadata' | 'body'
-        paths?: string
+        status?: EntryStatus;
+        q?: string;
+        mode?: "keyword" | "hybrid";
+        include?: "metadata" | "body";
+        paths?: string;
       } & ListOptions,
     ) =>
-      this.#list<EntriesResponse>('/entries', params, {
+      this.#list<EntriesResponse>("/entries", params, {
         status: params?.status,
         q: params?.q,
         mode: params?.mode,
@@ -385,88 +427,83 @@ export class KnowledgeBaseHandle {
      * The default `json` format resolves to {@link EntryDetail};
      * `markdown` and `plain` resolve to a string.
      */
-    get: <const F extends RenderFormat = 'json'>(
-      params: {path: string; format?: F},
+    get: <const F extends RenderFormat = "json">(
+      params: { path: string; format?: F },
       options?: RequestOptions,
     ) =>
-      this.#request<F extends 'json' ? EntryDetail : string>(
+      this.#request<F extends "json" ? EntryDetail : string>(
         `/entries/${encodeURIComponent(params.path)}`,
         {
-          query: params.format ? {format: params.format} : {},
+          query: params.format ? { format: params.format } : {},
           ...options,
         },
       ),
-  }
+  };
 
   /** Sources: the distilled units builds cite. */
   sources = {
-    list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
-    get: (params: {sourceId: string}, options?: RequestOptions) =>
+    list: (params?: ListOptions) =>
+      this.#list<SourcesResponse>("/sources", params),
+    get: (params: { sourceId: string }, options?: RequestOptions) =>
       this.#request<SourceDetail>(`/sources/${params.sourceId}`, options),
     /**
      * Distilled source content, optionally a line range: the evidence behind
      * a citation or an issue.
      */
     content: (
-      params: {sourceId: string; startLine?: number; endLine?: number},
+      params: { sourceId: string; startLine?: number; endLine?: number },
       options?: RequestOptions,
     ) =>
-      this.#request<SourceContentResponse>(`/sources/${params.sourceId}/content`, {
-        query: _query({
-          startLine: params.startLine,
-          endLine: params.endLine,
-        }),
-        ...options,
-      }),
-    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      this.#request<SourceContentResponse>(
+        `/sources/${params.sourceId}/content`,
+        {
+          query: _query({
+            startLine: params.startLine,
+            endLine: params.endLine,
+          }),
+          ...options,
+        },
+      ),
+    delete: async (params: { sourceId: string }, options?: RequestOptions) => {
       await this.#request<void>(`/sources/${params.sourceId}`, {
-        method: 'DELETE',
+        method: "DELETE",
         ...options,
-      })
+      });
     },
-  }
+  };
 
   /** The audit feed: who did what, when. */
   activity = {
-    list: (params?: ListOptions) => this.#list<ActivityResponse>('/activity', params),
-  }
+    list: (params?: ListOptions) =>
+      this.#list<ActivityResponse>("/activity", params),
+  };
 
   /** Revisions: one per build, with an accounting report per revision. */
   revisions = {
-    list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
-    report: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionReport>(`/revisions/${params.revisionId}/report`, options),
+    list: (params?: ListOptions) =>
+      this.#list<RevisionsResponse>("/revisions", params),
+    report: (params: { revisionId: string }, options?: RequestOptions) =>
+      this.#request<RevisionReport>(
+        `/revisions/${params.revisionId}/report`,
+        options,
+      ),
     /** The outline as it was at a past build revision. */
-    outline: (params: {revisionId: string}, options?: RequestOptions) =>
-      this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
-  }
+    outline: (params: { revisionId: string }, options?: RequestOptions) =>
+      this.#request<RevisionOutline>(
+        `/revisions/${params.revisionId}/outline`,
+        options,
+      ),
+  };
 
   /** Crawl options for the knowledge base's web source. */
   crawlOptions = {
     edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
-      this.#request<CrawlOptions>('/crawl-options', {
-        method: 'PATCH',
+      this.#request<CrawlOptions>("/crawl-options", {
+        method: "PATCH",
         body: params,
         ...options,
       }),
-  }
-
-  /**
-   * An ordinary `@sanity/client` bound to the knowledge base's dataset, for
-   * GROQ reads, listeners, and anything else the platform ships for
-   * documents. Not a wrapper: the returned client is a plain client.
-   */
-  async contentClient(options?: RequestOptions): Promise<SanityClient> {
-    const kb = await this.get(options)
-    if (!kb.sanityProjectId || !kb.sanityDatasetId) {
-      throw new Error(`Knowledge base "${this.#knowledgeBaseId}" has no dataset binding`)
-    }
-    return this.#client.withConfig({
-      projectId: kb.sanityProjectId,
-      dataset: kb.sanityDatasetId,
-      useCdn: false,
-    })
-  }
+  };
 }
 
 /**
@@ -489,38 +526,40 @@ export class KnowledgeBaseHandle {
  * @beta
  */
 export class ContextClient {
-  #client: SanityClient
-  #httpRequest: HttpRequest
+  #client: SanityClient;
+  #httpRequest: HttpRequest;
 
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this.#client = client;
+    this.#httpRequest = httpRequest;
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & {organizationId: string},
+      params: CreateKnowledgeBaseParams & { organizationId: string },
       options?: RequestOptions,
     ): Promise<KnowledgeBase> => {
-      const {organizationId, ...body} = params
+      const { organizationId, ...body } = params;
       return _request<KnowledgeBase>(this.#client, this.#httpRequest, {
         url: _collectionUrl(organizationId),
-        method: 'POST',
+        method: "POST",
         body,
         ...options,
-      })
+      });
     },
     /** List the organization's knowledge bases. */
-    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
+    list: (
+      params: { organizationId: string } & ListOptions,
+    ): Promise<KnowledgeBasesResponse> =>
       _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
         url: _collectionUrl(params.organizationId),
-        query: _query({cursor: params.cursor, limit: params.limit}),
+        query: _query({ cursor: params.cursor, limit: params.limit }),
         signal: params.signal,
         tag: params.tag,
       }),
-  }
+  };
 
   /**
    * A handle carrying everything scoped to one knowledge base, addressed by
@@ -528,7 +567,11 @@ export class ContextClient {
    * the first request and is reused after that.
    */
   knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
-    return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
+    return new KnowledgeBaseHandle(
+      this.#client,
+      this.#httpRequest,
+      knowledgeBaseId,
+    );
   }
 }
 
@@ -540,41 +583,43 @@ export class ContextClient {
  * @beta
  */
 export class ObservableContextClient {
-  #client: ObservableSanityClient
-  #httpRequest: HttpRequest
+  #client: ObservableSanityClient;
+  #httpRequest: HttpRequest;
 
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client
-    this.#httpRequest = httpRequest
+    this.#client = client;
+    this.#httpRequest = httpRequest;
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & {organizationId: string},
+      params: CreateKnowledgeBaseParams & { organizationId: string },
       options?: RequestOptions,
     ): Observable<KnowledgeBase> => {
-      const {organizationId, ...body} = params
+      const { organizationId, ...body } = params;
       return _observe(options?.signal, (signal) =>
         _request<KnowledgeBase>(this.#client, this.#httpRequest, {
           url: _collectionUrl(organizationId),
-          method: 'POST',
+          method: "POST",
           body,
           tag: options?.tag,
           signal,
         }),
-      )
+      );
     },
     /** List the organization's knowledge bases. */
-    list: (params: {organizationId: string} & ListOptions): Observable<KnowledgeBasesResponse> =>
+    list: (
+      params: { organizationId: string } & ListOptions,
+    ): Observable<KnowledgeBasesResponse> =>
       _observe(params.signal, (signal) =>
         _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
           url: _collectionUrl(params.organizationId),
-          query: _query({cursor: params.cursor, limit: params.limit}),
+          query: _query({ cursor: params.cursor, limit: params.limit }),
           tag: params.tag,
           signal,
         }),
       ),
-  }
+  };
 }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -32,6 +32,7 @@ import type {
   CreateImportParams,
   CreateInstructionParams,
   CreateKnowledgeBaseParams,
+  DeleteSourceResponse,
   DismissIssueResponse,
   EditCrawlOptionsParams,
   EditInstructionParams,
@@ -421,12 +422,11 @@ export class KnowledgeBaseHandle {
         }),
         ...options,
       }),
-    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
-      await this.#request<void>(`/sources/${params.sourceId}`, {
+    delete: (params: {sourceId: string}, options?: RequestOptions) =>
+      this.#request<DeleteSourceResponse>(`/sources/${params.sourceId}`, {
         method: 'DELETE',
         ...options,
-      })
-    },
+      }),
   }
 
   /** The audit feed: who did what, when. */

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -473,8 +473,6 @@ export class KnowledgeBaseHandle {
  *   organizationId: 'org123',
  *   name: 'Support docs',
  *   description: 'Product docs and troubleshooting guides',
- *   sanityProjectId: 'abc123',
- *   sanityDatasetId: 'production',
  * })
  * const kb = client.context.knowledgeBase(created.publicId)
  * await kb.imports.create({type: 'text', title: 'Refund policy', content: refundMd})
@@ -494,7 +492,7 @@ export class ContextClient {
 
   /** The knowledge base collection. */
   knowledgeBases = {
-    /** Create a knowledge base. Requires provisioning access to the target project. */
+    /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
     create: (
       params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,
@@ -545,7 +543,7 @@ export class ObservableContextClient {
 
   /** The knowledge base collection. */
   knowledgeBases = {
-    /** Create a knowledge base. Requires provisioning access to the target project. */
+    /** Create a knowledge base. Requires the org-level knowledge-base create grant. */
     create: (
       params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,6 +1,4 @@
 import {type FetchFunction} from 'get-it'
-
-type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
 import {type Observable} from 'rxjs'
 
 import {_observe, _request} from '../data/dataMethods'
@@ -84,6 +82,13 @@ function _query(entries: Record<string, string | number | undefined>): Record<st
       value === undefined ? [] : [[key, `${value}`]],
     ),
   )
+}
+
+function _fetchBody(file: CreateFileImportParams['file']) {
+  if (!ArrayBuffer.isView(file)) return file
+  return file.buffer instanceof ArrayBuffer
+    ? new Uint8Array(file.buffer, file.byteOffset, file.byteLength)
+    : Uint8Array.from(file)
 }
 
 /**
@@ -178,12 +183,10 @@ export class KnowledgeBaseHandle {
     // no auth header, and the body is raw bytes rather than JSON. Still uses
     // the client's fetch resolution so proxy config applies in Node.
     const config = this.#client.config()
-    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
+    const doFetch: FetchFunction = config.resolveFetch?.(config.proxy) ?? globalThis.fetch
     const putResponse = await doFetch(staged.uploadUrl, {
       method: 'PUT',
-      // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
-      // bound, even though fetch accepts it at runtime.
-      body: params.file as FetchBody,
+      body: _fetchBody(params.file),
       ...(params.contentType && {
         headers: {'content-type': params.contentType},
       }),

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,11 +1,11 @@
-import { type FetchFunction } from "get-it";
+import {type FetchFunction} from 'get-it'
 
-type FetchBody = NonNullable<Parameters<FetchFunction>[1]>["body"];
-import { type Observable } from "rxjs";
+type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
+import {type Observable} from 'rxjs'
 
-import { _observe, _request } from "../data/dataMethods";
-import type { ObservableSanityClient, SanityClient } from "../SanityClient";
-import type { HttpRequest } from "../types";
+import {_observe, _request} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest} from '../types'
 import type {
   ApplyIssuesParams,
   ApplyIssuesResponse,
@@ -46,16 +46,12 @@ import type {
   ResolveIssueResponse,
   SourceContentResponse,
   StagedUpload,
-} from "./types";
-import type {
-  CreateFileImportParams,
-  RenderFormat,
-  RequestOptions,
-} from "./types";
+} from './types'
+import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types'
 
-type ListOptions = RequestOptions & { cursor?: string; limit?: number };
+type ListOptions = RequestOptions & {cursor?: string; limit?: number}
 
-type Client = SanityClient | ObservableSanityClient;
+type Client = SanityClient | ObservableSanityClient
 
 /**
  * The knowledge base's org-scoped address. Every operation except the by-id
@@ -63,7 +59,7 @@ type Client = SanityClient | ObservableSanityClient;
  * handle is constructed from the id alone, so the address is resolved once
  * through the by-id endpoint and reused.
  */
-type ResolvedAddress = { organizationId: string; slug: string };
+type ResolvedAddress = {organizationId: string; slug: string}
 
 function _getKnowledgeBaseById(
   client: Client,
@@ -74,22 +70,20 @@ function _getKnowledgeBaseById(
   return _request<KnowledgeBase>(client, httpRequest, {
     url: `/context/knowledge-bases/${knowledgeBaseId}`,
     ...options,
-  });
+  })
 }
 
 function _collectionUrl(organizationId: string): string {
-  return `/context/organizations/${organizationId}/knowledge-bases`;
+  return `/context/organizations/${organizationId}/knowledge-bases`
 }
 
 /** Serialize defined values into query params, dropping the undefined ones. */
-function _query(
-  entries: Record<string, string | number | undefined>,
-): Record<string, string> {
+function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(entries).flatMap(([key, value]) =>
       value === undefined ? [] : [[key, `${value}`]],
     ),
-  );
+  )
 }
 
 /**
@@ -99,24 +93,20 @@ function _query(
  * @beta
  */
 export class KnowledgeBaseHandle {
-  #client: SanityClient;
-  #httpRequest: HttpRequest;
-  #knowledgeBaseId: string;
-  #address: Promise<ResolvedAddress> | undefined;
+  #client: SanityClient
+  #httpRequest: HttpRequest
+  #knowledgeBaseId: string
+  #address: Promise<ResolvedAddress> | undefined
 
-  constructor(
-    client: SanityClient,
-    httpRequest: HttpRequest,
-    knowledgeBaseId: string,
-  ) {
-    this.#client = client;
-    this.#httpRequest = httpRequest;
-    this.#knowledgeBaseId = knowledgeBaseId;
+  constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+    this.#knowledgeBaseId = knowledgeBaseId
   }
 
   /** The knowledge base id this handle was constructed with. */
   get knowledgeBaseId(): string {
-    return this.#knowledgeBaseId;
+    return this.#knowledgeBaseId
   }
 
   // The resolution is shared by every method on the handle, so it must not
@@ -130,29 +120,29 @@ export class KnowledgeBaseHandle {
       this.#httpRequest,
       this.#knowledgeBaseId,
     ).then(
-      (kb) => ({ organizationId: kb.organizationId, slug: kb.slug }),
+      (kb) => ({organizationId: kb.organizationId, slug: kb.slug}),
       (err) => {
         // A failed resolution must not poison the handle for retries.
-        this.#address = undefined;
-        throw err;
+        this.#address = undefined
+        throw err
       },
-    );
-    return this.#address;
+    )
+    return this.#address
   }
 
   async #request<R>(
     suffix: string,
     reqOptions: {
-      method?: string;
-      body?: unknown;
-      query?: Record<string, string>;
+      method?: string
+      body?: unknown
+      query?: Record<string, string>
     } & RequestOptions = {},
   ): Promise<R> {
-    const address = await this.#resolveAddress();
+    const address = await this.#resolveAddress()
     return _request<R>(this.#client, this.#httpRequest, {
       url: `${_collectionUrl(address.organizationId)}/${address.slug}${suffix}`,
       ...reqOptions,
-    });
+    })
   }
 
   /** Shared shape of every paginated list endpoint under the handle. */
@@ -169,73 +159,59 @@ export class KnowledgeBaseHandle {
       }),
       signal: params?.signal,
       tag: params?.tag,
-    });
+    })
   }
 
   async #uploadFile(
     params: CreateFileImportParams,
     options?: RequestOptions,
   ): Promise<JobAccepted> {
-    const staged = await this.#request<StagedUpload>("/imports/uploads", {
-      method: "POST",
+    const staged = await this.#request<StagedUpload>('/imports/uploads', {
+      method: 'POST',
       body: {
         filename: params.filename,
-        ...(params.contentType && { contentType: params.contentType }),
+        ...(params.contentType && {contentType: params.contentType}),
       },
       ...options,
-    });
+    })
     // The signed URL PUT goes straight to storage, outside the API pipeline:
     // no auth header, and the body is raw bytes rather than JSON. Still uses
     // the client's fetch resolution so proxy config applies in Node.
-    const config = this.#client.config();
-    const doFetch =
-      config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction);
+    const config = this.#client.config()
+    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
     const putResponse = await doFetch(staged.uploadUrl, {
-      method: "PUT",
+      method: 'PUT',
       // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
       // bound, even though fetch accepts it at runtime.
       body: params.file as FetchBody,
       ...(params.contentType && {
-        headers: { "content-type": params.contentType },
+        headers: {'content-type': params.contentType},
       }),
       signal: options?.signal,
-    });
+    })
     if (!putResponse.ok) {
-      throw new Error(
-        `File upload failed: ${putResponse.status} ${putResponse.statusText}`,
-      );
+      throw new Error(`File upload failed: ${putResponse.status} ${putResponse.statusText}`)
     }
-    return this.#request<JobAccepted>(
-      `/imports/uploads/${staged.importId}/complete`,
-      {
-        method: "POST",
-        body: {},
-        ...options,
-      },
-    );
+    return this.#request<JobAccepted>(`/imports/uploads/${staged.importId}/complete`, {
+      method: 'POST',
+      body: {},
+      ...options,
+    })
   }
 
   /** Fetch the knowledge base. */
   get(options?: RequestOptions): Promise<KnowledgeBase> {
-    return _getKnowledgeBaseById(
-      this.#client,
-      this.#httpRequest,
-      this.#knowledgeBaseId,
-      options,
-    );
+    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
   }
 
   /** Edit the knowledge base's configuration. */
-  edit(
-    params: EditKnowledgeBaseParams,
-    options?: RequestOptions,
-  ): Promise<KnowledgeBase> {
-    return this.#request("", { method: "PATCH", body: params, ...options });
+  edit(params: EditKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> {
+    return this.#request('', {method: 'PATCH', body: params, ...options})
   }
 
   /** Delete the knowledge base and its generated content. */
   async delete(options?: RequestOptions): Promise<void> {
-    await this.#request("", { method: "DELETE", ...options });
+    await this.#request('', {method: 'DELETE', ...options})
   }
 
   /**
@@ -244,19 +220,17 @@ export class KnowledgeBaseHandle {
    * the returned job with {@link jobs}.
    */
   build(options?: RequestOptions): Promise<JobAccepted> {
-    return this.#request("/build", { method: "POST", ...options });
+    return this.#request('/build', {method: 'POST', ...options})
   }
 
   /** Cancel the running build, if any. */
-  cancelBuild(options?: RequestOptions): Promise<{ cancelled: boolean }> {
-    return this.#request("/build/cancel", { method: "POST", ...options });
+  cancelBuild(options?: RequestOptions): Promise<{cancelled: boolean}> {
+    return this.#request('/build/cancel', {method: 'POST', ...options})
   }
 
   /** Run an incremental refresh: re-check sources and apply what changed. */
-  refresh(
-    options?: RequestOptions,
-  ): Promise<{ jobId: string | null; started: boolean }> {
-    return this.#request("/refresh", { method: "POST", ...options });
+  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
+    return this.#request('/refresh', {method: 'POST', ...options})
   }
 
   /**
@@ -264,19 +238,19 @@ export class KnowledgeBaseHandle {
    * `json` format resolves to {@link Outline}; `markdown` and
    * `plain` resolve to a string.
    */
-  outline<const F extends RenderFormat = "json">(
-    params?: { format?: F },
+  outline<const F extends RenderFormat = 'json'>(
+    params?: {format?: F},
     options?: RequestOptions,
-  ): Promise<F extends "json" ? Outline : string> {
-    return this.#request("/outline", {
-      query: params?.format ? { format: params.format } : {},
+  ): Promise<F extends 'json' ? Outline : string> {
+    return this.#request('/outline', {
+      query: params?.format ? {format: params.format} : {},
       ...options,
-    });
+    })
   }
 
   /** What changed in the corpus since the last build. */
   changes(options?: RequestOptions): Promise<Changes> {
-    return this.#request("/changes", options);
+    return this.#request('/changes', options)
   }
 
   /** Imports: feed content into the knowledge base. */
@@ -292,130 +266,114 @@ export class KnowledgeBaseHandle {
       params: CreateImportParams | CreateFileImportParams,
       options?: RequestOptions,
     ): Promise<JobAccepted> =>
-      params.type === "file"
+      params.type === 'file'
         ? this.#uploadFile(params, options)
-        : this.#request("/imports", {
-            method: "POST",
+        : this.#request('/imports', {
+            method: 'POST',
             body: params,
             ...options,
           }),
-    list: (params?: ListOptions) =>
-      this.#list<ImportsResponse>("/imports", params),
-    get: (params: { importId: string }, options?: RequestOptions) =>
+    list: (params?: ListOptions) => this.#list<ImportsResponse>('/imports', params),
+    get: (params: {importId: string}, options?: RequestOptions) =>
       this.#request<ImportDetail>(`/imports/${params.importId}`, options),
     /** A short-lived signed URL for the original uploaded bytes. */
-    download: (params: { importId: string }, options?: RequestOptions) =>
-      this.#request<ImportDownloadResponse>(
-        `/imports/${params.importId}/download`,
-        options,
-      ),
-    delete: async (params: { importId: string }, options?: RequestOptions) => {
+    download: (params: {importId: string}, options?: RequestOptions) =>
+      this.#request<ImportDownloadResponse>(`/imports/${params.importId}/download`, options),
+    delete: async (params: {importId: string}, options?: RequestOptions) => {
       await this.#request<void>(`/imports/${params.importId}`, {
-        method: "DELETE",
+        method: 'DELETE',
         ...options,
-      });
+      })
     },
     /** Preview which pages a crawl would ingest, before committing to it. */
     crawlPreview: (params: CrawlPreviewParams, options?: RequestOptions) =>
-      this.#request<CrawlPreviewResponse>("/imports/crawl-preview", {
-        method: "POST",
+      this.#request<CrawlPreviewResponse>('/imports/crawl-preview', {
+        method: 'POST',
         body: params,
         ...options,
       }),
-  };
+  }
 
   /** Jobs: poll async work (builds, imports) to a terminal state. */
   jobs = {
-    get: (params: { jobId: string }, options?: RequestOptions) =>
+    get: (params: {jobId: string}, options?: RequestOptions) =>
       this.#request<Job>(`/jobs/${params.jobId}`, options),
-  };
+  }
 
   /** Issues: findings from builds awaiting triage. */
   issues = {
-    list: (
-      params?: { status?: "open" | "accepted" | "rejected" } & ListOptions,
-    ) =>
-      this.#list<IssuesResponse>("/issues", params, {
+    list: (params?: {status?: 'open' | 'accepted' | 'rejected'} & ListOptions) =>
+      this.#list<IssuesResponse>('/issues', params, {
         status: params?.status,
       }),
-    get: (params: { issueId: string }, options?: RequestOptions) =>
+    get: (params: {issueId: string}, options?: RequestOptions) =>
       this.#request<IssueDetail>(`/issues/${params.issueId}`, options),
     /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
-    resolve: (
-      params: { issueId: string } & ResolveIssueParams,
-      options?: RequestOptions,
-    ) => {
-      const { issueId, ...body } = params;
+    resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
+      const {issueId, ...body} = params
       return this.#request<ResolveIssueResponse>(`/issues/${issueId}/resolve`, {
-        method: "POST",
+        method: 'POST',
         body,
         ...options,
-      });
+      })
     },
-    dismiss: (params: { issueId: string }, options?: RequestOptions) =>
+    dismiss: (params: {issueId: string}, options?: RequestOptions) =>
       this.#request<DismissIssueResponse>(`/issues/${params.issueId}/dismiss`, {
-        method: "POST",
+        method: 'POST',
         ...options,
       }),
-    reopen: (params: { issueId: string }, options?: RequestOptions) =>
+    reopen: (params: {issueId: string}, options?: RequestOptions) =>
       this.#request<ReopenIssueResponse>(`/issues/${params.issueId}/reopen`, {
-        method: "POST",
+        method: 'POST',
         ...options,
       }),
     /** Apply already-accepted issues to the knowledge base in one batch. */
     apply: (params: ApplyIssuesParams, options?: RequestOptions) =>
-      this.#request<ApplyIssuesResponse>("/issues/apply", {
-        method: "POST",
+      this.#request<ApplyIssuesResponse>('/issues/apply', {
+        method: 'POST',
         body: params,
         ...options,
       }),
-  };
+  }
 
   /** Instructions: standing decisions that steer every build. */
   instructions = {
     create: (params: CreateInstructionParams, options?: RequestOptions) =>
-      this.#request<Instruction>("/instructions", {
-        method: "POST",
+      this.#request<Instruction>('/instructions', {
+        method: 'POST',
         body: params,
         ...options,
       }),
-    list: (params?: ListOptions) =>
-      this.#list<InstructionsResponse>("/instructions", params),
-    edit: (
-      params: { instructionId: string } & EditInstructionParams,
-      options?: RequestOptions,
-    ) => {
-      const { instructionId, ...body } = params;
+    list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
+    edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
+      const {instructionId, ...body} = params
       return this.#request<Instruction>(`/instructions/${instructionId}`, {
-        method: "PATCH",
+        method: 'PATCH',
         body,
         ...options,
-      });
+      })
     },
-    delete: async (
-      params: { instructionId: string },
-      options?: RequestOptions,
-    ) => {
+    delete: async (params: {instructionId: string}, options?: RequestOptions) => {
       await this.#request<void>(`/instructions/${params.instructionId}`, {
-        method: "DELETE",
+        method: 'DELETE',
         ...options,
-      });
+      })
     },
-  };
+  }
 
   /** Entries: the built outline, one entry per node. */
   entries = {
     /** List entries, optionally filtered by status or searched (`q`). */
     list: (
       params?: {
-        status?: EntryStatus;
-        q?: string;
-        mode?: "keyword" | "hybrid";
-        include?: "metadata" | "body";
-        paths?: string;
+        status?: EntryStatus
+        q?: string
+        mode?: 'keyword' | 'hybrid'
+        include?: 'metadata' | 'body'
+        paths?: string
       } & ListOptions,
     ) =>
-      this.#list<EntriesResponse>("/entries", params, {
+      this.#list<EntriesResponse>('/entries', params, {
         status: params?.status,
         q: params?.q,
         mode: params?.mode,
@@ -427,83 +385,71 @@ export class KnowledgeBaseHandle {
      * The default `json` format resolves to {@link EntryDetail};
      * `markdown` and `plain` resolve to a string.
      */
-    get: <const F extends RenderFormat = "json">(
-      params: { path: string; format?: F },
+    get: <const F extends RenderFormat = 'json'>(
+      params: {path: string; format?: F},
       options?: RequestOptions,
     ) =>
-      this.#request<F extends "json" ? EntryDetail : string>(
+      this.#request<F extends 'json' ? EntryDetail : string>(
         `/entries/${encodeURIComponent(params.path)}`,
         {
-          query: params.format ? { format: params.format } : {},
+          query: params.format ? {format: params.format} : {},
           ...options,
         },
       ),
-  };
+  }
 
   /** Sources: the distilled units builds cite. */
   sources = {
-    list: (params?: ListOptions) =>
-      this.#list<SourcesResponse>("/sources", params),
-    get: (params: { sourceId: string }, options?: RequestOptions) =>
+    list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
+    get: (params: {sourceId: string}, options?: RequestOptions) =>
       this.#request<SourceDetail>(`/sources/${params.sourceId}`, options),
     /**
      * Distilled source content, optionally a line range: the evidence behind
      * a citation or an issue.
      */
     content: (
-      params: { sourceId: string; startLine?: number; endLine?: number },
+      params: {sourceId: string; startLine?: number; endLine?: number},
       options?: RequestOptions,
     ) =>
-      this.#request<SourceContentResponse>(
-        `/sources/${params.sourceId}/content`,
-        {
-          query: _query({
-            startLine: params.startLine,
-            endLine: params.endLine,
-          }),
-          ...options,
-        },
-      ),
-    delete: async (params: { sourceId: string }, options?: RequestOptions) => {
-      await this.#request<void>(`/sources/${params.sourceId}`, {
-        method: "DELETE",
+      this.#request<SourceContentResponse>(`/sources/${params.sourceId}/content`, {
+        query: _query({
+          startLine: params.startLine,
+          endLine: params.endLine,
+        }),
         ...options,
-      });
+      }),
+    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/sources/${params.sourceId}`, {
+        method: 'DELETE',
+        ...options,
+      })
     },
-  };
+  }
 
   /** The audit feed: who did what, when. */
   activity = {
-    list: (params?: ListOptions) =>
-      this.#list<ActivityResponse>("/activity", params),
-  };
+    list: (params?: ListOptions) => this.#list<ActivityResponse>('/activity', params),
+  }
 
   /** Revisions: one per build, with an accounting report per revision. */
   revisions = {
-    list: (params?: ListOptions) =>
-      this.#list<RevisionsResponse>("/revisions", params),
-    report: (params: { revisionId: string }, options?: RequestOptions) =>
-      this.#request<RevisionReport>(
-        `/revisions/${params.revisionId}/report`,
-        options,
-      ),
+    list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
+    report: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionReport>(`/revisions/${params.revisionId}/report`, options),
     /** The outline as it was at a past build revision. */
-    outline: (params: { revisionId: string }, options?: RequestOptions) =>
-      this.#request<RevisionOutline>(
-        `/revisions/${params.revisionId}/outline`,
-        options,
-      ),
-  };
+    outline: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
+  }
 
   /** Crawl options for the knowledge base's web source. */
   crawlOptions = {
     edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
-      this.#request<CrawlOptions>("/crawl-options", {
-        method: "PATCH",
+      this.#request<CrawlOptions>('/crawl-options', {
+        method: 'PATCH',
         body: params,
         ...options,
       }),
-  };
+  }
 }
 
 /**
@@ -526,40 +472,38 @@ export class KnowledgeBaseHandle {
  * @beta
  */
 export class ContextClient {
-  #client: SanityClient;
-  #httpRequest: HttpRequest;
+  #client: SanityClient
+  #httpRequest: HttpRequest
 
   constructor(client: SanityClient, httpRequest: HttpRequest) {
-    this.#client = client;
-    this.#httpRequest = httpRequest;
+    this.#client = client
+    this.#httpRequest = httpRequest
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & { organizationId: string },
+      params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,
     ): Promise<KnowledgeBase> => {
-      const { organizationId, ...body } = params;
+      const {organizationId, ...body} = params
       return _request<KnowledgeBase>(this.#client, this.#httpRequest, {
         url: _collectionUrl(organizationId),
-        method: "POST",
+        method: 'POST',
         body,
         ...options,
-      });
+      })
     },
     /** List the organization's knowledge bases. */
-    list: (
-      params: { organizationId: string } & ListOptions,
-    ): Promise<KnowledgeBasesResponse> =>
+    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
       _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
         url: _collectionUrl(params.organizationId),
-        query: _query({ cursor: params.cursor, limit: params.limit }),
+        query: _query({cursor: params.cursor, limit: params.limit}),
         signal: params.signal,
         tag: params.tag,
       }),
-  };
+  }
 
   /**
    * A handle carrying everything scoped to one knowledge base, addressed by
@@ -567,11 +511,7 @@ export class ContextClient {
    * the first request and is reused after that.
    */
   knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
-    return new KnowledgeBaseHandle(
-      this.#client,
-      this.#httpRequest,
-      knowledgeBaseId,
-    );
+    return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
   }
 }
 
@@ -583,43 +523,41 @@ export class ContextClient {
  * @beta
  */
 export class ObservableContextClient {
-  #client: ObservableSanityClient;
-  #httpRequest: HttpRequest;
+  #client: ObservableSanityClient
+  #httpRequest: HttpRequest
 
   constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
-    this.#client = client;
-    this.#httpRequest = httpRequest;
+    this.#client = client
+    this.#httpRequest = httpRequest
   }
 
   /** The knowledge base collection. */
   knowledgeBases = {
     /** Create a knowledge base. Requires provisioning access to the target project. */
     create: (
-      params: CreateKnowledgeBaseParams & { organizationId: string },
+      params: CreateKnowledgeBaseParams & {organizationId: string},
       options?: RequestOptions,
     ): Observable<KnowledgeBase> => {
-      const { organizationId, ...body } = params;
+      const {organizationId, ...body} = params
       return _observe(options?.signal, (signal) =>
         _request<KnowledgeBase>(this.#client, this.#httpRequest, {
           url: _collectionUrl(organizationId),
-          method: "POST",
+          method: 'POST',
           body,
           tag: options?.tag,
           signal,
         }),
-      );
+      )
     },
     /** List the organization's knowledge bases. */
-    list: (
-      params: { organizationId: string } & ListOptions,
-    ): Observable<KnowledgeBasesResponse> =>
+    list: (params: {organizationId: string} & ListOptions): Observable<KnowledgeBasesResponse> =>
       _observe(params.signal, (signal) =>
         _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
           url: _collectionUrl(params.organizationId),
-          query: _query({ cursor: params.cursor, limit: params.limit }),
+          query: _query({cursor: params.cursor, limit: params.limit}),
           tag: params.tag,
           signal,
         }),
       ),
-  };
+  }
 }

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -1,0 +1,580 @@
+import {type FetchFunction} from 'get-it'
+
+type FetchBody = NonNullable<Parameters<FetchFunction>[1]>['body']
+import {type Observable} from 'rxjs'
+
+import {_observe, _request} from '../data/dataMethods'
+import type {ObservableSanityClient, SanityClient} from '../SanityClient'
+import type {HttpRequest} from '../types'
+import type {
+  ApplyIssuesParams,
+  ApplyIssuesResponse,
+  ActivityResponse,
+  Changes,
+  EntriesResponse,
+  EntryDetail,
+  EntryStatus,
+  ImportDetail,
+  ImportsResponse,
+  Instruction,
+  InstructionsResponse,
+  IssueDetail,
+  IssuesResponse,
+  Job,
+  JobAccepted,
+  Outline,
+  RevisionOutline,
+  RevisionReport,
+  RevisionsResponse,
+  SourceDetail,
+  SourcesResponse,
+  CrawlOptions,
+  CrawlPreviewParams,
+  CrawlPreviewResponse,
+  CreateImportParams,
+  CreateInstructionParams,
+  CreateKnowledgeBaseParams,
+  DismissIssueResponse,
+  EditCrawlOptionsParams,
+  EditInstructionParams,
+  EditKnowledgeBaseParams,
+  ImportDownloadResponse,
+  KnowledgeBase,
+  KnowledgeBasesResponse,
+  ReopenIssueResponse,
+  ResolveIssueParams,
+  ResolveIssueResponse,
+  SourceContentResponse,
+  StagedUpload,
+} from './types'
+import type {CreateFileImportParams, RenderFormat, RequestOptions} from './types'
+
+type ListOptions = RequestOptions & {cursor?: string; limit?: number}
+
+type Client = SanityClient | ObservableSanityClient
+
+/**
+ * The knowledge base's org-scoped address. Every operation except the by-id
+ * read lives under `/organizations/{orgId}/knowledge-bases/{slug}`, but the
+ * handle is constructed from the id alone, so the address is resolved once
+ * through the by-id endpoint and reused.
+ */
+type ResolvedAddress = {organizationId: string; slug: string}
+
+function _getKnowledgeBaseById(
+  client: Client,
+  httpRequest: HttpRequest,
+  knowledgeBaseId: string,
+  options?: RequestOptions,
+): Promise<KnowledgeBase> {
+  return _request<KnowledgeBase>(client, httpRequest, {
+    url: `/context/knowledge-bases/${knowledgeBaseId}`,
+    ...options,
+  })
+}
+
+function _collectionUrl(organizationId: string): string {
+  return `/context/organizations/${organizationId}/knowledge-bases`
+}
+
+/** Serialize defined values into query params, dropping the undefined ones. */
+function _query(entries: Record<string, string | number | undefined>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(entries).flatMap(([key, value]) =>
+      value === undefined ? [] : [[key, `${value}`]],
+    ),
+  )
+}
+
+/**
+ * Everything scoped to one knowledge base, addressed by its id alone.
+ * Construct via {@link ContextClient.knowledgeBase}.
+ *
+ * @beta
+ */
+export class KnowledgeBaseHandle {
+  #client: SanityClient
+  #httpRequest: HttpRequest
+  #knowledgeBaseId: string
+  #address: Promise<ResolvedAddress> | undefined
+
+  constructor(client: SanityClient, httpRequest: HttpRequest, knowledgeBaseId: string) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+    this.#knowledgeBaseId = knowledgeBaseId
+  }
+
+  /** The knowledge base id this handle was constructed with. */
+  get knowledgeBaseId(): string {
+    return this.#knowledgeBaseId
+  }
+
+  // The resolution is shared by every method on the handle, so it must not
+  // carry any one caller's abort signal: aborting one request would reject
+  // the cached promise for every concurrent caller. An aborted caller still
+  // rejects, because its own follow-up request starts with the aborted
+  // signal.
+  #resolveAddress(): Promise<ResolvedAddress> {
+    this.#address ??= _getKnowledgeBaseById(
+      this.#client,
+      this.#httpRequest,
+      this.#knowledgeBaseId,
+    ).then(
+      (kb) => ({organizationId: kb.organizationId, slug: kb.slug}),
+      (err) => {
+        // A failed resolution must not poison the handle for retries.
+        this.#address = undefined
+        throw err
+      },
+    )
+    return this.#address
+  }
+
+  async #request<R>(
+    suffix: string,
+    reqOptions: {
+      method?: string
+      body?: unknown
+      query?: Record<string, string>
+    } & RequestOptions = {},
+  ): Promise<R> {
+    const address = await this.#resolveAddress()
+    return _request<R>(this.#client, this.#httpRequest, {
+      url: `${_collectionUrl(address.organizationId)}/${address.slug}${suffix}`,
+      ...reqOptions,
+    })
+  }
+
+  /** Shared shape of every paginated list endpoint under the handle. */
+  #list<R>(
+    suffix: string,
+    params?: ListOptions,
+    extraQuery?: Record<string, string | undefined>,
+  ): Promise<R> {
+    return this.#request<R>(suffix, {
+      query: _query({
+        cursor: params?.cursor,
+        limit: params?.limit,
+        ...extraQuery,
+      }),
+      signal: params?.signal,
+      tag: params?.tag,
+    })
+  }
+
+  async #uploadFile(
+    params: CreateFileImportParams,
+    options?: RequestOptions,
+  ): Promise<JobAccepted> {
+    const staged = await this.#request<StagedUpload>('/imports/uploads', {
+      method: 'POST',
+      body: {
+        filename: params.filename,
+        ...(params.contentType && {contentType: params.contentType}),
+      },
+      ...options,
+    })
+    // The signed URL PUT goes straight to storage, outside the API pipeline:
+    // no auth header, and the body is raw bytes rather than JSON. Still uses
+    // the client's fetch resolution so proxy config applies in Node.
+    const config = this.#client.config()
+    const doFetch = config.resolveFetch?.(config.proxy) ?? (fetch as FetchFunction)
+    const putResponse = await doFetch(staged.uploadUrl, {
+      method: 'PUT',
+      // Buffer's ArrayBufferLike generic misses the body type's ArrayBuffer
+      // bound, even though fetch accepts it at runtime.
+      body: params.file as FetchBody,
+      ...(params.contentType && {
+        headers: {'content-type': params.contentType},
+      }),
+      signal: options?.signal,
+    })
+    if (!putResponse.ok) {
+      throw new Error(`File upload failed: ${putResponse.status} ${putResponse.statusText}`)
+    }
+    return this.#request<JobAccepted>(`/imports/uploads/${staged.importId}/complete`, {
+      method: 'POST',
+      body: {},
+      ...options,
+    })
+  }
+
+  /** Fetch the knowledge base. */
+  get(options?: RequestOptions): Promise<KnowledgeBase> {
+    return _getKnowledgeBaseById(this.#client, this.#httpRequest, this.#knowledgeBaseId, options)
+  }
+
+  /** Edit the knowledge base's configuration. */
+  edit(params: EditKnowledgeBaseParams, options?: RequestOptions): Promise<KnowledgeBase> {
+    return this.#request('', {method: 'PATCH', body: params, ...options})
+  }
+
+  /** Delete the knowledge base and its generated content. */
+  async delete(options?: RequestOptions): Promise<void> {
+    await this.#request('', {method: 'DELETE', ...options})
+  }
+
+  /**
+   * Build the knowledge base. The server waits for pending import processing
+   * before assembling, so importing and building back to back is safe. Track
+   * the returned job with {@link jobs}.
+   */
+  build(options?: RequestOptions): Promise<JobAccepted> {
+    return this.#request('/build', {method: 'POST', ...options})
+  }
+
+  /** Cancel the running build, if any. */
+  cancelBuild(options?: RequestOptions): Promise<{cancelled: boolean}> {
+    return this.#request('/build/cancel', {method: 'POST', ...options})
+  }
+
+  /** Run an incremental refresh: re-check sources and apply what changed. */
+  refresh(options?: RequestOptions): Promise<{jobId: string | null; started: boolean}> {
+    return this.#request('/refresh', {method: 'POST', ...options})
+  }
+
+  /**
+   * The built outline: every entry, ordered, with stats. The default
+   * `json` format resolves to {@link Outline}; `markdown` and
+   * `plain` resolve to a string.
+   */
+  outline<const F extends RenderFormat = 'json'>(
+    params?: {format?: F},
+    options?: RequestOptions,
+  ): Promise<F extends 'json' ? Outline : string> {
+    return this.#request('/outline', {
+      query: params?.format ? {format: params.format} : {},
+      ...options,
+    })
+  }
+
+  /** What changed in the corpus since the last build. */
+  changes(options?: RequestOptions): Promise<Changes> {
+    return this.#request('/changes', options)
+  }
+
+  /** Imports: feed content into the knowledge base. */
+  imports = {
+    /**
+     * Import content. One entry point, discriminated on `type`: inline
+     * `text`, a website `crawl`, a Sanity `dataset` bind, or a `file`
+     * upload. Processing queues automatically. The file variant stages the
+     * upload, PUTs the bytes to a signed storage URL, and confirms; the
+     * bytes never pass through the Context API.
+     */
+    create: (
+      params: CreateImportParams | CreateFileImportParams,
+      options?: RequestOptions,
+    ): Promise<JobAccepted> =>
+      params.type === 'file'
+        ? this.#uploadFile(params, options)
+        : this.#request('/imports', {
+            method: 'POST',
+            body: params,
+            ...options,
+          }),
+    list: (params?: ListOptions) => this.#list<ImportsResponse>('/imports', params),
+    get: (params: {importId: string}, options?: RequestOptions) =>
+      this.#request<ImportDetail>(`/imports/${params.importId}`, options),
+    /** A short-lived signed URL for the original uploaded bytes. */
+    download: (params: {importId: string}, options?: RequestOptions) =>
+      this.#request<ImportDownloadResponse>(`/imports/${params.importId}/download`, options),
+    delete: async (params: {importId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/imports/${params.importId}`, {
+        method: 'DELETE',
+        ...options,
+      })
+    },
+    /** Preview which pages a crawl would ingest, before committing to it. */
+    crawlPreview: (params: CrawlPreviewParams, options?: RequestOptions) =>
+      this.#request<CrawlPreviewResponse>('/imports/crawl-preview', {
+        method: 'POST',
+        body: params,
+        ...options,
+      }),
+  }
+
+  /** Jobs: poll async work (builds, imports) to a terminal state. */
+  jobs = {
+    get: (params: {jobId: string}, options?: RequestOptions) =>
+      this.#request<Job>(`/jobs/${params.jobId}`, options),
+  }
+
+  /** Issues: findings from builds awaiting triage. */
+  issues = {
+    list: (params?: {status?: 'open' | 'accepted' | 'rejected'} & ListOptions) =>
+      this.#list<IssuesResponse>('/issues', params, {
+        status: params?.status,
+      }),
+    get: (params: {issueId: string}, options?: RequestOptions) =>
+      this.#request<IssueDetail>(`/issues/${params.issueId}`, options),
+    /** Resolve a conflict issue. Mints the standing instruction, same as the dashboard. */
+    resolve: (params: {issueId: string} & ResolveIssueParams, options?: RequestOptions) => {
+      const {issueId, ...body} = params
+      return this.#request<ResolveIssueResponse>(`/issues/${issueId}/resolve`, {
+        method: 'POST',
+        body,
+        ...options,
+      })
+    },
+    dismiss: (params: {issueId: string}, options?: RequestOptions) =>
+      this.#request<DismissIssueResponse>(`/issues/${params.issueId}/dismiss`, {
+        method: 'POST',
+        ...options,
+      }),
+    reopen: (params: {issueId: string}, options?: RequestOptions) =>
+      this.#request<ReopenIssueResponse>(`/issues/${params.issueId}/reopen`, {
+        method: 'POST',
+        ...options,
+      }),
+    /** Apply already-accepted issues to the knowledge base in one batch. */
+    apply: (params: ApplyIssuesParams, options?: RequestOptions) =>
+      this.#request<ApplyIssuesResponse>('/issues/apply', {
+        method: 'POST',
+        body: params,
+        ...options,
+      }),
+  }
+
+  /** Instructions: standing decisions that steer every build. */
+  instructions = {
+    create: (params: CreateInstructionParams, options?: RequestOptions) =>
+      this.#request<Instruction>('/instructions', {
+        method: 'POST',
+        body: params,
+        ...options,
+      }),
+    list: (params?: ListOptions) => this.#list<InstructionsResponse>('/instructions', params),
+    edit: (params: {instructionId: string} & EditInstructionParams, options?: RequestOptions) => {
+      const {instructionId, ...body} = params
+      return this.#request<Instruction>(`/instructions/${instructionId}`, {
+        method: 'PATCH',
+        body,
+        ...options,
+      })
+    },
+    delete: async (params: {instructionId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/instructions/${params.instructionId}`, {
+        method: 'DELETE',
+        ...options,
+      })
+    },
+  }
+
+  /** Entries: the built outline, one entry per node. */
+  entries = {
+    /** List entries, optionally filtered by status or searched (`q`). */
+    list: (
+      params?: {
+        status?: EntryStatus
+        q?: string
+        mode?: 'keyword' | 'hybrid'
+        include?: 'metadata' | 'body'
+        paths?: string
+      } & ListOptions,
+    ) =>
+      this.#list<EntriesResponse>('/entries', params, {
+        status: params?.status,
+        q: params?.q,
+        mode: params?.mode,
+        include: params?.include,
+        paths: params?.paths,
+      }),
+    /**
+     * One entry with its full body, by outline path (e.g. `billing/refunds`).
+     * The default `json` format resolves to {@link EntryDetail};
+     * `markdown` and `plain` resolve to a string.
+     */
+    get: <const F extends RenderFormat = 'json'>(
+      params: {path: string; format?: F},
+      options?: RequestOptions,
+    ) =>
+      this.#request<F extends 'json' ? EntryDetail : string>(
+        `/entries/${encodeURIComponent(params.path)}`,
+        {
+          query: params.format ? {format: params.format} : {},
+          ...options,
+        },
+      ),
+  }
+
+  /** Sources: the distilled units builds cite. */
+  sources = {
+    list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
+    get: (params: {sourceId: string}, options?: RequestOptions) =>
+      this.#request<SourceDetail>(`/sources/${params.sourceId}`, options),
+    /**
+     * Distilled source content, optionally a line range: the evidence behind
+     * a citation or an issue.
+     */
+    content: (
+      params: {sourceId: string; startLine?: number; endLine?: number},
+      options?: RequestOptions,
+    ) =>
+      this.#request<SourceContentResponse>(`/sources/${params.sourceId}/content`, {
+        query: _query({
+          startLine: params.startLine,
+          endLine: params.endLine,
+        }),
+        ...options,
+      }),
+    delete: async (params: {sourceId: string}, options?: RequestOptions) => {
+      await this.#request<void>(`/sources/${params.sourceId}`, {
+        method: 'DELETE',
+        ...options,
+      })
+    },
+  }
+
+  /** The audit feed: who did what, when. */
+  activity = {
+    list: (params?: ListOptions) => this.#list<ActivityResponse>('/activity', params),
+  }
+
+  /** Revisions: one per build, with an accounting report per revision. */
+  revisions = {
+    list: (params?: ListOptions) => this.#list<RevisionsResponse>('/revisions', params),
+    report: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionReport>(`/revisions/${params.revisionId}/report`, options),
+    /** The outline as it was at a past build revision. */
+    outline: (params: {revisionId: string}, options?: RequestOptions) =>
+      this.#request<RevisionOutline>(`/revisions/${params.revisionId}/outline`, options),
+  }
+
+  /** Crawl options for the knowledge base's web source. */
+  crawlOptions = {
+    edit: (params: EditCrawlOptionsParams, options?: RequestOptions) =>
+      this.#request<CrawlOptions>('/crawl-options', {
+        method: 'PATCH',
+        body: params,
+        ...options,
+      }),
+  }
+
+  /**
+   * An ordinary `@sanity/client` bound to the knowledge base's dataset, for
+   * GROQ reads, listeners, and anything else the platform ships for
+   * documents. Not a wrapper: the returned client is a plain client.
+   */
+  async contentClient(options?: RequestOptions): Promise<SanityClient> {
+    const kb = await this.get(options)
+    if (!kb.sanityProjectId || !kb.sanityDatasetId) {
+      throw new Error(`Knowledge base "${this.#knowledgeBaseId}" has no dataset binding`)
+    }
+    return this.#client.withConfig({
+      projectId: kb.sanityProjectId,
+      dataset: kb.sanityDatasetId,
+      useCdn: false,
+    })
+  }
+}
+
+/**
+ * `client.context` — knowledge bases and everything scoped to them.
+ *
+ * @example Zero to knowledge base
+ * ```ts
+ * const created = await client.context.knowledgeBases.create({
+ *   organizationId: 'org123',
+ *   name: 'Support docs',
+ *   description: 'Product docs and troubleshooting guides',
+ *   sanityProjectId: 'abc123',
+ *   sanityDatasetId: 'production',
+ * })
+ * const kb = client.context.knowledgeBase(created.publicId)
+ * await kb.imports.create({type: 'text', title: 'Refund policy', content: refundMd})
+ * const {jobId} = await kb.build()
+ * ```
+ *
+ * @beta
+ */
+export class ContextClient {
+  #client: SanityClient
+  #httpRequest: HttpRequest
+
+  constructor(client: SanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /** The knowledge base collection. */
+  knowledgeBases = {
+    /** Create a knowledge base. Requires provisioning access to the target project. */
+    create: (
+      params: CreateKnowledgeBaseParams & {organizationId: string},
+      options?: RequestOptions,
+    ): Promise<KnowledgeBase> => {
+      const {organizationId, ...body} = params
+      return _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+        url: _collectionUrl(organizationId),
+        method: 'POST',
+        body,
+        ...options,
+      })
+    },
+    /** List the organization's knowledge bases. */
+    list: (params: {organizationId: string} & ListOptions): Promise<KnowledgeBasesResponse> =>
+      _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
+        url: _collectionUrl(params.organizationId),
+        query: _query({cursor: params.cursor, limit: params.limit}),
+        signal: params.signal,
+        tag: params.tag,
+      }),
+  }
+
+  /**
+   * A handle carrying everything scoped to one knowledge base, addressed by
+   * id alone. Synchronous: the id-to-address resolution happens lazily on
+   * the first request and is reused after that.
+   */
+  knowledgeBase(knowledgeBaseId: string): KnowledgeBaseHandle {
+    return new KnowledgeBaseHandle(this.#client, this.#httpRequest, knowledgeBaseId)
+  }
+}
+
+/**
+ * Observable counterpart of {@link ContextClient}. Collection-level methods
+ * only; the per-knowledge-base handle is promise-based, so use the promise
+ * client (`client.context.knowledgeBase(id)`) for handle operations.
+ *
+ * @beta
+ */
+export class ObservableContextClient {
+  #client: ObservableSanityClient
+  #httpRequest: HttpRequest
+
+  constructor(client: ObservableSanityClient, httpRequest: HttpRequest) {
+    this.#client = client
+    this.#httpRequest = httpRequest
+  }
+
+  /** The knowledge base collection. */
+  knowledgeBases = {
+    /** Create a knowledge base. Requires provisioning access to the target project. */
+    create: (
+      params: CreateKnowledgeBaseParams & {organizationId: string},
+      options?: RequestOptions,
+    ): Observable<KnowledgeBase> => {
+      const {organizationId, ...body} = params
+      return _observe(options?.signal, (signal) =>
+        _request<KnowledgeBase>(this.#client, this.#httpRequest, {
+          url: _collectionUrl(organizationId),
+          method: 'POST',
+          body,
+          tag: options?.tag,
+          signal,
+        }),
+      )
+    },
+    /** List the organization's knowledge bases. */
+    list: (params: {organizationId: string} & ListOptions): Observable<KnowledgeBasesResponse> =>
+      _observe(params.signal, (signal) =>
+        _request<KnowledgeBasesResponse>(this.#client, this.#httpRequest, {
+          url: _collectionUrl(params.organizationId),
+          query: _query({cursor: params.cursor, limit: params.limit}),
+          tag: params.tag,
+          signal,
+        }),
+      ),
+  }
+}

--- a/src/context/openapi.json
+++ b/src/context/openapi.json
@@ -994,14 +994,6 @@
                       "type": "string",
                       "enum": ["created", "building", "ready", "review", "stale", "paused"]
                     },
-                    "sanityProjectId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "sanityDatasetId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
                     "activeJobId": {
                       "nullable": true,
                       "type": "string"
@@ -1195,8 +1187,6 @@
                     "name",
                     "description",
                     "state",
-                    "sanityProjectId",
-                    "sanityDatasetId",
                     "activeJobId",
                     "isBuilding",
                     "buildStageState",
@@ -1306,14 +1296,6 @@
                           "state": {
                             "type": "string",
                             "enum": ["created", "building", "ready", "review", "stale", "paused"]
-                          },
-                          "sanityProjectId": {
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "sanityDatasetId": {
-                            "nullable": true,
-                            "type": "string"
                           },
                           "activeJobId": {
                             "nullable": true,
@@ -1508,8 +1490,6 @@
                           "name",
                           "description",
                           "state",
-                          "sanityProjectId",
-                          "sanityDatasetId",
                           "activeJobId",
                           "isBuilding",
                           "buildStageState",
@@ -1575,17 +1555,9 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 2000
-                  },
-                  "sanityProjectId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "sanityDatasetId": {
-                    "type": "string",
-                    "minLength": 1
                   }
                 },
-                "required": ["name", "description", "sanityProjectId", "sanityDatasetId"]
+                "required": ["name", "description"]
               }
             }
           }
@@ -1639,14 +1611,6 @@
                     "state": {
                       "type": "string",
                       "enum": ["created", "building", "ready", "review", "stale", "paused"]
-                    },
-                    "sanityProjectId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "sanityDatasetId": {
-                      "nullable": true,
-                      "type": "string"
                     },
                     "activeJobId": {
                       "nullable": true,
@@ -1841,8 +1805,6 @@
                     "name",
                     "description",
                     "state",
-                    "sanityProjectId",
-                    "sanityDatasetId",
                     "activeJobId",
                     "isBuilding",
                     "buildStageState",
@@ -1922,14 +1884,6 @@
                       "type": "string",
                       "enum": ["created", "building", "ready", "review", "stale", "paused"]
                     },
-                    "sanityProjectId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "sanityDatasetId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
                     "activeJobId": {
                       "nullable": true,
                       "type": "string"
@@ -2123,8 +2077,6 @@
                     "name",
                     "description",
                     "state",
-                    "sanityProjectId",
-                    "sanityDatasetId",
                     "activeJobId",
                     "isBuilding",
                     "buildStageState",
@@ -2231,14 +2183,6 @@
                       "type": "string",
                       "enum": ["created", "building", "ready", "review", "stale", "paused"]
                     },
-                    "sanityProjectId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "sanityDatasetId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
                     "activeJobId": {
                       "nullable": true,
                       "type": "string"
@@ -2432,8 +2376,6 @@
                     "name",
                     "description",
                     "state",
-                    "sanityProjectId",
-                    "sanityDatasetId",
                     "activeJobId",
                     "isBuilding",
                     "buildStageState",
@@ -4590,6 +4532,7 @@
                             "type": "string"
                           },
                           "revisionId": {
+                            "nullable": true,
                             "type": "string",
                             "format": "uuid",
                             "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
@@ -4635,6 +4578,7 @@
                           "sourceIds": {
                             "type": "array",
                             "items": {
+                              "nullable": true,
                               "type": "string",
                               "format": "uuid",
                               "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
@@ -4784,6 +4728,7 @@
                       "type": "string"
                     },
                     "revisionId": {
+                      "nullable": true,
                       "type": "string",
                       "format": "uuid",
                       "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
@@ -4829,6 +4774,7 @@
                     "sourceIds": {
                       "type": "array",
                       "items": {
+                        "nullable": true,
                         "type": "string",
                         "format": "uuid",
                         "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
@@ -5957,104 +5903,6 @@
                   "required": ["jobId"],
                   "additionalProperties": false,
                   "description": "JobAccepted"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/{apiVersion}/context/organizations/{organizationId}/dataset-permissions": {
-      "post": {
-        "operationId": "getDatasetPermissions",
-        "summary": "Resolve the caller's access to datasets",
-        "tags": ["dataset-permissions"],
-        "description": "Resolves the caller's effective access to each requested dataset in one round trip, keyed by `\"{sanityProjectId}/{sanityDatasetId}\"`. `read` and `write` come from the Sanity ACL, with positive reads verified with a live read check. `fullRead` gates binding a dataset source; `admin` plus `write` gates creating a Context. Transient failures fail open on `read` and closed on `write`, `fullRead`, and `admin`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "datasets": {
-                    "maxItems": 200,
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "sanityProjectId": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "sanityDatasetId": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      },
-                      "required": ["sanityProjectId", "sanityDatasetId"]
-                    }
-                  }
-                },
-                "required": ["datasets"],
-                "description": "DatasetPermissionsInput"
-              }
-            }
-          },
-          "description": "DatasetPermissionsInput"
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "apiVersion",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "organizationId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "DatasetPermissionsResponse",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "permissions": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "read": {
-                            "type": "boolean"
-                          },
-                          "write": {
-                            "type": "boolean"
-                          },
-                          "fullRead": {
-                            "type": "boolean"
-                          },
-                          "admin": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": ["read", "write", "fullRead", "admin"],
-                        "additionalProperties": false
-                      }
-                    }
-                  },
-                  "required": ["permissions"],
-                  "additionalProperties": false,
-                  "description": "DatasetPermissionsResponse"
                 }
               }
             }
@@ -8750,6 +8598,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": "string"
+                    },
                     "threadId": {
                       "type": "string"
                     },
@@ -8866,6 +8717,7 @@
                     }
                   },
                   "required": [
+                    "id",
                     "threadId",
                     "mcpEndpointId",
                     "startedAt",
@@ -8963,6 +8815,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "id": {
+                      "type": "string"
+                    },
                     "threadId": {
                       "type": "string"
                     },
@@ -9079,178 +8934,7 @@
                     }
                   },
                   "required": [
-                    "threadId",
-                    "mcpEndpointId",
-                    "startedAt",
-                    "messagesUpdatedAt",
-                    "messages",
-                    "modelProvider",
-                    "modelId",
-                    "tokenUsage",
-                    "coreMetrics",
-                    "classifiedAt",
-                    "classificationError",
-                    "createdAt",
-                    "updatedAt"
-                  ],
-                  "additionalProperties": false,
-                  "description": "Conversation"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "operationId": "getConversation",
-        "summary": "Get a conversation",
-        "tags": ["conversations"],
-        "description": "Returns one recorded conversation by its thread id, transcript included.",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
-            "in": "path",
-            "name": "mcpEndpointName",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 200
-            },
-            "in": "path",
-            "name": "threadId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Conversation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "threadId": {
-                      "type": "string"
-                    },
-                    "mcpEndpointId": {
-                      "type": "string"
-                    },
-                    "startedAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
-                    },
-                    "messagesUpdatedAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
-                    },
-                    "messages": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "role": {
-                            "type": "string",
-                            "enum": ["user", "assistant", "system", "tool"]
-                          },
-                          "content": {
-                            "default": null,
-                            "nullable": true,
-                            "type": "string",
-                            "maxLength": 20000
-                          },
-                          "toolName": {
-                            "default": null,
-                            "nullable": true,
-                            "type": "string"
-                          },
-                          "toolType": {
-                            "default": null,
-                            "nullable": true,
-                            "type": "string",
-                            "enum": ["call", "result"]
-                          }
-                        },
-                        "required": ["role", "content", "toolName", "toolType"],
-                        "additionalProperties": false,
-                        "description": "ConversationMessage"
-                      }
-                    },
-                    "modelProvider": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "modelId": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "tokenUsage": {
-                      "nullable": true,
-                      "type": "object",
-                      "properties": {
-                        "inputTokens": {
-                          "type": "number"
-                        },
-                        "outputTokens": {
-                          "type": "number"
-                        },
-                        "totalTokens": {
-                          "type": "number"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "description": "ConversationTokenUsage"
-                    },
-                    "coreMetrics": {
-                      "nullable": true,
-                      "type": "object",
-                      "properties": {
-                        "successScore": {
-                          "type": "number"
-                        },
-                        "sentiment": {
-                          "type": "string",
-                          "enum": ["positive", "neutral", "negative"]
-                        },
-                        "contentGaps": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "additionalProperties": false,
-                      "description": "ConversationCoreMetrics"
-                    },
-                    "classifiedAt": {
-                      "nullable": true,
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
-                    },
-                    "classificationError": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
-                    }
-                  },
-                  "required": [
+                    "id",
                     "threadId",
                     "mcpEndpointId",
                     "startedAt",
@@ -9274,12 +8958,12 @@
         }
       }
     },
-    "/{apiVersion}/context/organizations/{organizationId}/mcp/{mcpEndpointName}/conversations": {
+    "/{apiVersion}/context/organizations/{organizationId}/conversations": {
       "get": {
-        "operationId": "listConversations",
-        "summary": "List conversations",
+        "operationId": "listOrganizationConversations",
+        "summary": "List conversations across the organization",
         "tags": ["conversations"],
-        "description": "The MCP endpoint's recorded conversations, most recently updated first. `?classification=` narrows to one classification state; `pending` flips to oldest-first work-queue order.",
+        "description": "Every recorded conversation in the organization, across all MCP endpoints, most recently updated first. Rows carry `mcpEndpointId` so callers can attribute each thread. Same filters and sort as the per-endpoint list; `?endpoint=` narrows to one endpoint by name (and 404s when it doesn't resolve).",
         "parameters": [
           {
             "schema": {
@@ -9313,10 +8997,57 @@
           {
             "schema": {
               "type": "string",
+              "enum": ["good", "okay", "poor", "critical"]
+            },
+            "in": "query",
+            "name": "scoreRange",
+            "required": false,
+            "description": "Filter by score bucket over the classifier score, matching the insights aggregate: `good` >= 8, `okay` 6-8, `poor` 4-6, `critical` < 4. Only conversations with a recorded score match. Composes with the other filters."
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["positive", "neutral", "negative"]
+            },
+            "in": "query",
+            "name": "sentiment",
+            "required": false,
+            "description": "Filter to conversations the classifier rated with this sentiment. Composes with the other filters."
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["date-desc", "date-asc", "score-desc", "score-asc"]
+            },
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "description": "Sort order, `date-desc` by default. Date sorts key on when the transcript last changed; score sorts key on the classifier score and only return conversations with a recorded score. An explicit sort overrides the oldest-first default of `classification=pending`; score sorts cannot combine with `pending`, whose threads have no score yet."
+          },
+          {
+            "schema": {
+              "type": "string",
               "minLength": 1
             },
+            "in": "query",
+            "name": "endpoint",
+            "required": false,
+            "description": "Narrow to one MCP endpoint by its URL name (the per-endpoint routes' path identifier). Omit for every endpoint in the organization."
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
             "in": "path",
-            "name": "mcpEndpointName",
+            "name": "apiVersion",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "organizationId",
             "required": true
           }
         ],
@@ -9333,7 +9064,13 @@
                       "items": {
                         "type": "object",
                         "properties": {
+                          "id": {
+                            "type": "string"
+                          },
                           "threadId": {
+                            "type": "string"
+                          },
+                          "mcpEndpointId": {
                             "type": "string"
                           },
                           "messagesUpdatedAt": {
@@ -9371,7 +9108,298 @@
                           }
                         },
                         "required": [
+                          "id",
                           "threadId",
+                          "mcpEndpointId",
+                          "messagesUpdatedAt",
+                          "messageCount",
+                          "firstMessage",
+                          "coreMetrics"
+                        ],
+                        "additionalProperties": false,
+                        "description": "ConversationSummary"
+                      }
+                    },
+                    "nextCursor": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": ["data", "nextCursor"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{apiVersion}/context/organizations/{organizationId}/insights": {
+      "get": {
+        "operationId": "getOrganizationConversationInsights",
+        "summary": "Organization insights",
+        "tags": ["conversations"],
+        "description": "Aggregate stats over every conversation recorded in the organization, across all MCP endpoints: volume, score and sentiment distributions, classification progress, and the most frequent content gaps. `?endpoint=` narrows to one endpoint by name.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "query",
+            "name": "endpoint",
+            "required": false,
+            "description": "Narrow to one MCP endpoint by its URL name (the per-endpoint routes' path identifier). Omit for every endpoint in the organization."
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "apiVersion",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "organizationId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ConversationInsights",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "conversations": {
+                      "type": "number"
+                    },
+                    "averageScore": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "averageMessages": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "analyzed": {
+                      "type": "number"
+                    },
+                    "classificationErrors": {
+                      "type": "number"
+                    },
+                    "scores": {
+                      "type": "object",
+                      "properties": {
+                        "good": {
+                          "type": "number"
+                        },
+                        "okay": {
+                          "type": "number"
+                        },
+                        "poor": {
+                          "type": "number"
+                        },
+                        "critical": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["good", "okay", "poor", "critical"],
+                      "additionalProperties": false
+                    },
+                    "sentiment": {
+                      "type": "object",
+                      "properties": {
+                        "positive": {
+                          "type": "number"
+                        },
+                        "neutral": {
+                          "type": "number"
+                        },
+                        "negative": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["positive", "neutral", "negative"],
+                      "additionalProperties": false
+                    },
+                    "contentGaps": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "gap": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": ["gap", "count"],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "conversations",
+                    "averageScore",
+                    "averageMessages",
+                    "analyzed",
+                    "classificationErrors",
+                    "scores",
+                    "sentiment",
+                    "contentGaps"
+                  ],
+                  "additionalProperties": false,
+                  "description": "ConversationInsights"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{apiVersion}/context/organizations/{organizationId}/mcp/{mcpEndpointName}/conversations": {
+      "get": {
+        "operationId": "listConversations",
+        "summary": "List conversations",
+        "tags": ["conversations"],
+        "description": "The MCP endpoint's recorded conversations, most recently updated first. `?classification=`, `?scoreRange=`, and `?sentiment=` narrow the list and compose; `?sort=` reorders it. `classification=pending` flips to oldest-first work-queue order unless an explicit sort overrides it.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "cursor",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 50,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["pending", "classified", "failed"]
+            },
+            "in": "query",
+            "name": "classification",
+            "required": false,
+            "description": "Filter by classification state. `pending` is the classifier work queue: threads with messages, no verdict, no recorded failure, and settled — the transcript unchanged for a server-owned 10-minute cooldown so a thread still being written is never scored mid-write — returned oldest first. `classified` and `failed` return newest first. Omit for all conversations."
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["good", "okay", "poor", "critical"]
+            },
+            "in": "query",
+            "name": "scoreRange",
+            "required": false,
+            "description": "Filter by score bucket over the classifier score, matching the insights aggregate: `good` >= 8, `okay` 6-8, `poor` 4-6, `critical` < 4. Only conversations with a recorded score match. Composes with the other filters."
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["positive", "neutral", "negative"]
+            },
+            "in": "query",
+            "name": "sentiment",
+            "required": false,
+            "description": "Filter to conversations the classifier rated with this sentiment. Composes with the other filters."
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["date-desc", "date-asc", "score-desc", "score-asc"]
+            },
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "description": "Sort order, `date-desc` by default. Date sorts key on when the transcript last changed; score sorts key on the classifier score and only return conversations with a recorded score. An explicit sort overrides the oldest-first default of `classification=pending`; score sorts cannot combine with `pending`, whose threads have no score yet."
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "mcpEndpointName",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "threadId": {
+                            "type": "string"
+                          },
+                          "mcpEndpointId": {
+                            "type": "string"
+                          },
+                          "messagesUpdatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                          },
+                          "messageCount": {
+                            "type": "number"
+                          },
+                          "firstMessage": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "coreMetrics": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "successScore": {
+                                "type": "number"
+                              },
+                              "sentiment": {
+                                "type": "string",
+                                "enum": ["positive", "neutral", "negative"]
+                              },
+                              "contentGaps": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "ConversationCoreMetrics"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "threadId",
+                          "mcpEndpointId",
                           "messagesUpdatedAt",
                           "messageCount",
                           "firstMessage",
@@ -9501,6 +9529,174 @@
                   ],
                   "additionalProperties": false,
                   "description": "ConversationInsights"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{apiVersion}/context/organizations/{organizationId}/conversations/{conversationId}": {
+      "get": {
+        "operationId": "getConversationById",
+        "summary": "Get a conversation",
+        "tags": ["conversations"],
+        "description": "Returns one recorded conversation by its canonical id (the `id` on list rows), transcript included. The id is unique across the organization, unlike `threadId`, which repeats across MCP endpoints.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "conversationId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "type": "string"
+                    },
+                    "mcpEndpointId": {
+                      "type": "string"
+                    },
+                    "startedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "messagesUpdatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "role": {
+                            "type": "string",
+                            "enum": ["user", "assistant", "system", "tool"]
+                          },
+                          "content": {
+                            "default": null,
+                            "nullable": true,
+                            "type": "string",
+                            "maxLength": 20000
+                          },
+                          "toolName": {
+                            "default": null,
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "toolType": {
+                            "default": null,
+                            "nullable": true,
+                            "type": "string",
+                            "enum": ["call", "result"]
+                          }
+                        },
+                        "required": ["role", "content", "toolName", "toolType"],
+                        "additionalProperties": false,
+                        "description": "ConversationMessage"
+                      }
+                    },
+                    "modelProvider": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "modelId": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "tokenUsage": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "inputTokens": {
+                          "type": "number"
+                        },
+                        "outputTokens": {
+                          "type": "number"
+                        },
+                        "totalTokens": {
+                          "type": "number"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "description": "ConversationTokenUsage"
+                    },
+                    "coreMetrics": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "successScore": {
+                          "type": "number"
+                        },
+                        "sentiment": {
+                          "type": "string",
+                          "enum": ["positive", "neutral", "negative"]
+                        },
+                        "contentGaps": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false,
+                      "description": "ConversationCoreMetrics"
+                    },
+                    "classifiedAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "classificationError": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "threadId",
+                    "mcpEndpointId",
+                    "startedAt",
+                    "messagesUpdatedAt",
+                    "messages",
+                    "modelProvider",
+                    "modelId",
+                    "tokenUsage",
+                    "coreMetrics",
+                    "classifiedAt",
+                    "classificationError",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false,
+                  "description": "Conversation"
                 }
               }
             }

--- a/src/context/types.gen.ts
+++ b/src/context/types.gen.ts
@@ -1006,8 +1006,6 @@ export interface operations {
             description: string
             /** @enum {string} */
             state: 'created' | 'building' | 'ready' | 'review' | 'stale' | 'paused'
-            sanityProjectId: string | null
-            sanityDatasetId: string | null
             activeJobId: string | null
             isBuilding: boolean
             buildStageState: {
@@ -1105,8 +1103,6 @@ export interface operations {
               description: string
               /** @enum {string} */
               state: 'created' | 'building' | 'ready' | 'review' | 'stale' | 'paused'
-              sanityProjectId: string | null
-              sanityDatasetId: string | null
               activeJobId: string | null
               isBuilding: boolean
               buildStageState: {
@@ -1190,8 +1186,6 @@ export interface operations {
           name: string
           slug?: string
           description: string
-          sanityProjectId: string
-          sanityDatasetId: string
         }
       }
     }
@@ -1212,8 +1206,6 @@ export interface operations {
             description: string
             /** @enum {string} */
             state: 'created' | 'building' | 'ready' | 'review' | 'stale' | 'paused'
-            sanityProjectId: string | null
-            sanityDatasetId: string | null
             activeJobId: string | null
             isBuilding: boolean
             buildStageState: {
@@ -1306,8 +1298,6 @@ export interface operations {
             description: string
             /** @enum {string} */
             state: 'created' | 'building' | 'ready' | 'review' | 'stale' | 'paused'
-            sanityProjectId: string | null
-            sanityDatasetId: string | null
             activeJobId: string | null
             isBuilding: boolean
             buildStageState: {
@@ -1432,8 +1422,6 @@ export interface operations {
             description: string
             /** @enum {string} */
             state: 'created' | 'building' | 'ready' | 'review' | 'stale' | 'paused'
-            sanityProjectId: string | null
-            sanityDatasetId: string | null
             activeJobId: string | null
             isBuilding: boolean
             buildStageState: {
@@ -1751,7 +1739,7 @@ export interface operations {
               id: string
               knowledgeBaseId: string
               /** Format: uuid */
-              revisionId: string
+              revisionId: string | null
               path: string
               title: string
               tldr: {
@@ -1764,7 +1752,7 @@ export interface operations {
               body: string | null
               /** @enum {string} */
               status: 'virtual' | 'outlined' | 'filled' | 'stale' | 'generation_failed'
-              sourceIds: string[]
+              sourceIds: (string | null)[]
               citations?: {
                 sourceId: string
                 supports?: string
@@ -1815,7 +1803,7 @@ export interface operations {
             id: string
             knowledgeBaseId: string
             /** Format: uuid */
-            revisionId: string
+            revisionId: string | null
             path: string
             title: string
             tldr: {
@@ -1828,7 +1816,7 @@ export interface operations {
             body: string | null
             /** @enum {string} */
             status: 'virtual' | 'outlined' | 'filled' | 'stale' | 'generation_failed'
-            sourceIds: string[]
+            sourceIds: (string | null)[]
             citations?: {
               sourceId: string
               supports?: string

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,0 +1,211 @@
+import type {UploadBody} from '../types'
+import type {components, paths} from './types.gen'
+
+/** Options accepted by every Context method. @beta */
+export type RequestOptions = {signal?: AbortSignal; tag?: string}
+
+/**
+ * Render format for outline and entry reads. `json` returns the typed
+ * shape; `markdown` and `plain` return the rendered text as a string.
+ * @beta
+ */
+export type RenderFormat = 'json' | 'markdown' | 'plain'
+
+/**
+ * A file import. The client stages the upload, PUTs the bytes straight to
+ * storage with a signed URL, and confirms. The Context API never holds the
+ * file content.
+ * @beta
+ */
+export type CreateFileImportParams = {
+  type: 'file'
+  /** Same shapes `assets.upload` accepts, minus node streams: the bytes go
+   * out through `fetch`, which has no portable stream support. */
+  file: Exclude<UploadBody, NodeJS.ReadableStream>
+  filename: string
+  contentType?: string
+}
+
+type KnowledgeBasesPath = '/{apiVersion}/context/organizations/{organizationId}/knowledge-bases'
+type KnowledgeBasePath =
+  '/{apiVersion}/context/organizations/{organizationId}/knowledge-bases/{knowledgeBaseSlug}'
+type KnowledgeBaseByIdPath = '/{apiVersion}/context/knowledge-bases/{knowledgeBaseId}'
+type ImportsPath = `${KnowledgeBasePath}/imports`
+type ImportPath = `${KnowledgeBasePath}/imports/{importId}`
+type UploadsPath = `${KnowledgeBasePath}/imports/uploads`
+type CrawlPreviewPath = `${KnowledgeBasePath}/imports/crawl-preview`
+type OutlinePath = `${KnowledgeBasePath}/outline`
+type EntryPath = `${KnowledgeBasePath}/entries/{entryPath}`
+type SourcesPath = `${KnowledgeBasePath}/sources`
+type SourcePath = `${KnowledgeBasePath}/sources/{sourceId}`
+type SourceContentPath = `${KnowledgeBasePath}/sources/{sourceId}/content`
+type ChangesPath = `${KnowledgeBasePath}/changes`
+type ActivityPath = `${KnowledgeBasePath}/activity`
+type RevisionsPath = `${KnowledgeBasePath}/revisions`
+type RevisionReportPath = `${KnowledgeBasePath}/revisions/{revisionId}/report`
+type RevisionOutlinePath = `${KnowledgeBasePath}/revisions/{revisionId}/outline`
+type IssuePath = `${KnowledgeBasePath}/issues/{issueId}`
+type IssuesApplyPath = `${KnowledgeBasePath}/issues/apply`
+type InstructionPath = `${KnowledgeBasePath}/instructions/{instructionId}`
+type CrawlOptionsPath = `${KnowledgeBasePath}/crawl-options`
+type JobPath = `${KnowledgeBasePath}/jobs/{jobId}`
+type IssuesPath = `${KnowledgeBasePath}/issues`
+type IssueResolvePath = `${KnowledgeBasePath}/issues/{issueId}/resolve`
+type IssueDismissPath = `${KnowledgeBasePath}/issues/{issueId}/dismiss`
+type IssueReopenPath = `${KnowledgeBasePath}/issues/{issueId}/reopen`
+type InstructionsPath = `${KnowledgeBasePath}/instructions`
+type EntriesPath = `${KnowledgeBasePath}/entries`
+
+type JsonResponse<T> = T extends {content: {'application/json': infer R}} ? R : never
+type JsonBody<T> = T extends {
+  requestBody: {content: {'application/json': infer R}}
+}
+  ? R
+  : never
+
+/**
+ * A knowledge base: one buildable body of knowledge inside Context.
+ * @beta
+ */
+export type KnowledgeBase = JsonResponse<paths[KnowledgeBaseByIdPath]['get']['responses']['200']>
+
+/**
+ * Parameters for creating a knowledge base.
+ * @beta
+ */
+export type CreateKnowledgeBaseParams = JsonBody<paths[KnowledgeBasesPath]['post']>
+/** @beta */
+export type EditKnowledgeBaseParams = JsonBody<paths[KnowledgeBasePath]['patch']>
+
+/**
+ * Parameters for importing content. Discriminated on `type`:
+ * inline text, a website crawl, or a Sanity dataset bind.
+ * @beta
+ */
+export type CreateImportParams = JsonBody<paths[ImportsPath]['post']>
+
+/**
+ * Accepted async work. Poll the job with `jobs.get` until it reaches a
+ * terminal state.
+ * @beta
+ */
+export type JobAccepted = JsonResponse<
+  paths[`${KnowledgeBasePath}/build`]['post']['responses']['202']
+>
+
+/** @beta */
+export type Job = JsonResponse<paths[JobPath]['get']['responses']['200']>
+
+/** @beta */
+export type IssuesResponse = JsonResponse<paths[IssuesPath]['get']['responses']['200']>
+/** @beta */
+export type Issue = IssuesResponse['data'][number]
+/** @beta */
+export type IssueDetail = JsonResponse<paths[IssuePath]['get']['responses']['200']>
+/** @beta */
+export type ApplyIssuesParams = JsonBody<paths[IssuesApplyPath]['post']>
+/** @beta */
+export type ApplyIssuesResponse = JsonResponse<paths[IssuesApplyPath]['post']['responses']['202']>
+/** @beta */
+export type ResolveIssueParams = JsonBody<paths[IssueResolvePath]['post']>
+/** @beta */
+export type ResolveIssueResponse = JsonResponse<paths[IssueResolvePath]['post']['responses']['200']>
+/** @beta */
+export type DismissIssueResponse = JsonResponse<paths[IssueDismissPath]['post']['responses']['200']>
+/** @beta */
+export type ReopenIssueResponse = JsonResponse<paths[IssueReopenPath]['post']['responses']['200']>
+
+/** @beta */
+export type CreateInstructionParams = JsonBody<paths[InstructionsPath]['post']>
+/** @beta */
+export type InstructionsResponse = JsonResponse<paths[InstructionsPath]['get']['responses']['200']>
+/** @beta */
+export type Instruction = InstructionsResponse['data'][number]
+/** @beta */
+export type EditInstructionParams = JsonBody<paths[InstructionPath]['patch']>
+
+/** @beta */
+export type EntriesResponse = JsonResponse<paths[EntriesPath]['get']['responses']['200']>
+/** @beta */
+export type Entry = EntriesResponse['data'][number]
+
+/** @beta */
+export type KnowledgeBasesResponse = JsonResponse<
+  paths[KnowledgeBasesPath]['get']['responses']['200']
+>
+
+/** @beta */
+export type ImportsResponse = JsonResponse<paths[ImportsPath]['get']['responses']['200']>
+/** @beta */
+export type Import = ImportsResponse['data'][number]
+/** @beta */
+export type ImportDetail = JsonResponse<paths[ImportPath]['get']['responses']['200']>
+/** @beta */
+export type ImportDownloadResponse = JsonResponse<
+  paths[`${ImportPath}/download`]['get']['responses']['200']
+>
+
+/**
+ * The staged half of a file upload: PUT the bytes to `uploadUrl`, then
+ * confirm with the complete endpoint. `imports.create({type: 'file'})` does
+ * all of this in one call.
+ * @beta
+ */
+export type StagedUpload = JsonResponse<paths[UploadsPath]['post']['responses']['201']>
+/** @beta */
+export type StageUploadParams = JsonBody<paths[UploadsPath]['post']>
+
+/** @beta */
+export type CrawlPreviewParams = JsonBody<paths[CrawlPreviewPath]['post']>
+/** @beta */
+export type CrawlPreviewResponse = JsonResponse<paths[CrawlPreviewPath]['post']['responses']['200']>
+
+/** @beta */
+export type Outline = JsonResponse<paths[OutlinePath]['get']['responses']['200']>
+/** @beta */
+export type EntryDetail = JsonResponse<paths[EntryPath]['get']['responses']['200']>
+
+/** @beta */
+export type SourcesResponse = JsonResponse<paths[SourcesPath]['get']['responses']['200']>
+/** @beta */
+export type Source = SourcesResponse['data'][number]
+/** @beta */
+export type SourceDetail = JsonResponse<paths[SourcePath]['get']['responses']['200']>
+/** @beta */
+export type SourceContentResponse = JsonResponse<
+  paths[SourceContentPath]['get']['responses']['200']
+>
+
+/** @beta */
+export type Changes = JsonResponse<paths[ChangesPath]['get']['responses']['200']>
+/** @beta */
+export type ActivityResponse = JsonResponse<paths[ActivityPath]['get']['responses']['200']>
+/** @beta */
+export type ActivityEvent = ActivityResponse['data'][number]
+
+/** @beta */
+export type RevisionsResponse = JsonResponse<paths[RevisionsPath]['get']['responses']['200']>
+/** @beta */
+export type Revision = RevisionsResponse['data'][number]
+/** @beta */
+export type RevisionReport = JsonResponse<paths[RevisionReportPath]['get']['responses']['200']>
+/** @beta */
+export type RevisionOutline = JsonResponse<paths[RevisionOutlinePath]['get']['responses']['200']>
+
+/** @beta */
+export type EditCrawlOptionsParams = JsonBody<paths[CrawlOptionsPath]['patch']>
+/** @beta */
+export type CrawlOptions = JsonResponse<paths[CrawlOptionsPath]['patch']['responses']['200']>
+/** @beta */
+export type EntryStatus = 'virtual' | 'outlined' | 'filled' | 'stale' | 'generation_failed'
+
+/**
+ * The raw `sanity.context.entry` document shape, as stored in the bound
+ * dataset. For typing GROQ reads made with a regular dataset client.
+ * @beta
+ */
+export type EntryDoc = components['schemas']['EntryDoc']
+/** @beta */
+export type IssueDoc = components['schemas']['IssueDoc']
+/** @beta */
+export type InstructionDoc = components['schemas']['InstructionDoc']

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -172,6 +172,8 @@ export type Source = SourcesResponse['data'][number]
 /** @beta */
 export type SourceDetail = JsonResponse<paths[SourcePath]['get']['responses']['200']>
 /** @beta */
+export type DeleteSourceResponse = JsonResponse<paths[SourcePath]['delete']['responses']['202']>
+/** @beta */
 export type SourceContentResponse = JsonResponse<
   paths[SourceContentPath]['get']['responses']['200']
 >

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -172,8 +172,6 @@ export type Source = SourcesResponse['data'][number]
 /** @beta */
 export type SourceDetail = JsonResponse<paths[SourcePath]['get']['responses']['200']>
 /** @beta */
-export type DeleteSourceResponse = JsonResponse<paths[SourcePath]['delete']['responses']['202']>
-/** @beta */
 export type SourceContentResponse = JsonResponse<
   paths[SourceContentPath]['get']['responses']['200']
 >

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -1128,7 +1128,7 @@ export function _prepareRequest(client: Client, options: RequestObservableOption
  *
  * @internal
  */
-function _observe<R>(
+export function _observe<R>(
   userSignal: AbortSignal | undefined,
   run: (signal: AbortSignal) => Promise<R>,
 ): Observable<R> {

--- a/src/defineCreateClient.ts
+++ b/src/defineCreateClient.ts
@@ -26,6 +26,7 @@ export {
   isQueryParseError,
   ServerError,
 } from './http/errors'
+export * as Context from './context/types'
 export * from './SanityClient'
 export * from './types'
 

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -17,10 +17,8 @@ describe('client.context format-dependent return types', () => {
     expectTypeOf(await kb.entries.get({path: 'a/b', format: 'markdown'})).toEqualTypeOf<string>()
   })
 
-  test('sources.delete resolves to the accepted job', async () => {
-    expectTypeOf(
-      await kb.sources.delete({sourceId: 'source1'}),
-    ).toEqualTypeOf<Context.DeleteSourceResponse>()
+  test('sources.delete resolves to void', async () => {
+    expectTypeOf(await kb.sources.delete({sourceId: 'source1'})).toEqualTypeOf<void>()
   })
 
   test('the file import variant is only valid with file fields', async () => {

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -34,16 +34,12 @@ describe('client.context format-dependent return types', () => {
         organizationId: 'org',
         name: 'n',
         description: 'd',
-        sanityProjectId: 'p',
-        sanityDatasetId: 'ds',
       }),
     ).toEqualTypeOf<Context.KnowledgeBase>()
     // @ts-expect-error -- should fail: organizationId is required
     void client.context.knowledgeBases.create({
       name: 'n',
       description: 'd',
-      sanityProjectId: 'p',
-      sanityDatasetId: 'ds',
     })
   })
 })

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -1,0 +1,45 @@
+import {type Context, createClient} from '@sanity/client'
+import {describe, expectTypeOf, test} from 'vitest'
+
+describe('client.context format-dependent return types', () => {
+  const client = createClient({})
+  const kb = client.context.knowledgeBase('kb123')
+
+  test('outline resolves to the typed shape by default and to a string for text formats', async () => {
+    expectTypeOf(await kb.outline()).toEqualTypeOf<Context.Outline>()
+    expectTypeOf(await kb.outline({format: 'json'})).toEqualTypeOf<Context.Outline>()
+    expectTypeOf(await kb.outline({format: 'markdown'})).toEqualTypeOf<string>()
+    expectTypeOf(await kb.outline({format: 'plain'})).toEqualTypeOf<string>()
+  })
+
+  test('entries.get resolves to the typed shape by default and to a string for text formats', async () => {
+    expectTypeOf(await kb.entries.get({path: 'a/b'})).toEqualTypeOf<Context.EntryDetail>()
+    expectTypeOf(await kb.entries.get({path: 'a/b', format: 'markdown'})).toEqualTypeOf<string>()
+  })
+
+  test('the file import variant is only valid with file fields', async () => {
+    // @ts-expect-error -- should fail: file imports require a filename
+    void kb.imports.create({type: 'file', file: new Blob(['x'])})
+    // @ts-expect-error -- should fail: text imports carry content, not a file
+    void kb.imports.create({type: 'text', title: 't', file: new Blob(['x'])})
+  })
+
+  test('knowledgeBases.create requires the organizationId alongside the wire fields', async () => {
+    expectTypeOf(
+      await client.context.knowledgeBases.create({
+        organizationId: 'org',
+        name: 'n',
+        description: 'd',
+        sanityProjectId: 'p',
+        sanityDatasetId: 'ds',
+      }),
+    ).toEqualTypeOf<Context.KnowledgeBase>()
+    // @ts-expect-error -- should fail: organizationId is required
+    void client.context.knowledgeBases.create({
+      name: 'n',
+      description: 'd',
+      sanityProjectId: 'p',
+      sanityDatasetId: 'ds',
+    })
+  })
+})

--- a/test/contextClient.test-d.ts
+++ b/test/contextClient.test-d.ts
@@ -17,6 +17,12 @@ describe('client.context format-dependent return types', () => {
     expectTypeOf(await kb.entries.get({path: 'a/b', format: 'markdown'})).toEqualTypeOf<string>()
   })
 
+  test('sources.delete resolves to the accepted job', async () => {
+    expectTypeOf(
+      await kb.sources.delete({sourceId: 'source1'}),
+    ).toEqualTypeOf<Context.DeleteSourceResponse>()
+  })
+
   test('the file import variant is only valid with file fields', async () => {
     // @ts-expect-error -- should fail: file imports require a filename
     void kb.imports.create({type: 'file', file: new Blob(['x'])})

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -216,4 +216,16 @@ describe('ContextClient', () => {
       endLine: '10',
     })
   })
+
+  test('sources.delete returns the accepted job', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+
+    const result = await context.knowledgeBase(TEST_KB_ID).sources.delete({sourceId: 'source1'})
+
+    expect(httpRequest.mock.calls[1][0]).toMatchObject({
+      method: 'DELETE',
+      url: expect.stringContaining('/sources/source1'),
+    })
+    expect(result).toEqual({jobId: 'job1'})
+  })
 })

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -217,8 +217,8 @@ describe('ContextClient', () => {
     })
   })
 
-  test('sources.delete returns the accepted job', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+  test('sources.delete issues a DELETE and resolves to nothing', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce(undefined)
 
     const result = await context.knowledgeBase(TEST_KB_ID).sources.delete({sourceId: 'source1'})
 
@@ -226,6 +226,6 @@ describe('ContextClient', () => {
       method: 'DELETE',
       url: expect.stringContaining('/sources/source1'),
     })
-    expect(result).toEqual({jobId: 'job1'})
+    expect(result).toBeUndefined()
   })
 })

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -1,0 +1,229 @@
+import {createClient} from '@sanity/client'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {ContextClient} from '../src/context/ContextClient'
+import type {SanityClient} from '../src/SanityClient'
+
+const TEST_ORG_ID = 'orgAbc123'
+const TEST_KB_ID = 'kb3do82whm'
+const TEST_KB = {
+  id: 'c0ffee00-0000-4000-8000-000000000000',
+  publicId: TEST_KB_ID,
+  slug: 'support-docs',
+  organizationId: TEST_ORG_ID,
+  name: 'Support docs',
+  sanityProjectId: 'proj123',
+  sanityDatasetId: 'production',
+}
+
+const httpRequest = vi.fn()
+
+describe('ContextClient', () => {
+  let client: SanityClient
+  let context: ContextClient
+
+  beforeEach(() => {
+    client = createClient({
+      projectId: 'proj123',
+      dataset: 'production',
+      apiVersion: '2026-05-26',
+      useCdn: false,
+    })
+    httpRequest.mockReset()
+    context = new ContextClient(client, httpRequest)
+  })
+
+  test('knowledgeBases.create posts to the org-scoped collection', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB)
+
+    const created = await context.knowledgeBases.create({
+      organizationId: TEST_ORG_ID,
+      name: 'Support docs',
+      description: 'Docs and guides',
+      sanityProjectId: 'proj123',
+      sanityDatasetId: 'production',
+    })
+
+    expect(httpRequest).toHaveBeenCalledTimes(1)
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.method).toBe('POST')
+    // organizationId addresses the request, it is not part of the body
+    expect(req.body.organizationId).toBeUndefined()
+    expect(req.body.name).toBe('Support docs')
+    expect(created.publicId).toBe(TEST_KB_ID)
+  })
+
+  test('knowledgeBases.list forwards pagination as query params', async () => {
+    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
+
+    await context.knowledgeBases.list({
+      organizationId: TEST_ORG_ID,
+      limit: 5,
+      cursor: 'abc',
+    })
+
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.query).toMatchObject({limit: '5', cursor: 'abc'})
+  })
+
+  test('handle resolves the org/slug address once and reuses it', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB) // by-id resolution
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.issues.list()
+    await kb.entries.list()
+
+    expect(httpRequest).toHaveBeenCalledTimes(3)
+    expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
+    expect(httpRequest.mock.calls[1][0].url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
+    )
+    expect(httpRequest.mock.calls[2][0].url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/entries`,
+    )
+  })
+
+  test('address resolution never carries a caller abort signal', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+
+    const controller = new AbortController()
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.build({signal: controller.signal})
+
+    // The by-id resolution is shared by every method on the handle; a
+    // caller's signal on it would abort concurrent callers too.
+    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined()
+    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal)
+  })
+
+  test('a failed resolution does not poison the handle', async () => {
+    httpRequest
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(TEST_KB)
+      .mockResolvedValueOnce({jobId: 'job1'})
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await expect(kb.build()).rejects.toThrow('network down')
+    await expect(kb.build()).resolves.toEqual({jobId: 'job1'})
+  })
+
+  test('issues.resolve posts the resolution with the issueId in the path', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+      issue: {status: 'accepted'},
+      entry: null,
+      jobId: null,
+    })
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    const result = await kb.issues.resolve({
+      issueId: 'issue.abc',
+      resolution: 'keep_existing',
+    })
+
+    const req = httpRequest.mock.calls[1][0]
+    expect(req.url).toContain('/issues/issue.abc/resolve')
+    expect(req.body).toEqual({resolution: 'keep_existing'})
+    expect(result.issue.status).toBe('accepted')
+  })
+
+  test('imports.create with type file stages, PUTs to the signed URL, and confirms', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB) // address resolution
+      .mockResolvedValueOnce({
+        importId: 'imp1',
+        uploadUrl: 'https://storage.example/signed',
+      })
+      .mockResolvedValueOnce({jobId: 'job9'}) // complete
+    // The PUT rides the client's fetch resolution (so proxy config applies),
+    // injected the same way the transport tests inject theirs.
+    const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
+
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
+    const result = await kb.imports.create({
+      type: 'file',
+      file: new Blob(['hello']),
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
+
+    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads')
+    expect(httpRequest.mock.calls[1][0].body).toEqual({
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
+    expect(uploadFetch).toHaveBeenCalledWith(
+      'https://storage.example/signed',
+      expect.objectContaining({method: 'PUT'}),
+    )
+    expect(httpRequest.mock.calls[2][0].url).toContain('/imports/uploads/imp1/complete')
+    expect(result).toEqual({jobId: 'job9'})
+  })
+
+  test('a failed signed-URL PUT surfaces as an error and never confirms', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+      importId: 'imp1',
+      uploadUrl: 'https://storage.example/signed',
+    })
+    const uploadFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
+
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
+    await expect(
+      kb.imports.create({
+        type: 'file',
+        file: new Blob(['x']),
+        filename: 'x.txt',
+      }),
+    ).rejects.toThrow('File upload failed: 403')
+    // stage + resolution only; the confirm call must not have fired
+    expect(httpRequest).toHaveBeenCalledTimes(2)
+  })
+
+  test('entry paths are encoded and read endpoints hit their routes', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB)
+      .mockResolvedValueOnce({id: 'e1'}) // entries.get
+      .mockResolvedValueOnce({entries: [], stats: {}}) // outline
+      .mockResolvedValueOnce({
+        content: '',
+        slice: null,
+        sourceId: 's1',
+        totalLines: 1,
+      }) // sources.content
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.entries.get({path: 'billing/refunds', format: 'markdown'})
+    await kb.outline()
+    await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
+
+    expect(httpRequest.mock.calls[1][0].url).toContain('/entries/billing%2Frefunds')
+    expect(httpRequest.mock.calls[1][0].query).toMatchObject({
+      format: 'markdown',
+    })
+    expect(httpRequest.mock.calls[2][0].url).toContain('/outline')
+    expect(httpRequest.mock.calls[3][0].query).toMatchObject({
+      startLine: '4',
+      endLine: '10',
+    })
+  })
+
+  test('contentClient returns a native client bound to the dataset', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB)
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    const content = await kb.contentClient()
+
+    expect(content.config().projectId).toBe('proj123')
+    expect(content.config().dataset).toBe('production')
+  })
+})

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -12,8 +12,6 @@ const TEST_KB = {
   slug: 'support-docs',
   organizationId: TEST_ORG_ID,
   name: 'Support docs',
-  sanityProjectId: 'proj123',
-  sanityDatasetId: 'production',
 }
 
 const httpRequest = vi.fn()
@@ -40,8 +38,6 @@ describe('ContextClient', () => {
       organizationId: TEST_ORG_ID,
       name: 'Support docs',
       description: 'Docs and guides',
-      sanityProjectId: 'proj123',
-      sanityDatasetId: 'production',
     })
 
     expect(httpRequest).toHaveBeenCalledTimes(1)

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -88,6 +88,22 @@ describe('ContextClient', () => {
     )
   })
 
+  test('get() seeds the address cache for follow-up scoped calls', async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB) // get() by-id fetch
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
+
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.get()
+    await kb.issues.list()
+
+    // No second by-id resolve: get() already carried the org and slug.
+    expect(httpRequest).toHaveBeenCalledTimes(2)
+    expect(httpRequest.mock.calls[1][0].url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
+    )
+  })
+
   test('address resolution never carries a caller abort signal', async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
 

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -1,235 +1,219 @@
-import { createClient } from "@sanity/client";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import {createClient} from '@sanity/client'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
-import { ContextClient } from "../src/context/ContextClient";
-import type { SanityClient } from "../src/SanityClient";
+import {ContextClient} from '../src/context/ContextClient'
+import type {SanityClient} from '../src/SanityClient'
 
-const TEST_ORG_ID = "orgAbc123";
-const TEST_KB_ID = "kb3do82whm";
+const TEST_ORG_ID = 'orgAbc123'
+const TEST_KB_ID = 'kb3do82whm'
 const TEST_KB = {
-  id: "c0ffee00-0000-4000-8000-000000000000",
+  id: 'c0ffee00-0000-4000-8000-000000000000',
   publicId: TEST_KB_ID,
-  slug: "support-docs",
+  slug: 'support-docs',
   organizationId: TEST_ORG_ID,
-  name: "Support docs",
-  sanityProjectId: "proj123",
-  sanityDatasetId: "production",
-};
+  name: 'Support docs',
+  sanityProjectId: 'proj123',
+  sanityDatasetId: 'production',
+}
 
-const httpRequest = vi.fn();
+const httpRequest = vi.fn()
 
-describe("ContextClient", () => {
-  let client: SanityClient;
-  let context: ContextClient;
+describe('ContextClient', () => {
+  let client: SanityClient
+  let context: ContextClient
 
   beforeEach(() => {
     client = createClient({
-      projectId: "proj123",
-      dataset: "production",
-      apiVersion: "2026-05-26",
+      projectId: 'proj123',
+      dataset: 'production',
+      apiVersion: '2026-05-26',
       useCdn: false,
-    });
-    httpRequest.mockReset();
-    context = new ContextClient(client, httpRequest);
-  });
+    })
+    httpRequest.mockReset()
+    context = new ContextClient(client, httpRequest)
+  })
 
-  test("knowledgeBases.create posts to the org-scoped collection", async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB);
+  test('knowledgeBases.create posts to the org-scoped collection', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB)
 
     const created = await context.knowledgeBases.create({
       organizationId: TEST_ORG_ID,
-      name: "Support docs",
-      description: "Docs and guides",
-      sanityProjectId: "proj123",
-      sanityDatasetId: "production",
-    });
+      name: 'Support docs',
+      description: 'Docs and guides',
+      sanityProjectId: 'proj123',
+      sanityDatasetId: 'production',
+    })
 
-    expect(httpRequest).toHaveBeenCalledTimes(1);
-    const req = httpRequest.mock.calls[0][0];
-    expect(req.url).toContain(
-      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
-    );
-    expect(req.method).toBe("POST");
+    expect(httpRequest).toHaveBeenCalledTimes(1)
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.method).toBe('POST')
     // organizationId addresses the request, it is not part of the body
-    expect(req.body.organizationId).toBeUndefined();
-    expect(req.body.name).toBe("Support docs");
-    expect(created.publicId).toBe(TEST_KB_ID);
-  });
+    expect(req.body.organizationId).toBeUndefined()
+    expect(req.body.name).toBe('Support docs')
+    expect(created.publicId).toBe(TEST_KB_ID)
+  })
 
-  test("knowledgeBases.list forwards pagination as query params", async () => {
-    httpRequest.mockResolvedValueOnce({ data: [], nextCursor: null });
+  test('knowledgeBases.list forwards pagination as query params', async () => {
+    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
 
     await context.knowledgeBases.list({
       organizationId: TEST_ORG_ID,
       limit: 5,
-      cursor: "abc",
-    });
+      cursor: 'abc',
+    })
 
-    const req = httpRequest.mock.calls[0][0];
-    expect(req.url).toContain(
-      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
-    );
-    expect(req.query).toMatchObject({ limit: "5", cursor: "abc" });
-  });
+    const req = httpRequest.mock.calls[0][0]
+    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
+    expect(req.query).toMatchObject({limit: '5', cursor: 'abc'})
+  })
 
-  test("handle resolves the org/slug address once and reuses it", async () => {
+  test('handle resolves the org/slug address once and reuses it', async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // by-id resolution
-      .mockResolvedValueOnce({ data: [], nextCursor: null }) // issues.list
-      .mockResolvedValueOnce({ data: [], nextCursor: null }); // entries.list
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
+      .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await kb.issues.list();
-    await kb.entries.list();
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.issues.list()
+    await kb.entries.list()
 
-    expect(httpRequest).toHaveBeenCalledTimes(3);
-    expect(httpRequest.mock.calls[0][0].url).toContain(
-      `/context/knowledge-bases/${TEST_KB_ID}`,
-    );
+    expect(httpRequest).toHaveBeenCalledTimes(3)
+    expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
     expect(httpRequest.mock.calls[1][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
-    );
+    )
     expect(httpRequest.mock.calls[2][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/entries`,
-    );
-  });
+    )
+  })
 
-  test("address resolution never carries a caller abort signal", async () => {
-    httpRequest
-      .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({ jobId: "job1" });
+  test('address resolution never carries a caller abort signal', async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
 
-    const controller = new AbortController();
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await kb.build({ signal: controller.signal });
+    const controller = new AbortController()
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.build({signal: controller.signal})
 
     // The by-id resolution is shared by every method on the handle; a
     // caller's signal on it would abort concurrent callers too.
-    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined();
-    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal);
-  });
+    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined()
+    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal)
+  })
 
-  test("a failed resolution does not poison the handle", async () => {
+  test('a failed resolution does not poison the handle', async () => {
     httpRequest
-      .mockRejectedValueOnce(new Error("network down"))
+      .mockRejectedValueOnce(new Error('network down'))
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({ jobId: "job1" });
+      .mockResolvedValueOnce({jobId: 'job1'})
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await expect(kb.build()).rejects.toThrow("network down");
-    await expect(kb.build()).resolves.toEqual({ jobId: "job1" });
-  });
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await expect(kb.build()).rejects.toThrow('network down')
+    await expect(kb.build()).resolves.toEqual({jobId: 'job1'})
+  })
 
-  test("issues.resolve posts the resolution with the issueId in the path", async () => {
+  test('issues.resolve posts the resolution with the issueId in the path', async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      issue: { status: "accepted" },
+      issue: {status: 'accepted'},
       entry: null,
       jobId: null,
-    });
+    })
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
+    const kb = context.knowledgeBase(TEST_KB_ID)
     const result = await kb.issues.resolve({
-      issueId: "issue.abc",
-      resolution: "keep_existing",
-    });
+      issueId: 'issue.abc',
+      resolution: 'keep_existing',
+    })
 
-    const req = httpRequest.mock.calls[1][0];
-    expect(req.url).toContain("/issues/issue.abc/resolve");
-    expect(req.body).toEqual({ resolution: "keep_existing" });
-    expect(result.issue.status).toBe("accepted");
-  });
+    const req = httpRequest.mock.calls[1][0]
+    expect(req.url).toContain('/issues/issue.abc/resolve')
+    expect(req.body).toEqual({resolution: 'keep_existing'})
+    expect(result.issue.status).toBe('accepted')
+  })
 
-  test("imports.create with type file stages, PUTs to the signed URL, and confirms", async () => {
+  test('imports.create with type file stages, PUTs to the signed URL, and confirms', async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // address resolution
       .mockResolvedValueOnce({
-        importId: "imp1",
-        uploadUrl: "https://storage.example/signed",
+        importId: 'imp1',
+        uploadUrl: 'https://storage.example/signed',
       })
-      .mockResolvedValueOnce({ jobId: "job9" }); // complete
+      .mockResolvedValueOnce({jobId: 'job9'}) // complete
     // The PUT rides the client's fetch resolution (so proxy config applies),
     // injected the same way the transport tests inject theirs.
-    const uploadFetch = vi
-      .fn()
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
-    const uploadContext = new ContextClient(uploadClient, httpRequest);
+    const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
     const result = await kb.imports.create({
-      type: "file",
-      file: new Blob(["hello"]),
-      filename: "hello.txt",
-      contentType: "text/plain",
-    });
+      type: 'file',
+      file: new Blob(['hello']),
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
 
-    expect(httpRequest.mock.calls[1][0].url).toContain("/imports/uploads");
+    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads')
     expect(httpRequest.mock.calls[1][0].body).toEqual({
-      filename: "hello.txt",
-      contentType: "text/plain",
-    });
+      filename: 'hello.txt',
+      contentType: 'text/plain',
+    })
     expect(uploadFetch).toHaveBeenCalledWith(
-      "https://storage.example/signed",
-      expect.objectContaining({ method: "PUT" }),
-    );
-    expect(httpRequest.mock.calls[2][0].url).toContain(
-      "/imports/uploads/imp1/complete",
-    );
-    expect(result).toEqual({ jobId: "job9" });
-  });
+      'https://storage.example/signed',
+      expect.objectContaining({method: 'PUT'}),
+    )
+    expect(httpRequest.mock.calls[2][0].url).toContain('/imports/uploads/imp1/complete')
+    expect(result).toEqual({jobId: 'job9'})
+  })
 
-  test("a failed signed-URL PUT surfaces as an error and never confirms", async () => {
+  test('a failed signed-URL PUT surfaces as an error and never confirms', async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      importId: "imp1",
-      uploadUrl: "https://storage.example/signed",
-    });
+      importId: 'imp1',
+      uploadUrl: 'https://storage.example/signed',
+    })
     const uploadFetch = vi
       .fn()
-      .mockResolvedValueOnce(
-        new Response(null, { status: 403, statusText: "Forbidden" }),
-      );
-    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
-    const uploadContext = new ContextClient(uploadClient, httpRequest);
+      .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
+    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
+    const uploadContext = new ContextClient(uploadClient, httpRequest)
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
     await expect(
       kb.imports.create({
-        type: "file",
-        file: new Blob(["x"]),
-        filename: "x.txt",
+        type: 'file',
+        file: new Blob(['x']),
+        filename: 'x.txt',
       }),
-    ).rejects.toThrow("File upload failed: 403");
+    ).rejects.toThrow('File upload failed: 403')
     // stage + resolution only; the confirm call must not have fired
-    expect(httpRequest).toHaveBeenCalledTimes(2);
-  });
+    expect(httpRequest).toHaveBeenCalledTimes(2)
+  })
 
-  test("entry paths are encoded and read endpoints hit their routes", async () => {
+  test('entry paths are encoded and read endpoints hit their routes', async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({ id: "e1" }) // entries.get
-      .mockResolvedValueOnce({ entries: [], stats: {} }) // outline
+      .mockResolvedValueOnce({id: 'e1'}) // entries.get
+      .mockResolvedValueOnce({entries: [], stats: {}}) // outline
       .mockResolvedValueOnce({
-        content: "",
+        content: '',
         slice: null,
-        sourceId: "s1",
+        sourceId: 's1',
         totalLines: 1,
-      }); // sources.content
+      }) // sources.content
 
-    const kb = context.knowledgeBase(TEST_KB_ID);
-    await kb.entries.get({ path: "billing/refunds", format: "markdown" });
-    await kb.outline();
-    await kb.sources.content({ sourceId: "s1", startLine: 4, endLine: 10 });
+    const kb = context.knowledgeBase(TEST_KB_ID)
+    await kb.entries.get({path: 'billing/refunds', format: 'markdown'})
+    await kb.outline()
+    await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
 
-    expect(httpRequest.mock.calls[1][0].url).toContain(
-      "/entries/billing%2Frefunds",
-    );
+    expect(httpRequest.mock.calls[1][0].url).toContain('/entries/billing%2Frefunds')
     expect(httpRequest.mock.calls[1][0].query).toMatchObject({
-      format: "markdown",
-    });
-    expect(httpRequest.mock.calls[2][0].url).toContain("/outline");
+      format: 'markdown',
+    })
+    expect(httpRequest.mock.calls[2][0].url).toContain('/outline')
     expect(httpRequest.mock.calls[3][0].query).toMatchObject({
-      startLine: "4",
-      endLine: "10",
-    });
-  });
-});
+      startLine: '4',
+      endLine: '10',
+    })
+  })
+})

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -1,229 +1,235 @@
-import {createClient} from '@sanity/client'
-import {beforeEach, describe, expect, test, vi} from 'vitest'
+import { createClient } from "@sanity/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import {ContextClient} from '../src/context/ContextClient'
-import type {SanityClient} from '../src/SanityClient'
+import { ContextClient } from "../src/context/ContextClient";
+import type { SanityClient } from "../src/SanityClient";
 
-const TEST_ORG_ID = 'orgAbc123'
-const TEST_KB_ID = 'kb3do82whm'
+const TEST_ORG_ID = "orgAbc123";
+const TEST_KB_ID = "kb3do82whm";
 const TEST_KB = {
-  id: 'c0ffee00-0000-4000-8000-000000000000',
+  id: "c0ffee00-0000-4000-8000-000000000000",
   publicId: TEST_KB_ID,
-  slug: 'support-docs',
+  slug: "support-docs",
   organizationId: TEST_ORG_ID,
-  name: 'Support docs',
-  sanityProjectId: 'proj123',
-  sanityDatasetId: 'production',
-}
+  name: "Support docs",
+  sanityProjectId: "proj123",
+  sanityDatasetId: "production",
+};
 
-const httpRequest = vi.fn()
+const httpRequest = vi.fn();
 
-describe('ContextClient', () => {
-  let client: SanityClient
-  let context: ContextClient
+describe("ContextClient", () => {
+  let client: SanityClient;
+  let context: ContextClient;
 
   beforeEach(() => {
     client = createClient({
-      projectId: 'proj123',
-      dataset: 'production',
-      apiVersion: '2026-05-26',
+      projectId: "proj123",
+      dataset: "production",
+      apiVersion: "2026-05-26",
       useCdn: false,
-    })
-    httpRequest.mockReset()
-    context = new ContextClient(client, httpRequest)
-  })
+    });
+    httpRequest.mockReset();
+    context = new ContextClient(client, httpRequest);
+  });
 
-  test('knowledgeBases.create posts to the org-scoped collection', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB)
+  test("knowledgeBases.create posts to the org-scoped collection", async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB);
 
     const created = await context.knowledgeBases.create({
       organizationId: TEST_ORG_ID,
-      name: 'Support docs',
-      description: 'Docs and guides',
-      sanityProjectId: 'proj123',
-      sanityDatasetId: 'production',
-    })
+      name: "Support docs",
+      description: "Docs and guides",
+      sanityProjectId: "proj123",
+      sanityDatasetId: "production",
+    });
 
-    expect(httpRequest).toHaveBeenCalledTimes(1)
-    const req = httpRequest.mock.calls[0][0]
-    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
-    expect(req.method).toBe('POST')
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+    const req = httpRequest.mock.calls[0][0];
+    expect(req.url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
+    );
+    expect(req.method).toBe("POST");
     // organizationId addresses the request, it is not part of the body
-    expect(req.body.organizationId).toBeUndefined()
-    expect(req.body.name).toBe('Support docs')
-    expect(created.publicId).toBe(TEST_KB_ID)
-  })
+    expect(req.body.organizationId).toBeUndefined();
+    expect(req.body.name).toBe("Support docs");
+    expect(created.publicId).toBe(TEST_KB_ID);
+  });
 
-  test('knowledgeBases.list forwards pagination as query params', async () => {
-    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
+  test("knowledgeBases.list forwards pagination as query params", async () => {
+    httpRequest.mockResolvedValueOnce({ data: [], nextCursor: null });
 
     await context.knowledgeBases.list({
       organizationId: TEST_ORG_ID,
       limit: 5,
-      cursor: 'abc',
-    })
+      cursor: "abc",
+    });
 
-    const req = httpRequest.mock.calls[0][0]
-    expect(req.url).toContain(`/context/organizations/${TEST_ORG_ID}/knowledge-bases`)
-    expect(req.query).toMatchObject({limit: '5', cursor: 'abc'})
-  })
+    const req = httpRequest.mock.calls[0][0];
+    expect(req.url).toContain(
+      `/context/organizations/${TEST_ORG_ID}/knowledge-bases`,
+    );
+    expect(req.query).toMatchObject({ limit: "5", cursor: "abc" });
+  });
 
-  test('handle resolves the org/slug address once and reuses it', async () => {
+  test("handle resolves the org/slug address once and reuses it", async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // by-id resolution
-      .mockResolvedValueOnce({data: [], nextCursor: null}) // issues.list
-      .mockResolvedValueOnce({data: [], nextCursor: null}) // entries.list
+      .mockResolvedValueOnce({ data: [], nextCursor: null }) // issues.list
+      .mockResolvedValueOnce({ data: [], nextCursor: null }); // entries.list
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.issues.list()
-    await kb.entries.list()
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await kb.issues.list();
+    await kb.entries.list();
 
-    expect(httpRequest).toHaveBeenCalledTimes(3)
-    expect(httpRequest.mock.calls[0][0].url).toContain(`/context/knowledge-bases/${TEST_KB_ID}`)
+    expect(httpRequest).toHaveBeenCalledTimes(3);
+    expect(httpRequest.mock.calls[0][0].url).toContain(
+      `/context/knowledge-bases/${TEST_KB_ID}`,
+    );
     expect(httpRequest.mock.calls[1][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/issues`,
-    )
+    );
     expect(httpRequest.mock.calls[2][0].url).toContain(
       `/context/organizations/${TEST_ORG_ID}/knowledge-bases/${TEST_KB.slug}/entries`,
-    )
-  })
+    );
+  });
 
-  test('address resolution never carries a caller abort signal', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({jobId: 'job1'})
+  test("address resolution never carries a caller abort signal", async () => {
+    httpRequest
+      .mockResolvedValueOnce(TEST_KB)
+      .mockResolvedValueOnce({ jobId: "job1" });
 
-    const controller = new AbortController()
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.build({signal: controller.signal})
+    const controller = new AbortController();
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await kb.build({ signal: controller.signal });
 
     // The by-id resolution is shared by every method on the handle; a
     // caller's signal on it would abort concurrent callers too.
-    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined()
-    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal)
-  })
+    expect(httpRequest.mock.calls[0][0].signal).toBeUndefined();
+    expect(httpRequest.mock.calls[1][0].signal).toBe(controller.signal);
+  });
 
-  test('a failed resolution does not poison the handle', async () => {
+  test("a failed resolution does not poison the handle", async () => {
     httpRequest
-      .mockRejectedValueOnce(new Error('network down'))
+      .mockRejectedValueOnce(new Error("network down"))
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({jobId: 'job1'})
+      .mockResolvedValueOnce({ jobId: "job1" });
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await expect(kb.build()).rejects.toThrow('network down')
-    await expect(kb.build()).resolves.toEqual({jobId: 'job1'})
-  })
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await expect(kb.build()).rejects.toThrow("network down");
+    await expect(kb.build()).resolves.toEqual({ jobId: "job1" });
+  });
 
-  test('issues.resolve posts the resolution with the issueId in the path', async () => {
+  test("issues.resolve posts the resolution with the issueId in the path", async () => {
     httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      issue: {status: 'accepted'},
+      issue: { status: "accepted" },
       entry: null,
       jobId: null,
-    })
+    });
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
+    const kb = context.knowledgeBase(TEST_KB_ID);
     const result = await kb.issues.resolve({
-      issueId: 'issue.abc',
-      resolution: 'keep_existing',
-    })
+      issueId: "issue.abc",
+      resolution: "keep_existing",
+    });
 
-    const req = httpRequest.mock.calls[1][0]
-    expect(req.url).toContain('/issues/issue.abc/resolve')
-    expect(req.body).toEqual({resolution: 'keep_existing'})
-    expect(result.issue.status).toBe('accepted')
-  })
+    const req = httpRequest.mock.calls[1][0];
+    expect(req.url).toContain("/issues/issue.abc/resolve");
+    expect(req.body).toEqual({ resolution: "keep_existing" });
+    expect(result.issue.status).toBe("accepted");
+  });
 
-  test('imports.create with type file stages, PUTs to the signed URL, and confirms', async () => {
+  test("imports.create with type file stages, PUTs to the signed URL, and confirms", async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB) // address resolution
       .mockResolvedValueOnce({
-        importId: 'imp1',
-        uploadUrl: 'https://storage.example/signed',
+        importId: "imp1",
+        uploadUrl: "https://storage.example/signed",
       })
-      .mockResolvedValueOnce({jobId: 'job9'}) // complete
+      .mockResolvedValueOnce({ jobId: "job9" }); // complete
     // The PUT rides the client's fetch resolution (so proxy config applies),
     // injected the same way the transport tests inject theirs.
-    const uploadFetch = vi.fn().mockResolvedValueOnce(new Response(null, {status: 200}))
-    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
-    const uploadContext = new ContextClient(uploadClient, httpRequest)
-
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
-    const result = await kb.imports.create({
-      type: 'file',
-      file: new Blob(['hello']),
-      filename: 'hello.txt',
-      contentType: 'text/plain',
-    })
-
-    expect(httpRequest.mock.calls[1][0].url).toContain('/imports/uploads')
-    expect(httpRequest.mock.calls[1][0].body).toEqual({
-      filename: 'hello.txt',
-      contentType: 'text/plain',
-    })
-    expect(uploadFetch).toHaveBeenCalledWith(
-      'https://storage.example/signed',
-      expect.objectContaining({method: 'PUT'}),
-    )
-    expect(httpRequest.mock.calls[2][0].url).toContain('/imports/uploads/imp1/complete')
-    expect(result).toEqual({jobId: 'job9'})
-  })
-
-  test('a failed signed-URL PUT surfaces as an error and never confirms', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
-      importId: 'imp1',
-      uploadUrl: 'https://storage.example/signed',
-    })
     const uploadFetch = vi
       .fn()
-      .mockResolvedValueOnce(new Response(null, {status: 403, statusText: 'Forbidden'}))
-    const uploadClient = client.withConfig({resolveFetch: () => uploadFetch})
-    const uploadContext = new ContextClient(uploadClient, httpRequest)
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
+    const uploadContext = new ContextClient(uploadClient, httpRequest);
 
-    const kb = uploadContext.knowledgeBase(TEST_KB_ID)
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
+    const result = await kb.imports.create({
+      type: "file",
+      file: new Blob(["hello"]),
+      filename: "hello.txt",
+      contentType: "text/plain",
+    });
+
+    expect(httpRequest.mock.calls[1][0].url).toContain("/imports/uploads");
+    expect(httpRequest.mock.calls[1][0].body).toEqual({
+      filename: "hello.txt",
+      contentType: "text/plain",
+    });
+    expect(uploadFetch).toHaveBeenCalledWith(
+      "https://storage.example/signed",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(httpRequest.mock.calls[2][0].url).toContain(
+      "/imports/uploads/imp1/complete",
+    );
+    expect(result).toEqual({ jobId: "job9" });
+  });
+
+  test("a failed signed-URL PUT surfaces as an error and never confirms", async () => {
+    httpRequest.mockResolvedValueOnce(TEST_KB).mockResolvedValueOnce({
+      importId: "imp1",
+      uploadUrl: "https://storage.example/signed",
+    });
+    const uploadFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, { status: 403, statusText: "Forbidden" }),
+      );
+    const uploadClient = client.withConfig({ resolveFetch: () => uploadFetch });
+    const uploadContext = new ContextClient(uploadClient, httpRequest);
+
+    const kb = uploadContext.knowledgeBase(TEST_KB_ID);
     await expect(
       kb.imports.create({
-        type: 'file',
-        file: new Blob(['x']),
-        filename: 'x.txt',
+        type: "file",
+        file: new Blob(["x"]),
+        filename: "x.txt",
       }),
-    ).rejects.toThrow('File upload failed: 403')
+    ).rejects.toThrow("File upload failed: 403");
     // stage + resolution only; the confirm call must not have fired
-    expect(httpRequest).toHaveBeenCalledTimes(2)
-  })
+    expect(httpRequest).toHaveBeenCalledTimes(2);
+  });
 
-  test('entry paths are encoded and read endpoints hit their routes', async () => {
+  test("entry paths are encoded and read endpoints hit their routes", async () => {
     httpRequest
       .mockResolvedValueOnce(TEST_KB)
-      .mockResolvedValueOnce({id: 'e1'}) // entries.get
-      .mockResolvedValueOnce({entries: [], stats: {}}) // outline
+      .mockResolvedValueOnce({ id: "e1" }) // entries.get
+      .mockResolvedValueOnce({ entries: [], stats: {} }) // outline
       .mockResolvedValueOnce({
-        content: '',
+        content: "",
         slice: null,
-        sourceId: 's1',
+        sourceId: "s1",
         totalLines: 1,
-      }) // sources.content
+      }); // sources.content
 
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    await kb.entries.get({path: 'billing/refunds', format: 'markdown'})
-    await kb.outline()
-    await kb.sources.content({sourceId: 's1', startLine: 4, endLine: 10})
+    const kb = context.knowledgeBase(TEST_KB_ID);
+    await kb.entries.get({ path: "billing/refunds", format: "markdown" });
+    await kb.outline();
+    await kb.sources.content({ sourceId: "s1", startLine: 4, endLine: 10 });
 
-    expect(httpRequest.mock.calls[1][0].url).toContain('/entries/billing%2Frefunds')
+    expect(httpRequest.mock.calls[1][0].url).toContain(
+      "/entries/billing%2Frefunds",
+    );
     expect(httpRequest.mock.calls[1][0].query).toMatchObject({
-      format: 'markdown',
-    })
-    expect(httpRequest.mock.calls[2][0].url).toContain('/outline')
+      format: "markdown",
+    });
+    expect(httpRequest.mock.calls[2][0].url).toContain("/outline");
     expect(httpRequest.mock.calls[3][0].query).toMatchObject({
-      startLine: '4',
-      endLine: '10',
-    })
-  })
-
-  test('contentClient returns a native client bound to the dataset', async () => {
-    httpRequest.mockResolvedValueOnce(TEST_KB)
-
-    const kb = context.knowledgeBase(TEST_KB_ID)
-    const content = await kb.contentClient()
-
-    expect(content.config().projectId).toBe('proj123')
-    expect(content.config().dataset).toBe('production')
-  })
-})
+      startLine: "4",
+      endLine: "10",
+    });
+  });
+});


### PR DESCRIPTION
Regenerates the vendored Context spec from sanity-io/atlas#380: knowledge bases no longer bind a Sanity project/dataset, so `knowledgeBases.create` takes only `name` + `description` and the read shape stops exposing `sanityProjectId`/`sanityDatasetId`.

Stacked on `feat/sage-817-context-namespace`; merge after the atlas PR.

Part of SAGE-892

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes required knowledge-base create fields and response properties—a breaking contract for callers still passing or reading project/dataset IDs, shipped as a minor changeset.
> 
> **Overview**
> Syncs the vendored Context OpenAPI and generated types with **atlas#380**, so knowledge bases are no longer tied to a Sanity project/dataset at creation or on list/get responses.
> 
> **Knowledge bases:** `knowledgeBases.create` now accepts only `name`, optional `slug`, and `description`—`sanityProjectId` and `sanityDatasetId` are removed from the request body and from the `KnowledgeBase` shape. `ContextClient` docs now describe org-level **knowledge-base create** grants instead of project provisioning access. Tests and type tests match the slimmer params.
> 
> **Same spec refresh (client types only):** Removes the org `dataset-permissions` route from the OpenAPI snapshot. Conversation resources gain a canonical `id`, org-wide list/insights routes, fetch-by-`conversationId`, and extra list filters/sort on MCP conversation lists. Entry types allow nullable `revisionId` and nullable items in `sourceIds`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ba14cdf6fdf8dacca6a8e04234241499c84649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->