### PR TITLE
test: add non-node export condition tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,11 +269,8 @@ jobs:
       - uses: antongolub/action-setup-bun@f0b9f339a7ce9ba1174a58484e4dc9bbd6f7b133 # v1
       - run: pnpm run test:bun
 
-  # Repurposed from the former `node-runtimes` placeholder (test-suite-cleanup Task 13):
-  # that job's `runtimes/node` tree is gone (Task 12), and the CJS interop guard it ran
-  # now lives at `test/packaging/cjs-interop.test.ts`, alongside the `dist/` graph guard
-  # (`test/packaging/distGraph.test.ts`). Both need a real build, not `dist/` aliased to
-  # source, so this job builds fresh rather than restoring the `build` job's artifact.
+  # Runs against a real build (`dist`), ensures CJS interop (`require('esm')`), dist graph and
+  # the non-node export conditions being free of node-only modules (prefixed and unprefixed)
   test-packaging:
     name: 'Test: Packaging'
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "oxlint-tsgolint": "^7.0.2001",
     "pkg-pr-new": "^0.0.88",
     "playwright": "^1.62.1",
+    "rolldown": "^1.2.4",
     "typescript": "7.0.2",
     "undici": "^7.29.0",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       playwright:
         specifier: ^1.62.1
         version: 1.62.1
+      rolldown:
+        specifier: ^1.2.4
+        version: 1.2.4
       typescript:
         specifier: 7.0.2
         version: 7.0.2

--- a/test/packaging/cjs-interop.test.ts
+++ b/test/packaging/cjs-interop.test.ts
@@ -2,10 +2,9 @@ import {createRequire} from 'node:module'
 
 import {expect, test} from 'vitest'
 
-// Ported from the old `runtimes/node/test.cjs`, which smoke-tested that
-// CommonJS `require('@sanity/client')` continues to work on Node 22.12+ via
-// the runtime's native `require(esm)` support. The package itself is
-// ESM-only, but `require(esm)` makes that a soft constraint.
+// Smoke-tests that CommonJS `require('@sanity/client')` continues to work on
+// Node 22.12+ via the runtime's native `require(esm)` support. The package
+// itself is ESM-only, but `require(esm)` makes that a soft constraint.
 //
 // `createRequire` returns Node's real `require`, so it resolves through the
 // package's actual `exports` map (built `dist/`, not source) exactly like a

