### PR TITLE
fix: fix description field not being nullable in some types

### DIFF
--- a/.changeset/red-lilies-stay.md
+++ b/.changeset/red-lilies-stay.md
@@ -1,0 +1,5 @@
+---
+"@sanity/client": patch
+---
+
+fix: fix description field not being nullable in some types

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,7 +635,7 @@ export type DatasetAclMode = 'public' | 'private' | 'custom'
 /** @public */
 export type DatasetCreateOptions = {
   aclMode?: DatasetAclMode
-  description?: string
+  description?: string | null
   embeddings?: {
     enabled: boolean
     projection?: string
@@ -645,7 +645,7 @@ export type DatasetCreateOptions = {
 /** @public */
 export type DatasetEditOptions = {
   aclMode?: DatasetAclMode
-  description?: string
+  description?: string | null
 }
 
 /** @public */
@@ -662,12 +662,16 @@ export type EmbeddingsSettingsBody = {
 }
 
 /** @public */
-export type DatasetResponse = {datasetName: string; aclMode: DatasetAclMode; description: string}
+export type DatasetResponse = {
+  datasetName: string
+  aclMode: DatasetAclMode
+  description: string | null
+}
 /** @public */
 export type DatasetsResponse = {
   name: string
   aclMode: DatasetAclMode
-  description: string
+  description?: string
   createdAt: string
   createdByUserId: string
   addonFor: string | null


### PR DESCRIPTION
Fixes dataset's `description` field not being correctly typed. There are times where it can be `null` in inputs/outputs that wasn't represented in the types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes that widen or correct optionality; may surface new compile errors where code assumed `description` was always a string.
> 
> **Overview**
> Aligns **dataset** TypeScript types with API behavior where `description` can be absent or explicitly cleared.
> 
> **Create/edit inputs** (`DatasetCreateOptions`, `DatasetEditOptions`) now allow `description?: string | null`, so callers can pass `null` when clearing a description without fighting the type checker.
> 
> **Single-dataset responses** (`DatasetResponse`) type `description` as `string | null` instead of always `string`, matching payloads that return `null`.
> 
> **List responses** (`DatasetsResponse` entries) mark `description` as optional (`description?: string`) rather than required, reflecting list items that may omit the field.
> 
> Shipped as a **patch** for `@sanity/client` via changeset; no runtime client changes—only published `.d.ts` accuracy for `datasets.create`, `datasets.edit`, and `datasets.list`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd7510eb363ba864a0ff97d2e0076c64c7b302f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->