### PR TITLE
ci: avoid cancelling source runs for generated changesets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, v7]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.actor == 'squiggler-app[bot]' && 'changeset' || 'source' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -13,7 +13,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ github.actor == 'squiggler-app[bot]' && 'changeset' || 'source' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Automatic changeset commits currently share a concurrency group with the source commit. This cancels the source commit CI and Live API runs, leaving a red X even though nothing failed. PR #1305 is one example.

Put runs triggered by `squiggler-app[bot]` in a separate `changeset` concurrency lane. Contributor pushes still cancel older source runs, and later bot updates still cancel older changeset runs. The source and changeset runs can execute in parallel.

### Testing

- `pnpm run format:check -- .github/workflows/ci.yml .github/workflows/live.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only concurrency tuning with no application or secret-handling changes.
> 
> **Overview**
> **CI** and **Live API** workflow concurrency groups now append a lane suffix: `source` for normal pushes and `changeset` when `github.actor` is `squiggler-app[bot]`.
> 
> That stops automatic changeset commits from cancelling in-flight runs on the contributor’s commit (which showed as a red X without a real failure). Within each lane, `cancel-in-progress` behavior is unchanged, and source vs changeset runs can run in parallel on the same PR branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9490e85b062cf250d29d8f5490fe19c682e796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->