--- a/test/packaging/nonNodeBundle.test.ts
+++ b/test/packaging/nonNodeBundle.test.ts
@@ -1,0 +1,126 @@
+import {isBuiltin} from 'node:module'
+import {relative, resolve} from 'node:path'
+
+import {rolldown} from 'rolldown'
+import {describe, expect, test} from 'vitest'
+
+interface NonNodeTarget {
+  aliasFields: string[][]
+  conditionNames: string[]
+  name: string
+  mainFields: string[]
+}
+
+// `__dirname` rather than `import.meta.url`: Vite/vitest can rewrite
+// `import.meta.url` in ways `node:path` can't resolve.
+const packageDir = resolve(__dirname, '../..')
+const fetchEntry = resolve(packageDir, 'dist/index.js')
+
+/**
+ * Conditions, legacy package entry fields and browser-field aliases asserted
+ * by representative non-Node consumers. Some server and worker runtimes also
+ * assert `node` for compatibility, so those cases verify that a more specific
+ * condition keeps both this package and its dependencies on their neutral
+ * branches. Rolldown replaces its default condition list when configured, so
+ * each target includes the implicit `import` and `default` conditions.
+ */
+const nonNodeTargets: NonNodeTarget[] = [
+  {
+    aliasFields: [],
+    conditionNames: ['import', 'default'],
+    name: 'default',
+    mainFields: ['module', 'main'],
+  },
+  {
+    aliasFields: [['browser']],
+    conditionNames: ['import', 'browser', 'default'],
+    name: 'browser',
+    mainFields: ['browser', 'module', 'main'],
+  },
+  {
+    aliasFields: [['react-native'], ['browser']],
+    conditionNames: ['import', 'require', 'react-native', 'default'],
+    name: 'react-native',
+    mainFields: ['react-native', 'browser', 'main'],
+  },
+  {
+    aliasFields: [],
+    conditionNames: ['import', 'react-server', 'node', 'module', 'default'],
+    name: 'react-server',
+    mainFields: ['module', 'main'],
+  },
+  {
+    aliasFields: [['browser']],
+    conditionNames: ['import', 'workerd', 'worker', 'browser', 'node', 'module', 'default'],
+    name: 'workerd',
+    mainFields: ['browser', 'module', 'main'],
+  },
+  {
+    aliasFields: [['browser']],
+    conditionNames: ['import', 'worker', 'browser', 'node', 'module', 'default'],
+    name: 'worker',
+    mainFields: ['browser', 'module', 'main'],
+  },
+]
+
+async function bundleFor(target: NonNodeTarget): Promise<{
+  builtins: string[]
+  inputs: string[]
+}> {
+  const builtins = new Set<string>()
+  const inputs = new Set<string>()
+  const virtualEntry = resolve(packageDir, `.non-node-${target.name}.js`)
+  const bundle = await rolldown({
+    cwd: packageDir,
+    input: virtualEntry,
+    logLevel: 'silent',
+    platform: 'neutral',
+    plugins: [
+      {
+        name: 'record-non-node-bundle',
+        resolveId(source, importer) {
+          if (source === virtualEntry) return virtualEntry
+          if (!isBuiltin(source)) return null
+
+          builtins.add(`${source} from ${relative(packageDir, importer ?? virtualEntry)}`)
+          return {external: true, id: source}
+        },
+        load(id) {
+          if (id !== virtualEntry) return null
+          return `import * as client from '@sanity/client'; export {client}`
+        },
+        moduleParsed(moduleInfo) {
+          inputs.add(moduleInfo.id)
+        },
+      },
+    ],
+    resolve: {
+      aliasFields: target.aliasFields,
+      conditionNames: target.conditionNames,
+      mainFields: target.mainFields,
+    },
+    treeshake: false,
+  })
+
+  try {
+    await bundle.generate({format: 'esm'})
+  } finally {
+    await bundle.close()
+  }
+
+  return {
+    builtins: [...builtins].sort(),
+    inputs: [...inputs],
+  }
+}
+
+describe('non-Node consumer bundles', () => {
+  for (const target of nonNodeTargets) {
+    test(`${target.name} resolves the fetch build with no Node built-ins`, async () => {
+      const {builtins, inputs} = await bundleFor(target)
+
+      expect(inputs).toContain(fetchEntry)
+      expect(builtins).toEqual([])
+    })
+  }
+})


### PR DESCRIPTION
https://github.com/sanity-io/client/issues/1301 revealed some gaps in our testing. I'd rather not add a full react native test suite (not even sure how realistic it is), but doing a pass to ensure we don't have node internals in the non-node exports seems worthwhile. The added suite exercises different conditions, as well - react native/metro has a bit of an [odd resolution strategy](https://metrobundler.dev/docs/configuration/), so we try to match that using rolldown. If we encounter even more react-native issues, we can consider adding an actual metro build/test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and devDependency changes; no published runtime or export map behavior is modified.
> 
> **Overview**
> Adds **Rolldown-based packaging tests** that simulate how browser, React Native, React Server, worker, and workerd consumers resolve `@sanity/client`, and assert each path lands on the neutral **`dist/index.js`** fetch build with **no Node built-in imports** (addressing gaps like [#1301](https://github.com/sanity-io/client/issues/1301)).
> 
> **`rolldown`** is added as a devDependency to drive those neutral-platform bundles with per-target `conditionNames`, `mainFields`, and `browser` / `react-native` alias fields (including Metro-style resolution for react-native).
> 
> CI docs for the **`test-packaging`** job are tightened to call out this non-Node export guard alongside existing CJS interop and dist-graph checks; **`cjs-interop.test.ts`** comments are trimmed to drop obsolete `runtimes/node` references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997c75b562a0d140e3bc03e3da1bc459b769eaa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->