### PR TITLE
fix: drop debug for browser uploads

### DIFF
--- a/.changeset/pr-1305.md
+++ b/.changeset/pr-1305.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': patch
+---
+
+fix: drop debug for browser uploads

--- a/src/http/browserUpload.ts
+++ b/src/http/browserUpload.ts
@@ -1,13 +1,8 @@
-import {createDebug} from 'obug'
 import {Observable} from 'rxjs'
 
 import type {UploadEvent} from '../types'
 import {ClientError, httpResponseFromFetch, ServerError} from './errors'
 import {parseJsonText} from './request'
-
-const log = createDebug('sanity:client')
-
-let nextRequestId = 1
 
 /**
  * Options for a browser-side asset upload that needs progress events.
@@ -36,10 +31,7 @@ export interface BrowserUploadOptions {
 export function uploadWithProgress<T>(options: BrowserUploadOptions): Observable<UploadEvent<T>> {
   return new Observable<UploadEvent<T>>((subscriber) => {
     const xhr = new XMLHttpRequest()
-    const requestId = nextRequestId++
     const {url, method, headers, body, withCredentials, timeout, signal} = options
-
-    log('[%d] %s %s (XHR upload with progress)', requestId, method, url)
 
     xhr.open(method, url)
     xhr.withCredentials = withCredentials
@@ -63,8 +55,6 @@ export function uploadWithProgress<T>(options: BrowserUploadOptions): Observable
     }
 
     xhr.onload = () => {
-      log('[%d] %s %s — %d', requestId, method, url, xhr.status)
-
       if (xhr.status >= 400) {
         // Same typed errors as the fetch transport, so consumers can keep
         // detecting `ClientError`/`ServerError` and reading `statusCode`,
@@ -100,12 +90,10 @@ export function uploadWithProgress<T>(options: BrowserUploadOptions): Observable
     }
 
     xhr.onerror = () => {
-      log('[%d] %s %s — network error', requestId, method, url)
       subscriber.error(new Error('XHR upload network error'))
     }
 
     xhr.ontimeout = () => {
-      log('[%d] %s %s — timed out after %dms', requestId, method, url, timeout)
       // Same error shape as the fetch transport's timeout rejection.
       subscriber.error(
         new DOMException(


### PR DESCRIPTION
Confusingly, this is related to [react native support](https://github.com/sanity-io/client/issues/1301). I've [opened a PR](https://github.com/sxzz/obug/pull/6) upstream to obug to address the issue, but as I was looking into this, I realized that the client doesn't use the debug middleware for non-node builds anyway - _except for_ the XHR upload path. It doesn't make sense to me that we'd have only debug support for that particular code path - either we apply it across the client, or not at all.

This takes the easier path of just removing it from the XHR uploader, which also means reducing the bundle size and dependencies used in the browser build, and should hopefully also fix the react native support as a side effect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only removal with no changes to upload logic, error handling, or public API.
> 
> **Overview**
> Removes **`obug`** debug logging from the browser XHR upload path in `browserUpload.ts`, aligning it with the rest of the non-Node client (debug middleware stays Node-only via `nodeMiddleware.ts`).
> 
> The change drops the `createDebug` import, request-id counter, and log lines on upload start, completion, network errors, and timeouts. Upload behavior, progress events, and error shapes are unchanged.
> 
> This should shrink the browser bundle by not pulling **`obug`** into the progress-upload code path and may unblock React Native builds that hit issues with that dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efcab8662c400b36682e0c692f9a736becf31a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->