### PR TITLE
feat: support source list filters on client.context

### DIFF
--- a/.changeset/pr-context-sources-filters.md
+++ b/.changeset/pr-context-sources-filters.md
@@ -1,0 +1,5 @@
+---
+'@sanity/client': patch
+---
+
+feat: support status, importId, and ids filters on `context.sources.list`

--- a/src/context/ContextClient.ts
+++ b/src/context/ContextClient.ts
@@ -19,7 +19,12 @@ import {_fetch as _fetchStore, _listen as _listenStore} from './store'
 import type {
   ApplyIssuesParams,
   ApplyIssuesResponse,
+  ClassifyConversationParams,
+  ContextListenOptions,
+  ContextRequestOptions,
+  Conversation,
   ConversationDoc,
+  CreateFileImportParams,
   CreateImportParams,
   CreateInstructionParams,
   CreateInstructionResponse,
@@ -42,21 +47,15 @@ import type {
   McpDoc,
   RebuildEntryResponse,
   ReopenIssueResponse,
+  RequestOptions,
   ResolveIssueParams,
   ResolveIssueResponse,
+  SaveConversationParams,
+  Source,
   SourceContentResponse,
   SourceDetail,
   SourcesResponse,
   StagedUpload,
-} from './types'
-import type {
-  ClassifyConversationParams,
-  ContextListenOptions,
-  ContextRequestOptions,
-  Conversation,
-  CreateFileImportParams,
-  RequestOptions,
-  SaveConversationParams,
 } from './types'
 
 type ListOptions = RequestOptions & {cursor?: string; limit?: number}
@@ -609,7 +608,23 @@ export class ContextClient {
 
   /** Sources: the distilled units builds cite. */
   sources = {
-    list: (params?: ListOptions) => this.#list<SourcesResponse>('/sources', params),
+    /**
+     * List sources, optionally filtered by `status` or the `importId` they
+     * came from. `ids` is a lookup mode: it resolves those exact sources
+     * (e.g. from an entry's citations) and overrides `status` and `cursor`.
+     */
+    list: (
+      params?: {
+        status?: Source['status']
+        importId?: string
+        ids?: string[]
+      } & ListOptions,
+    ) =>
+      this.#list<SourcesResponse>('/sources', params, {
+        status: params?.status,
+        importId: params?.importId,
+        ids: params?.ids?.join(','),
+      }),
     get: (params: {sourceId: string}, options?: RequestOptions) =>
       this.#request<SourceDetail>(`/sources/${encodeURIComponent(params.sourceId)}`, options),
     /**

--- a/test/contextClient.test.ts
+++ b/test/contextClient.test.ts
@@ -260,6 +260,22 @@ describe('ContextClient', () => {
     })
   })
 
+  test('sources.list forwards the status, importId, and ids filters', async () => {
+    httpRequest.mockResolvedValueOnce({data: [], nextCursor: null})
+
+    await kbContext.sources.list({
+      status: 'ready',
+      importId: 'imp1',
+      ids: ['s1', 's2'],
+    })
+
+    expect(httpRequest.mock.calls[0][0].query).toMatchObject({
+      status: 'ready',
+      importId: 'imp1',
+      ids: 's1,s2',
+    })
+  })
+
   test('sources.delete issues a DELETE and resolves to nothing', async () => {
     httpRequest.mockResolvedValueOnce(undefined)
 


### PR DESCRIPTION
Follow-up to review comments on #1276.

- `sources.list` now forwards `status`, `importId`, and `ids` from the vendored spec. Sources have no GROQ twin, so these filters were unreachable before. `ids` resolves exact sources (e.g. from entry citations) and overrides `status` and `cursor`, matching the API.
- Merged the duplicate `import type` blocks in `ContextClient.ts` (@rexxars' nit).

Closes SAGE-1000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 99c8cf2ae251d05dadae8f4078f261e644c77193. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->