### PR TITLE
feat: configure transparent OAuth token refresh via auth.oauth

### DIFF
--- a/.changeset/pr-1323.md
+++ b/.changeset/pr-1323.md
@@ -1,0 +1,6 @@
+<!-- auto-generated -->
+---
+'@sanity/client': minor
+---
+
+feat: accept an OAuth token setup as `token` for transparent refresh

--- a/src/assets/AssetsClient.ts
+++ b/src/assets/AssetsClient.ts
@@ -1,7 +1,8 @@
 import {defer, lastValueFrom, type Observable} from 'rxjs'
-import {filter, map, mergeAll} from 'rxjs/operators'
+import {catchError, filter, map, mergeAll} from 'rxjs/operators'
 
 import {_prepareRequest, _uploadObservable} from '../data/dataMethods'
+import {applyOAuthToken, getOAuthTokenSetup, refreshOnAuthError} from '../http/oauthRefreshHandler'
 import type {FetchRequest} from '../http/requestOptions'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import type {
@@ -262,10 +263,15 @@ function _upload<
       // credentials and timeout are identical across both upload transports.
       // The XHR API needs the query baked into the URL, though.
       const req = _prepareRequest(client, {...baseRequest})
-      return uploadWithProgress<T>({
+      // XHR uploads bypass the request handler, so the OAuth token is resolved
+      // (and a 401 refreshed, without auto-retry) here — same rules as the
+      // fetch-path `_uploadObservable`.
+      const oauth = getOAuthTokenSetup(config.token)
+      const reqHeaders = oauth ? await applyOAuthToken(oauth, req.headers) : req.headers
+      const upload = uploadWithProgress<T>({
         url: appendQuery(req.url, req.query),
         method: req.method ?? 'POST',
-        headers: req.headers,
+        headers: reqHeaders,
         body,
         withCredentials: req.credentials === 'include',
         // XHR only has a single total-deadline timer, so a structured
@@ -273,6 +279,9 @@ function _upload<
         timeout: typeof req.timeout === 'object' ? req.timeout.total : req.timeout,
         signal: req.signal,
       })
+      return oauth
+        ? upload.pipe(catchError((err) => refreshOnAuthError(oauth, reqHeaders, err)))
+        : upload
     }).pipe(mergeAll())
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,7 +126,10 @@ export const initConfig = (
     newConfig.withCredentials = false
   }
 
-  if (isBrowser && isLocalhost && hasToken && newConfig.ignoreBrowserTokenWarning !== true) {
+  // The browser warning targets a secret baked into client-side code. An
+  // OAuthTokenSetup obtains tokens per user at runtime, so it is exempt.
+  const hasStringToken = typeof newConfig.token === 'string' && newConfig.token !== ''
+  if (isBrowser && isLocalhost && hasStringToken && newConfig.ignoreBrowserTokenWarning !== true) {
     warnings.printBrowserTokenWarning()
   } else if (typeof newConfig.useCdn === 'undefined') {
     warnings.printCdnWarning()

--- a/src/data/dataMethods.ts
+++ b/src/data/dataMethods.ts
@@ -1,9 +1,15 @@
 import {getDraftId, getVersionFromId, getVersionId, isDraftId} from '@sanity/client/csm'
 import {anySignal} from 'get-it/any-signal'
-import {type MonoTypeOperatorFunction, Observable} from 'rxjs'
-import {filter, map} from 'rxjs/operators'
+import {defer, type MonoTypeOperatorFunction, Observable} from 'rxjs'
+import {catchError, filter, map, mergeMap} from 'rxjs/operators'
 
 import {validateApiPerspective} from '../config'
+import {
+  applyOAuthToken,
+  getOAuthTokenSetup,
+  refreshOnAuthError,
+  resolveRequestHandler,
+} from '../http/oauthRefreshHandler'
 import {type FetchRequest, requestOptions} from '../http/requestOptions'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import {stegaClean, type StegaCleaned} from '../stega/stegaClean'
@@ -1157,7 +1163,7 @@ export function _observe<R>(
  */
 export function _request<R>(client: Client, httpRequest: HttpRequest, options: Any): Promise<R> {
   const reqOptions = _prepareRequest(client, options)
-  return httpRequest(reqOptions, client.config().requestHandler).then((body) => body as R)
+  return httpRequest(reqOptions, resolveRequestHandler(client.config())).then((body) => body as R)
 }
 
 /**
@@ -1191,9 +1197,25 @@ export function _uploadObservable<T>(
   options: RequestObservableOptions,
 ): Observable<UploadEvent<T>> {
   const reqOptions = _prepareRequest(client, options)
-  const requester = client.config().requester
-  const request = new Observable<Any>((subscriber) =>
-    requester(reqOptions).subscribe(subscriber),
+  const config = client.config()
+  const requester = config.requester
+  // This path bypasses the request handler, so the OAuth token is resolved
+  // here — per subscription, so a resubscribe picks up a refreshed token. A
+  // 401 refreshes but does not auto-retry (the body may be a consumed stream);
+  // the error surfaces and a caller-level retry gets the fresh token.
+  const oauth = getOAuthTokenSetup(config.token)
+  const upload = (req: FetchRequest) =>
+    new Observable<Any>((subscriber) => requester(req).subscribe(subscriber))
+  const request = (
+    oauth
+      ? defer(() => applyOAuthToken(oauth, reqOptions.headers)).pipe(
+          mergeMap((headers) =>
+            upload({...reqOptions, headers}).pipe(
+              catchError((err) => refreshOnAuthError(oauth, headers, err)),
+            ),
+          ),
+        )
+      : upload(reqOptions)
   ).pipe(
     filter((event: Any) => event?.type === 'progress' || event?.type === 'response'),
     map((event: Any): UploadEvent<T> =>

--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -2,6 +2,7 @@ import {EventSource} from 'eventsource'
 import {Observable, throwError} from 'rxjs'
 import {filter, map} from 'rxjs/operators'
 
+import {getOAuthRefresher, getOAuthTokenSetup} from '../http/oauthRefreshHandler'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import {
   type Any,
@@ -166,23 +167,25 @@ export function _connectListenEventSource<TEvent extends {type: string}>(
   const {token, withCredentials, headers: configHeaders} = config
 
   const headers: Record<string, string> = {}
-  if (token) {
+  if (typeof token === 'string') {
     headers.Authorization = `Bearer ${token}`
   }
   if (configHeaders) {
     Object.assign(headers, configHeaders)
   }
+  const tokenSetup = getOAuthTokenSetup(token)
 
   const initEventSource = () =>
     new EventSource(uri, {
       fetch: resolveEventSourceFetch(config, {
         headers: Object.keys(headers).length ? headers : undefined,
+        tokenSetup,
         withCredentials,
       }),
     })
 
   return connectEventSource(initEventSource, listenFor).pipe(
-    reconnectOnConnectionFailure(),
+    reconnectOnConnectionFailure(tokenSetup && getOAuthRefresher(tokenSetup)),
     filter((event) => listenFor.includes(event.type)),
     map((event) => ({
       type: event.type,

--- a/src/data/listen.ts
+++ b/src/data/listen.ts
@@ -1,6 +1,6 @@
 import {EventSource} from 'eventsource'
 import {Observable, throwError} from 'rxjs'
-import {filter, map} from 'rxjs/operators'
+import {filter, map, tap} from 'rxjs/operators'
 
 import {getOAuthRefresher, getOAuthTokenSetup} from '../http/oauthRefreshHandler'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
@@ -174,17 +174,24 @@ export function _connectListenEventSource<TEvent extends {type: string}>(
     Object.assign(headers, configHeaders)
   }
   const tokenSetup = getOAuthTokenSetup(token)
+  let lastEventId: string | undefined
 
   const initEventSource = () =>
     new EventSource(uri, {
       fetch: resolveEventSourceFetch(config, {
         headers: Object.keys(headers).length ? headers : undefined,
+        lastEventId,
         tokenSetup,
         withCredentials,
       }),
     })
 
   return connectEventSource(initEventSource, listenFor).pipe(
+    tap((event) => {
+      if ('id' in event && typeof event.id === 'string' && event.id) {
+        lastEventId = event.id
+      }
+    }),
     reconnectOnConnectionFailure(tokenSetup && getOAuthRefresher(tokenSetup)),
     filter((event) => listenFor.includes(event.type)),
     map((event) => ({

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -4,6 +4,7 @@ import {catchError, mergeMap, Observable, of, throwError} from 'rxjs'
 import {finalize, map} from 'rxjs/operators'
 
 import {CorsOriginError} from '../http/errors'
+import {getOAuthRefresher, getOAuthTokenSetup} from '../http/oauthRefreshHandler'
 import type {ObservableSanityClient, SanityClient} from '../SanityClient'
 import type {
   InitializedClientConfig,
@@ -13,6 +14,7 @@ import type {
   LiveEventReconnect,
   LiveEventRestart,
   LiveEventWelcome,
+  OAuthTokenSetup,
   SyncTag,
 } from '../types'
 import {isRecord} from '../util/isRecord'
@@ -90,12 +92,16 @@ export class LiveClient {
       url.searchParams.set('waitFor', waitFor)
     }
     const eventSourceHeaders: Record<string, string> = {}
-    if (includeDrafts && token) {
+    if (includeDrafts && typeof token === 'string') {
       eventSourceHeaders.Authorization = `Bearer ${token}`
     }
     if (configHeaders) {
       Object.assign(eventSourceHeaders, configHeaders)
     }
+    // An OAuth token setup can't be baked into the headers — it is resolved
+    // per request inside the EventSource fetch, so reconnects pick up
+    // refreshed tokens.
+    const tokenSetup = includeDrafts ? getOAuthTokenSetup(token) : undefined
     const eventSourceWithCredentials = Boolean(includeDrafts && withCredentials)
 
     let transportCache = eventsCache.get(config.resolveFetch)
@@ -108,6 +114,10 @@ export class LiveClient {
       typeof config.proxy === 'string' ? config.proxy : null,
       eventSourceHeaders,
       eventSourceWithCredentials,
+      // A string-token connection is distinguished by its Authorization header
+      // above; an OAuth setup contributes its identity instead, so two clients
+      // with different setups never share a stream.
+      tokenSetup ? tokenSetupCacheKey(tokenSetup) : null,
     ])
     const existing = transportCache.get(cacheKey)
 
@@ -119,6 +129,7 @@ export class LiveClient {
       new EventSource(url.href, {
         fetch: resolveEventSourceFetch(config, {
           headers: Object.keys(eventSourceHeaders).length ? eventSourceHeaders : undefined,
+          tokenSetup,
           withCredentials: eventSourceWithCredentials,
         }),
       })
@@ -140,7 +151,7 @@ export class LiveClient {
 
     const observable = events
       .pipe(
-        reconnectOnConnectionFailure(),
+        reconnectOnConnectionFailure(tokenSetup && getOAuthRefresher(tokenSetup)),
         mergeMap((event) => {
           if (event.type === 'reconnect') {
             // Check for CORS on reconnect events (which happen on 403s)
@@ -289,3 +300,18 @@ const eventsCache = new Map<
   InitializedClientConfig['resolveFetch'],
   Map<string, Observable<LiveEvent>>
 >()
+
+/**
+ * Stable identity for an OAuth token setup in the string cache key — the setup
+ * object itself can't be stringified (its functions serialise to nothing).
+ */
+let nextTokenSetupId = 0
+const tokenSetupIds = new WeakMap<OAuthTokenSetup, number>()
+function tokenSetupCacheKey(setup: OAuthTokenSetup): number {
+  let id = tokenSetupIds.get(setup)
+  if (id === undefined) {
+    id = nextTokenSetupId++
+    tokenSetupIds.set(setup, id)
+  }
+  return id
+}

--- a/src/data/live.ts
+++ b/src/data/live.ts
@@ -1,7 +1,7 @@
 import {EventSource} from 'eventsource'
 import type {FetchFunction} from 'get-it'
 import {catchError, mergeMap, Observable, of, throwError} from 'rxjs'
-import {finalize, map} from 'rxjs/operators'
+import {finalize, map, tap} from 'rxjs/operators'
 
 import {CorsOriginError} from '../http/errors'
 import {getOAuthRefresher, getOAuthTokenSetup} from '../http/oauthRefreshHandler'
@@ -125,10 +125,13 @@ export class LiveClient {
       return existing
     }
 
+    let lastEventId: string | undefined
+
     const initEventSource = () =>
       new EventSource(url.href, {
         fetch: resolveEventSourceFetch(config, {
           headers: Object.keys(eventSourceHeaders).length ? eventSourceHeaders : undefined,
+          lastEventId,
           tokenSetup,
           withCredentials: eventSourceWithCredentials,
         }),
@@ -151,6 +154,11 @@ export class LiveClient {
 
     const observable = events
       .pipe(
+        tap((event) => {
+          if ('id' in event && typeof event.id === 'string' && event.id) {
+            lastEventId = event.id
+          }
+        }),
         reconnectOnConnectionFailure(tokenSetup && getOAuthRefresher(tokenSetup)),
         mergeMap((event) => {
           if (event.type === 'reconnect') {

--- a/src/data/reconnectOnConnectionFailure.ts
+++ b/src/data/reconnectOnConnectionFailure.ts
@@ -1,6 +1,7 @@
 import {
   catchError,
   concat,
+  from,
   mergeMap,
   Observable,
   of,
@@ -14,12 +15,29 @@ import {ConnectionFailedError} from './eventsource'
 const RETRYABLE_STATUSES = new Set([408, 429])
 
 /**
+ * Minimum spacing between 401-triggered auth refreshes. A refresh → reconnect
+ * → 401 cycle completes within seconds, so a second 401 inside this window
+ * means the server is rejecting freshly refreshed tokens — surface it rather
+ * than rotate refresh tokens forever. A 401 after the window (a token that
+ * expired hours into a healthy connection) gets its own refresh.
+ */
+const AUTH_RETRY_WINDOW = 30_000
+
+/**
  * Note: connection failure is not the same as network disconnect which may happen more frequent.
  * The EventSource instance will automatically reconnect in case of a network disconnect, however,
  * in some rare cases a ConnectionFailed Error will be thrown and this operator explicitly retries these
+ *
+ * @param refreshAuth - When the connection authenticates via an OAuth token
+ * setup, the setup's single-flight refresher. A connection rejected with a 401
+ * then refreshes and reconnects once, mirroring the request handler's 401
+ * semantics.
  */
-export function reconnectOnConnectionFailure<T>(): OperatorFunction<T, T | {type: 'reconnect'}> {
+export function reconnectOnConnectionFailure<T>(
+  refreshAuth?: () => Promise<unknown>,
+): OperatorFunction<T, T | {type: 'reconnect'}> {
   return function (source: Observable<T>) {
+    let lastAuthRetryAt = -Infinity
     return source.pipe(
       catchError((err, caught) => {
         // Only reconnect on transient connection failures. A 4xx response is a
@@ -36,6 +54,25 @@ export function reconnectOnConnectionFailure<T>(): OperatorFunction<T, T | {type
             RETRYABLE_STATUSES.has(err.status))
         ) {
           return concat(of({type: 'reconnect' as const}), timer(1000).pipe(mergeMap(() => caught)))
+        }
+        if (
+          refreshAuth &&
+          err instanceof ConnectionFailedError &&
+          err.status === 401 &&
+          Date.now() - lastAuthRetryAt >= AUTH_RETRY_WINDOW
+        ) {
+          lastAuthRetryAt = Date.now()
+          return concat(
+            of({type: 'reconnect' as const}),
+            from(refreshAuth()).pipe(
+              // Surface the original connection error, not the refresh failure
+              // — `onAuthError` has already fired inside the refresher. Placed
+              // before `mergeMap` so it only catches the refresh promise, never
+              // errors from the resubscribed stream.
+              catchError(() => throwError(() => err)),
+              mergeMap(() => caught),
+            ),
+          )
         }
         return throwError(() => err)
       }),

--- a/src/data/resolveEventSourceFetch.ts
+++ b/src/data/resolveEventSourceFetch.ts
@@ -1,7 +1,7 @@
 import type {EventSourceFetchInit, FetchLikeResponse} from 'eventsource'
 import type {FetchFunction, FetchInit} from 'get-it'
 
-import type {InitializedClientConfig} from '../types'
+import type {InitializedClientConfig, OAuthTokenSetup} from '../types'
 
 /** @internal */
 export interface EventSourceFetchOptions {
@@ -11,6 +11,15 @@ export interface EventSourceFetchOptions {
    * etc. — things the native EventSource API has no equivalent for.
    */
   headers?: Record<string, string>
+  /**
+   * OAuth token setup to resolve an `Authorization` header from. Resolved via
+   * `getToken()` on every request — not once per connection — so the
+   * `eventsource` package's reconnects pick up a refreshed token. This fetch
+   * only reads; 401-driven `refresh()` lives upstream in
+   * `reconnectOnConnectionFailure`. Config `headers` take precedence,
+   * mirroring the string-token merge order.
+   */
+  tokenSetup?: OAuthTokenSetup
   /**
    * If the client was configured with `withCredentials: true`, the
    * resolved fetch forwards `credentials: 'include'` so the browser
@@ -50,19 +59,25 @@ export function resolveEventSourceFetch(
   options: EventSourceFetchOptions = {},
 ): EventSourceFetch {
   const extraHeaders = options.headers
+  const tokenSetup = options.tokenSetup
   const credentials: FetchInit['credentials'] = options.withCredentials ? 'include' : undefined
 
-  return function eventSourceFetch(url, init) {
+  return async function eventSourceFetch(url, init) {
     const baseFetch = pickBaseFetch(config)
 
     // Extra `EventSourceFetchInit` fields get-it's `FetchInit` doesn't
     // declare (`mode`, `cache`) survive the spread and reach whichever
     // fetch implementation is effective.
     const mergedInit: FetchInit = {...init}
-    if (extraHeaders) {
+    if (extraHeaders || tokenSetup) {
       const headers = new Headers(init?.headers)
-      for (const [key, value] of Object.entries(extraHeaders)) {
-        headers.set(key, value)
+      if (tokenSetup) {
+        headers.set('Authorization', `Bearer ${await tokenSetup.getToken()}`)
+      }
+      if (extraHeaders) {
+        for (const [key, value] of Object.entries(extraHeaders)) {
+          headers.set(key, value)
+        }
       }
       mergedInit.headers = headers
     }
@@ -71,7 +86,14 @@ export function resolveEventSourceFetch(
     }
     // get-it's `FetchResponse` is a structural superset of the package's
     // `FetchLikeResponse`, so it can be handed over as-is.
-    return baseFetch(typeof url === 'string' ? url : url.href, mergedInit)
+    const response = baseFetch(typeof url === 'string' ? url : url.href, mergedInit)
+    // Returning a promise from an async function attaches its rejection
+    // handler one microtask later (thenable adoption), and workerd's
+    // unhandled-rejection tracker flags a rejected promise in that gap.
+    // Attach a no-op handler synchronously; the rejection still propagates
+    // through the async return to the `eventsource` package's catch.
+    response.catch(() => {})
+    return response
   }
 }
 

--- a/src/data/resolveEventSourceFetch.ts
+++ b/src/data/resolveEventSourceFetch.ts
@@ -13,6 +13,14 @@ export interface EventSourceFetchOptions {
    */
   headers?: Record<string, string>
   /**
+   * Last event id from a prior EventSource instance. Used when the client has
+   * to construct a fresh EventSource itself (eg after an OAuth refresh on a
+   * rejected reconnect) so the new instance can resume from the previous
+   * position. The `eventsource` package's own reconnect header, when present,
+   * still wins.
+   */
+  lastEventId?: string
+  /**
    * OAuth token setup to resolve an `Authorization` header from. Resolved via
    * `resolveOAuthToken()` on every request — not once per connection — so the
    * `eventsource` package's reconnects pick up a refreshed token, and a token
@@ -60,6 +68,7 @@ export function resolveEventSourceFetch(
   options: EventSourceFetchOptions = {},
 ): EventSourceFetch {
   const extraHeaders = options.headers
+  const lastEventId = options.lastEventId
   const tokenSetup = options.tokenSetup
   const credentials: FetchInit['credentials'] = options.withCredentials ? 'include' : undefined
 
@@ -70,8 +79,11 @@ export function resolveEventSourceFetch(
     // declare (`mode`, `cache`) survive the spread and reach whichever
     // fetch implementation is effective.
     const mergedInit: FetchInit = {...init}
-    if (extraHeaders || tokenSetup) {
+    if (extraHeaders || tokenSetup || lastEventId) {
       const headers = new Headers(init?.headers)
+      if (lastEventId && !headers.has('last-event-id')) {
+        headers.set('Last-Event-ID', lastEventId)
+      }
       if (tokenSetup) {
         headers.set('Authorization', `Bearer ${await resolveOAuthToken(tokenSetup)}`)
       }

--- a/src/data/resolveEventSourceFetch.ts
+++ b/src/data/resolveEventSourceFetch.ts
@@ -1,6 +1,7 @@
 import type {EventSourceFetchInit, FetchLikeResponse} from 'eventsource'
 import type {FetchFunction, FetchInit} from 'get-it'
 
+import {resolveOAuthToken} from '../http/oauthRefreshHandler'
 import type {InitializedClientConfig, OAuthTokenSetup} from '../types'
 
 /** @internal */
@@ -13,11 +14,11 @@ export interface EventSourceFetchOptions {
   headers?: Record<string, string>
   /**
    * OAuth token setup to resolve an `Authorization` header from. Resolved via
-   * `getToken()` on every request — not once per connection — so the
-   * `eventsource` package's reconnects pick up a refreshed token. This fetch
-   * only reads; 401-driven `refresh()` lives upstream in
-   * `reconnectOnConnectionFailure`. Config `headers` take precedence,
-   * mirroring the string-token merge order.
+   * `resolveOAuthToken()` on every request — not once per connection — so the
+   * `eventsource` package's reconnects pick up a refreshed token, and a token
+   * about to expire is refreshed proactively. 401-driven `refresh()` still
+   * lives upstream in `reconnectOnConnectionFailure`. Config `headers` take
+   * precedence, mirroring the string-token merge order.
    */
   tokenSetup?: OAuthTokenSetup
   /**
@@ -72,7 +73,7 @@ export function resolveEventSourceFetch(
     if (extraHeaders || tokenSetup) {
       const headers = new Headers(init?.headers)
       if (tokenSetup) {
-        headers.set('Authorization', `Bearer ${await tokenSetup.getToken()}`)
+        headers.set('Authorization', `Bearer ${await resolveOAuthToken(tokenSetup)}`)
       }
       if (extraHeaders) {
         for (const [key, value] of Object.entries(extraHeaders)) {

--- a/src/http/oauthRefreshHandler.ts
+++ b/src/http/oauthRefreshHandler.ts
@@ -1,0 +1,180 @@
+import type {
+  InitializedClientConfig,
+  OAuthTokenSetup,
+  RequestHandler,
+  RequestHandlerOptions,
+} from '../types'
+import {ClientError} from './errors'
+
+/**
+ * The single spot deciding "is this token an OAuth setup" — shared by request
+ * handler resolution, SSE and asset uploads so the paths can never disagree on
+ * what counts as one.
+ *
+ * @internal
+ */
+export function getOAuthTokenSetup(
+  token: InitializedClientConfig['token'],
+): OAuthTokenSetup | undefined {
+  return token && typeof token === 'object' ? token : undefined
+}
+
+/**
+ * Resolve `getToken()` into an `Authorization` header for request paths that
+ * bypass the request handler (asset uploads). A pre-existing `Authorization`
+ * header (config `headers`) wins, matching the refresh handler's pass-through.
+ *
+ * @internal
+ */
+export async function applyOAuthToken(
+  setup: OAuthTokenSetup,
+  headers: Record<string, string>,
+): Promise<Record<string, string>> {
+  // `new Headers()` gives a case-insensitive lookup over the plain record.
+  if (new Headers(headers).has('authorization')) return headers
+  return {...headers, Authorization: `Bearer ${await setup.getToken()}`}
+}
+
+/**
+ * Per-setup memo of single-flight refreshers, keyed on the setup object itself
+ * so every path that can refresh (the request handler, SSE reconnects) and
+ * every client holding the same setup (clones, `withConfig()` children, the
+ * observable twin) share one in-flight refresh. That is a correctness
+ * requirement, not an optimisation: OAuth 2.1 refresh tokens are single-use,
+ * so two concurrent refreshes would present the same consumed token and trip
+ * reuse detection, which can revoke the whole token family.
+ */
+const refreshers = new WeakMap<OAuthTokenSetup, () => Promise<string>>()
+
+/**
+ * The setup's single-flight `refresh()`: concurrent callers share one attempt,
+ * and `onAuthError` fires once per attempt, not once per waiting caller. Only
+ * dedupes within this process — cross-tab serialisation is the provider's job.
+ *
+ * @internal
+ */
+export function getOAuthRefresher(setup: OAuthTokenSetup): () => Promise<string> {
+  let refresher = refreshers.get(setup)
+  if (!refresher) {
+    // `??=` is synchronous, so two refreshes can never start at once.
+    let inFlight: Promise<string> | null = null
+    refresher = () =>
+      (inFlight ??= setup
+        .refresh()
+        .catch((error) => {
+          setup.onAuthError?.(error)
+          throw error
+        })
+        .finally(() => {
+          inFlight = null
+        }))
+    refreshers.set(setup, refresher)
+  }
+  return refresher
+}
+
+/**
+ * 401 handling for paths that can't safely retry — uploads, where a
+ * `NodeJS.ReadableStream` body is consumed by the first attempt. Refreshes so
+ * `onAuthError` can fire on an unrecoverable refresh and a caller-level retry
+ * gets a fresh token, then rethrows the original error: the caller decides
+ * whether its body is replayable, not the client.
+ *
+ * Mirrors the request handler's re-read guard: no refresh when the token has
+ * already moved on since the request was built, or when the `Authorization`
+ * header wasn't ours to begin with (explicit-header pass-through).
+ *
+ * @internal
+ */
+export async function refreshOnAuthError(
+  setup: OAuthTokenSetup,
+  sentHeaders: Record<string, string>,
+  error: unknown,
+): Promise<never> {
+  if (error instanceof ClientError && error.statusCode === 401) {
+    try {
+      if (sentHeaders.Authorization === `Bearer ${await setup.getToken()}`) {
+        await getOAuthRefresher(setup)()
+      }
+    } catch {
+      // onAuthError already fired inside the refresher; surface the 401 below.
+    }
+  }
+  throw error
+}
+
+/**
+ * Resolve the effective request handler for a request. The OAuth refresh
+ * handler wraps any user-supplied `requestHandler` (rather than being stored
+ * in `config.requestHandler`) so a later `withConfig({requestHandler})` swap
+ * can't silently drop auth.
+ *
+ * Resolved from the live config on every request, so reconfiguring the token
+ * via `client.config({token})` / `withConfig({token})` swaps refresh behaviour
+ * in or out like any other config change.
+ *
+ * @internal
+ */
+export function resolveRequestHandler(
+  config: InitializedClientConfig,
+): RequestHandler | undefined {
+  const setup = getOAuthTokenSetup(config.token)
+  if (!setup) return config.requestHandler
+  const oauthHandler = createOAuthRefreshHandler(setup)
+  const userHandler = config.requestHandler
+  if (!userHandler) return oauthHandler
+  return (request, next) => oauthHandler(request, (r) => userHandler(r, next))
+}
+
+function withToken(request: RequestHandlerOptions, token: string): RequestHandlerOptions {
+  // `new Headers()` normalises every `FetchHeaders` shape, so no assertion.
+  const headers = new Headers(request.headers)
+  headers.set('Authorization', `Bearer ${token}`)
+  return {...request, headers}
+}
+
+/**
+ * Build the request handler that keeps a client authenticated from an
+ * {@link OAuthTokenSetup}: it applies the current token to every request and,
+ * on a 401, refreshes and retries once.
+ *
+ * On a 401 it re-reads the token before refreshing: if another request — or
+ * another tab, via the provider's storage — already refreshed, it retries with
+ * the current token instead of rotating a still-valid refresh token again.
+ */
+function createOAuthRefreshHandler(setup: OAuthTokenSetup): RequestHandler {
+  const refreshOnce = getOAuthRefresher(setup)
+
+  return async function oauthRefreshHandler(request, next) {
+    // An explicit `Authorization` header (a per-request `token` override or a
+    // config `headers` entry) wins: pass through, with no refresh semantics —
+    // a 401 against a token this handler didn't supply isn't its to fix.
+    if (new Headers(request.headers).has('authorization')) return next(request)
+
+    const token = await setup.getToken()
+    try {
+      return await next(withToken(request, token))
+    } catch (error) {
+      if (!(error instanceof ClientError) || error.statusCode !== 401) throw error
+
+      // Refresh only if the current token is still the one that just failed;
+      // otherwise someone already refreshed and we retry with what's current.
+      let nextToken = await setup.getToken()
+      if (nextToken === token) {
+        try {
+          nextToken = await refreshOnce()
+        } catch {
+          // onAuthError already fired inside refreshOnce. Surface the 401, the
+          // error the caller's request produced, not the refresh failure.
+          throw error
+        }
+      }
+
+      // A logged-out provider yields no token; don't retry with an empty bearer.
+      if (!nextToken) throw error
+
+      // Retry once. A second 401 with a fresh token is a real authz failure.
+      return next(withToken(request, nextToken))
+    }
+  }
+}

--- a/src/http/oauthRefreshHandler.ts
+++ b/src/http/oauthRefreshHandler.ts
@@ -32,7 +32,7 @@ export async function applyOAuthToken(
 ): Promise<Record<string, string>> {
   // `new Headers()` gives a case-insensitive lookup over the plain record.
   if (new Headers(headers).has('authorization')) return headers
-  return {...headers, Authorization: `Bearer ${await setup.getToken()}`}
+  return {...headers, Authorization: `Bearer ${await resolveOAuthToken(setup)}`}
 }
 
 /**
@@ -71,6 +71,27 @@ export function getOAuthRefresher(setup: OAuthTokenSetup): () => Promise<string>
     refreshers.set(setup, refresher)
   }
   return refresher
+}
+
+/**
+ * In ms how early before the expiry do we attempt an automatic refresh.
+ * TODO: define this properly based on what the end lifespan of a token is.
+ */
+const REFRESH_SKEW_MS = 30_000
+
+/**
+ * `getToken()`, or a single-flight `refresh()` when the token is about to
+ * expire. A failed proactive refresh falls back to the current token and
+ * lets the 401 path decide (onAuthError already fired inside the refresher).
+ *
+ * @internal
+ */
+export async function resolveOAuthToken(setup: OAuthTokenSetup): Promise<string> {
+  const expiresAt = setup.getExpiresAt?.()
+  if (expiresAt !== undefined && Date.now() >= expiresAt - REFRESH_SKEW_MS) {
+    return getOAuthRefresher(setup)().catch(() => setup.getToken())
+  }
+  return setup.getToken()
 }
 
 /**
@@ -115,9 +136,7 @@ export async function refreshOnAuthError(
  *
  * @internal
  */
-export function resolveRequestHandler(
-  config: InitializedClientConfig,
-): RequestHandler | undefined {
+export function resolveRequestHandler(config: InitializedClientConfig): RequestHandler | undefined {
   const setup = getOAuthTokenSetup(config.token)
   if (!setup) return config.requestHandler
   const oauthHandler = createOAuthRefreshHandler(setup)
@@ -151,7 +170,7 @@ function createOAuthRefreshHandler(setup: OAuthTokenSetup): RequestHandler {
     // a 401 against a token this handler didn't supply isn't its to fix.
     if (new Headers(request.headers).has('authorization')) return next(request)
 
-    const token = await setup.getToken()
+    const token = await resolveOAuthToken(setup)
     try {
       return await next(withToken(request, token))
     } catch (error) {

--- a/src/http/requestOptions.ts
+++ b/src/http/requestOptions.ts
@@ -34,8 +34,11 @@ export function requestOptions(config: Any, overrides: Any = {}): FetchRequest {
     Object.assign(headers, config.headers)
   }
 
+  // A string token becomes a Bearer header here; an OAuthTokenSetup object is
+  // resolved by the OAuth refresh handler (see `resolveRequestHandler`), which
+  // sets the header itself — never stringify the object into one.
   const token = overrides.token || config.token
-  if (token) {
+  if (typeof token === 'string') {
     headers['Authorization'] = `Bearer ${token}`
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,26 @@ export type RequestHandler = (
 ) => Promise<unknown>
 
 /**
+ * An OAuth token setup, accepted as `token` in place of a static string so the
+ * client can refresh a short-lived access token transparently.
+ * @public
+ */
+export interface OAuthTokenSetup {
+  /**
+   * Resolve the access token for the next request. A provider may refresh
+   * proactively here on expiry skew, so the common path avoids a 401.
+   */
+  getToken: () => Promise<string>
+  /**
+   * Force a refresh after a 401 and resolve to the new access token. Once
+   * resolved, subsequent `getToken()` calls must return the refreshed token.
+   */
+  refresh: () => Promise<string>
+  /** Called when `refresh()` rejects */
+  onAuthError?: (error: unknown) => void
+}
+
+/**
  * @public
  * @deprecated – The `r`-prefix is not required, use `string` instead
  */
@@ -132,7 +152,7 @@ export interface ClientConfig {
   dataset?: string
   /** @defaultValue true */
   useCdn?: boolean
-  token?: string
+  token?: string | OAuthTokenSetup
 
   /**
    * Configure the client to work with a specific Sanity resource (Media Library, Canvas, etc.)

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,11 @@ export interface OAuthTokenSetup {
    * resolved, subsequent `getToken()` calls must return the refreshed token.
    */
   refresh: () => Promise<string>
+  /**
+   * Epoch ms the current access token expires. When provided, the client
+   * refreshes shortly before expiry instead of waiting for a 401.
+   */
+  getExpiresAt?: () => number | undefined
   /** Called when `refresh()` rejects */
   onAuthError?: (error: unknown) => void
 }

--- a/test/oauthRefreshHandler.node.test.ts
+++ b/test/oauthRefreshHandler.node.test.ts
@@ -1,0 +1,48 @@
+import {ClientError, type OAuthTokenSetup} from '@sanity/client'
+import {describe, expect, test, vi} from 'vitest'
+
+import {getClient, projectHost} from './client/helpers'
+import {getActiveMock} from './helpers/mockFetch'
+
+// Where `XMLHttpRequest` is a global (browsers, happy-dom) `assets.upload()`
+// takes the XHR path (`src/http/browserUpload.ts`), which bypasses the client's
+// `resolveFetch` seam and therefore the get-it fetch mock — so these mock-based
+// assertions can only run where XHR is absent and uploads use the fetch path.
+// The XHR path has its own coverage in `browserUpload.browser.test.ts`.
+
+const oauthClient = (setup: OAuthTokenSetup) => getClient({token: setup})
+
+function authHeaders(): Array<string | null> {
+  return getActiveMock()
+    .getRequests()
+    .map((request) => request.headers.get('authorization'))
+}
+
+describe('OAuth auto-refresh (token as OAuthTokenSetup), fetch upload path', () => {
+  test('upload: a 401 refreshes but surfaces the error; the retry uses the fresh token', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('POST', '/v1/assets/images/foo')
+      .respond({status: 401, body: {error: {description: 'Token expired'}}})
+      .respond({status: 201, body: {document: {url: 'https://some.asset.url'}}})
+
+    let currentToken = 'expired-token'
+    const refresh = vi.fn(() => {
+      currentToken = 'fresh-token'
+      return Promise.resolve(currentToken)
+    })
+    const client = oauthClient({getToken: async () => currentToken, refresh})
+
+    // No auto-retry: the 401 surfaces (the body may be a consumed stream)...
+    const error = await client.assets.upload('image', Buffer.from('img')).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ClientError)
+    if (!(error instanceof ClientError)) throw error
+    expect(error.statusCode).toBe(401)
+    // ...but the refresh already happened, so the caller's retry succeeds.
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await expect(client.assets.upload('image', Buffer.from('img'))).resolves.toMatchObject({
+      url: 'https://some.asset.url',
+    })
+    expect(authHeaders()).toEqual(['Bearer expired-token', 'Bearer fresh-token'])
+  })
+})

--- a/test/oauthRefreshHandler.test.ts
+++ b/test/oauthRefreshHandler.test.ts
@@ -1,0 +1,195 @@
+import {ClientError, ConnectionFailedError, type OAuthTokenSetup} from '@sanity/client'
+import {encode} from 'eventsource-encoder'
+import {firstValueFrom} from 'rxjs'
+import {describe, expect, test, vi} from 'vitest'
+
+import {getClient, projectHost} from './client/helpers'
+import {getActiveMock} from './helpers/mockFetch'
+
+const usersPath = '/v1/users/me'
+
+// The DX under test: an OAuth setup handed straight to `token` on the real client.
+const oauthClient = (setup: OAuthTokenSetup) => getClient({token: setup})
+
+function authHeaders(): Array<string | null> {
+  return getActiveMock()
+    .getRequests()
+    .map((request) => request.headers.get('authorization'))
+}
+
+describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
+  test('proactive: applies the token from getToken() to every request', async () => {
+    getActiveMock().scope(projectHost()).on('GET', usersPath).respond({status: 200, body: {id: 'me'}})
+
+    const setup: OAuthTokenSetup = {
+      getToken: async () => 'proactive-token',
+      refresh: () => Promise.reject(new Error('should not refresh')),
+    }
+    const client = oauthClient(setup)
+
+    await expect(client.users.getById('me')).resolves.toEqual({id: 'me'})
+    expect(authHeaders()).toEqual(['Bearer proactive-token'])
+  })
+
+  test('reactive: a 401 refreshes then retries once with the new token', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', usersPath)
+      .respond({status: 401, body: {error: {description: 'Token expired'}}})
+      .respond({status: 200, body: {id: 'me'}})
+
+    const refresh = vi.fn(() => Promise.resolve('fresh-token'))
+    const setup: OAuthTokenSetup = {getToken: async () => 'expired-token', refresh}
+    const client = oauthClient(setup)
+
+    await expect(client.users.getById('me')).resolves.toEqual({id: 'me'})
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(authHeaders()).toEqual(['Bearer expired-token', 'Bearer fresh-token'])
+  })
+
+  test('single-flight: concurrent 401s share one refresh, then each retries', async () => {
+    const concurrency = 3
+    const route = getActiveMock().scope(projectHost()).on('GET', usersPath)
+    for (let i = 0; i < concurrency; i++) {
+      route.respond({status: 401, body: {error: {description: 'Token expired'}}})
+    }
+    for (let i = 0; i < concurrency; i++) {
+      route.respond({status: 200, body: {id: 'me'}})
+    }
+
+    // Gate refresh open until all requests reach it; a straggler starting a
+    // second refresh would fail the dedupe.
+    const gate = Promise.withResolvers<string>()
+    const refresh = vi.fn(() => gate.promise)
+    const setup: OAuthTokenSetup = {getToken: async () => 'expired-token', refresh}
+    const client = oauthClient(setup)
+
+    const inflight = Promise.all(
+      Array.from({length: concurrency}, () => client.users.getById('me')),
+    )
+
+    // Let the first attempts 401 and land on the shared refresh.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    gate.resolve('fresh-token')
+    await expect(inflight).resolves.toEqual([{id: 'me'}, {id: 'me'}, {id: 'me'}])
+
+    const headers = authHeaders()
+    expect(headers.filter((h) => h === 'Bearer expired-token')).toHaveLength(concurrency)
+    expect(headers.filter((h) => h === 'Bearer fresh-token')).toHaveLength(concurrency)
+  })
+
+  test('unrecoverable refresh: calls onAuthError and surfaces the original 401', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', usersPath)
+      .respond({status: 401, body: {error: {description: 'Token expired'}}})
+
+    const refreshError = new Error('refresh token expired')
+    const onAuthError = vi.fn()
+    const setup: OAuthTokenSetup = {
+      getToken: async () => 'expired-token',
+      refresh: () => Promise.reject(refreshError),
+      onAuthError,
+    }
+    const client = oauthClient(setup)
+
+    const error = await client.users.getById('me').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ClientError)
+    if (!(error instanceof ClientError)) throw error
+    expect(error.statusCode).toBe(401)
+    expect(onAuthError).toHaveBeenCalledTimes(1)
+    expect(onAuthError).toHaveBeenCalledWith(refreshError)
+  })
+
+  test('already refreshed: retries with the current token without refreshing', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', usersPath)
+      .respond({status: 401, body: {error: {description: 'Token expired'}}})
+      .respond({status: 200, body: {id: 'me'}})
+
+    // First read is the token we send; by the 401 the provider already holds a
+    // newer one (another request or tab refreshed it).
+    const getToken = vi.fn(async () => 'current-token')
+    getToken.mockResolvedValueOnce('stale-token')
+    const refresh = vi.fn(() => Promise.resolve('unused-token'))
+    const client = oauthClient({getToken, refresh})
+
+    await expect(client.users.getById('me')).resolves.toEqual({id: 'me'})
+    expect(refresh).not.toHaveBeenCalled()
+    expect(authHeaders()).toEqual(['Bearer stale-token', 'Bearer current-token'])
+  })
+
+  test('listen: a 401-rejected connection refreshes then reconnects with the new token', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', '/v1/data/listen/foo')
+      .respond({status: 401, body: 'Unauthorized'})
+      .respond({
+        status: 200,
+        body: encode({event: 'welcome', data: '{}'}),
+        headers: {'Content-Type': 'text/event-stream'},
+      })
+
+    let currentToken = 'expired-token'
+    const refresh = vi.fn(() => {
+      currentToken = 'fresh-token'
+      return Promise.resolve(currentToken)
+    })
+    const client = oauthClient({getToken: async () => currentToken, refresh})
+
+    const event = await firstValueFrom(client.listen('*', {}, {events: ['welcome']}))
+    expect(event).toEqual({type: 'welcome'})
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(authHeaders()).toEqual(['Bearer expired-token', 'Bearer fresh-token'])
+  })
+
+  test('listen: a second consecutive 401 surfaces without another refresh', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', '/v1/data/listen/foo')
+      .respondPersist({status: 401, body: 'Unauthorized'})
+
+    const refresh = vi.fn(() => Promise.resolve('fresh-but-rejected-token'))
+    const client = oauthClient({getToken: async () => 'expired-token', refresh})
+
+    const error = await firstValueFrom(client.listen('*', {}, {events: ['welcome']})).catch(
+      (e: unknown) => e,
+    )
+    expect(error).toBeInstanceOf(ConnectionFailedError)
+    if (!(error instanceof ConnectionFailedError)) throw error
+    expect(error.status).toBe(401)
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  test('unrecoverable refresh: fires onAuthError once across concurrent 401s', async () => {
+    const concurrency = 3
+    const route = getActiveMock().scope(projectHost()).on('GET', usersPath)
+    for (let i = 0; i < concurrency; i++) {
+      route.respond({status: 401, body: {error: {description: 'Token expired'}}})
+    }
+
+    // Gate the shared refresh open until all three 401s have joined it, so the
+    // rejection is observed by all three but onAuthError fires once.
+    const gate = Promise.withResolvers<string>()
+    const refresh = vi.fn(() => gate.promise)
+    const onAuthError = vi.fn()
+    const client = oauthClient({getToken: async () => 'expired-token', refresh, onAuthError})
+
+    const inflight = Promise.allSettled(
+      Array.from({length: concurrency}, () => client.users.getById('me')),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    const refreshError = new Error('refresh token expired')
+    gate.reject(refreshError)
+    const results = await inflight
+
+    expect(results.every((r) => r.status === 'rejected')).toBe(true)
+    expect(onAuthError).toHaveBeenCalledTimes(1)
+    expect(onAuthError).toHaveBeenCalledWith(refreshError)
+  })
+})

--- a/test/oauthRefreshHandler.test.ts
+++ b/test/oauthRefreshHandler.test.ts
@@ -18,8 +18,11 @@ function authHeaders(): Array<string | null> {
 }
 
 describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
-  test('proactive: applies the token from getToken() to every request', async () => {
-    getActiveMock().scope(projectHost()).on('GET', usersPath).respond({status: 200, body: {id: 'me'}})
+  test('applies the token from getToken() to every request', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', usersPath)
+      .respond({status: 200, body: {id: 'me'}})
 
     const setup: OAuthTokenSetup = {
       getToken: async () => 'proactive-token',
@@ -31,7 +34,89 @@ describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
     expect(authHeaders()).toEqual(['Bearer proactive-token'])
   })
 
-  test('reactive: a 401 refreshes then retries once with the new token', async () => {
+  test('an expiring token refreshes before sending, without a 401', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', usersPath)
+      .respond({status: 200, body: {id: 'me'}})
+
+    const refresh = vi.fn(() => Promise.resolve('fresh-token'))
+    const setup: OAuthTokenSetup = {
+      getToken: async () => 'expiring-token',
+      refresh,
+      getExpiresAt: () => Date.now() + 10_000,
+    }
+    const client = oauthClient(setup)
+
+    await expect(client.users.getById('me')).resolves.toEqual({id: 'me'})
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(authHeaders()).toEqual(['Bearer fresh-token'])
+  })
+
+  test('concurrent requests with an expiring token refresh once', async () => {
+    const concurrency = 2
+    const route = getActiveMock().scope(projectHost()).on('GET', usersPath)
+    for (let i = 0; i < concurrency; i++) {
+      route.respond({status: 200, body: {id: 'me'}})
+    }
+
+    const refresh = vi.fn(() => Promise.resolve('fresh-token'))
+    const setup: OAuthTokenSetup = {
+      getToken: async () => 'expiring-token',
+      refresh,
+      getExpiresAt: () => Date.now() + 10_000,
+    }
+    const client = oauthClient(setup)
+
+    await expect(
+      Promise.all(Array.from({length: concurrency}, () => client.users.getById('me'))),
+    ).resolves.toEqual([{id: 'me'}, {id: 'me'}])
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(authHeaders()).toEqual(['Bearer fresh-token', 'Bearer fresh-token'])
+  })
+
+  test('a far-future expiry does not refresh', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', usersPath)
+      .respond({status: 200, body: {id: 'me'}})
+
+    const refresh = vi.fn(() => Promise.reject(new Error('should not refresh')))
+    const setup: OAuthTokenSetup = {
+      getToken: async () => 'valid-token',
+      refresh,
+      getExpiresAt: () => Date.now() + 60 * 60 * 1000,
+    }
+    const client = oauthClient(setup)
+
+    await expect(client.users.getById('me')).resolves.toEqual({id: 'me'})
+    expect(refresh).not.toHaveBeenCalled()
+    expect(authHeaders()).toEqual(['Bearer valid-token'])
+  })
+
+  test('a rejected refresh fires onAuthError and sends the getToken() token', async () => {
+    getActiveMock()
+      .scope(projectHost())
+      .on('GET', usersPath)
+      .respond({status: 200, body: {id: 'me'}})
+
+    const refreshError = new Error('refresh token expired')
+    const onAuthError = vi.fn()
+    const setup: OAuthTokenSetup = {
+      getToken: async () => 'expiring-token',
+      refresh: () => Promise.reject(refreshError),
+      getExpiresAt: () => Date.now() + 10_000,
+      onAuthError,
+    }
+    const client = oauthClient(setup)
+
+    await expect(client.users.getById('me')).resolves.toEqual({id: 'me'})
+    expect(onAuthError).toHaveBeenCalledTimes(1)
+    expect(onAuthError).toHaveBeenCalledWith(refreshError)
+    expect(authHeaders()).toEqual(['Bearer expiring-token'])
+  })
+
+  test('a 401 refreshes then retries once with the new token', async () => {
     getActiveMock()
       .scope(projectHost())
       .on('GET', usersPath)
@@ -47,7 +132,7 @@ describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
     expect(authHeaders()).toEqual(['Bearer expired-token', 'Bearer fresh-token'])
   })
 
-  test('single-flight: concurrent 401s share one refresh, then each retries', async () => {
+  test('concurrent 401s share one refresh, then each retries', async () => {
     const concurrency = 3
     const route = getActiveMock().scope(projectHost()).on('GET', usersPath)
     for (let i = 0; i < concurrency; i++) {
@@ -80,7 +165,7 @@ describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
     expect(headers.filter((h) => h === 'Bearer fresh-token')).toHaveLength(concurrency)
   })
 
-  test('unrecoverable refresh: calls onAuthError and surfaces the original 401', async () => {
+  test('calls onAuthError and surfaces the original 401 for an unrecoverable refresh', async () => {
     getActiveMock()
       .scope(projectHost())
       .on('GET', usersPath)
@@ -103,7 +188,7 @@ describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
     expect(onAuthError).toHaveBeenCalledWith(refreshError)
   })
 
-  test('already refreshed: retries with the current token without refreshing', async () => {
+  test('retries with the current token without refreshing', async () => {
     getActiveMock()
       .scope(projectHost())
       .on('GET', usersPath)
@@ -122,7 +207,7 @@ describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
     expect(authHeaders()).toEqual(['Bearer stale-token', 'Bearer current-token'])
   })
 
-  test('listen: a 401-rejected connection refreshes then reconnects with the new token', async () => {
+  test('a 401-rejected connection refreshes then reconnects with the new token', async () => {
     getActiveMock()
       .scope(projectHost())
       .on('GET', '/v1/data/listen/foo')
@@ -146,7 +231,7 @@ describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
     expect(authHeaders()).toEqual(['Bearer expired-token', 'Bearer fresh-token'])
   })
 
-  test('listen: a second consecutive 401 surfaces without another refresh', async () => {
+  test('a second consecutive 401 surfaces without another refresh', async () => {
     getActiveMock()
       .scope(projectHost())
       .on('GET', '/v1/data/listen/foo')
@@ -164,7 +249,7 @@ describe('OAuth auto-refresh (token as OAuthTokenSetup)', () => {
     expect(refresh).toHaveBeenCalledTimes(1)
   })
 
-  test('unrecoverable refresh: fires onAuthError once across concurrent 401s', async () => {
+  test('fires onAuthError once across concurrent 401s for an unrecoverable refresh', async () => {
     const concurrency = 3
     const route = getActiveMock().scope(projectHost()).on('GET', usersPath)
     for (let i = 0; i < concurrency; i++) {

--- a/test/resumability.test.ts
+++ b/test/resumability.test.ts
@@ -1,0 +1,100 @@
+import {ConnectionFailedError, type OAuthTokenSetup} from '@sanity/client'
+import {encode} from 'eventsource-encoder'
+import {firstValueFrom, take, toArray} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {getClient, projectHost} from './client/helpers'
+import {getActiveMock} from './helpers/mockFetch'
+
+const sse = (body: string) => ({status: 200, body, headers: {'Content-Type': 'text/event-stream'}})
+const oauthClient = (setup: OAuthTokenSetup) => getClient({token: setup})
+
+test('given a listener with a string token, when the server drops the connection, then the eventsource lib reconnects with Last-Event-ID and the same token', async () => {
+  getActiveMock()
+    .scope(projectHost())
+    .on('GET', '/v1/data/listen/foo')
+    .respond(sse(`retry: 1\n\n` + encode({event: 'mutation', id: 'evt-1', data: '{}'})))
+    .respond(sse(encode({event: 'mutation', id: 'evt-2', data: '{}'})))
+
+  const client = getClient({token: 'static-token'})
+  expect(await firstValueFrom(client.listen('*').pipe(take(2), toArray()))).toHaveLength(2)
+
+  const requests = getActiveMock().getRequests()
+  expect(requests.map((r) => r.headers.get('last-event-id'))).toEqual([null, 'evt-1'])
+  expect(requests.map((r) => r.headers.get('authorization'))).toEqual([
+    'Bearer static-token',
+    'Bearer static-token',
+  ])
+})
+
+test('given a listener whose OAuth token rotates mid-stream, when the server drops the connection, then the eventsource lib reconnects with Last-Event-ID and the current token', async () => {
+  getActiveMock()
+    .scope(projectHost())
+    .on('GET', '/v1/data/listen/foo')
+    // `retry: 1` so the eventsource lib reconnects in 1ms instead of 3s; body then ends (server drop)
+    .respond(sse(`retry: 1\n\n` + encode({event: 'mutation', id: 'evt-1', data: '{}'})))
+    .respond(sse(encode({event: 'mutation', id: 'evt-2', data: '{}'})))
+
+  let currentToken = 'token-a'
+  const client = oauthClient({
+    getToken: async () => currentToken,
+    refresh: () => Promise.reject(new Error('not needed')),
+  })
+
+  const events = firstValueFrom(client.listen('*').pipe(take(2), toArray()))
+  // rotate between the two connections, as a provider's background refresh would
+  await new Promise((r) => setTimeout(r, 0))
+  currentToken = 'token-b'
+  expect(await events).toHaveLength(2)
+
+  const requests = getActiveMock().getRequests()
+  expect(requests.map((r) => r.headers.get('last-event-id'))).toEqual([null, 'evt-1'])
+  expect(requests.map((r) => r.headers.get('authorization'))).toEqual([
+    'Bearer token-a',
+    'Bearer token-b',
+  ])
+})
+
+test('given a listener with a string token, when the reconnect is rejected with a 401, then the error surfaces and nothing reconnects', async () => {
+  getActiveMock()
+    .scope(projectHost())
+    .on('GET', '/v1/data/listen/foo')
+    .respond(sse(`retry: 1\n\n` + encode({event: 'mutation', id: 'evt-1', data: '{}'})))
+    .respond({status: 401, body: 'Unauthorized'})
+
+  const client = getClient({token: 'static-token'})
+  const error = await firstValueFrom(client.listen('*').pipe(take(2), toArray())).catch(
+    (e: unknown) => e,
+  )
+
+  expect(error).toBeInstanceOf(ConnectionFailedError)
+  if (!(error instanceof ConnectionFailedError)) throw error
+  expect(error.status).toBe(401)
+  expect(getActiveMock().getRequests()).toHaveLength(2)
+})
+
+test('given a listener whose token has expired, when the reconnect is rejected with a 401, then the EventSource closes and a refreshed one opens without Last-Event-ID', async () => {
+  getActiveMock()
+    .scope(projectHost())
+    .on('GET', '/v1/data/listen/foo')
+    .respond(sse(`retry: 1\n\n` + encode({event: 'mutation', id: 'evt-1', data: '{}'})))
+    .respond({status: 401, body: 'Unauthorized'})
+    .respond(sse(encode({event: 'mutation', id: 'evt-2', data: '{}'})))
+
+  let currentToken = 'expired'
+  const client = oauthClient({
+    getToken: async () => currentToken,
+    refresh: async () => (currentToken = 'fresh'),
+  })
+
+  expect(await firstValueFrom(client.listen('*').pipe(take(2), toArray()))).toHaveLength(2)
+
+  const requests = getActiveMock().getRequests()
+  expect(requests.map((r) => r.headers.get('authorization'))).toEqual([
+    'Bearer expired',
+    'Bearer expired',
+    'Bearer fresh',
+  ])
+  // Last-Event-ID survives the lib's own reconnect (2nd request) but not ours (3rd)
+  expect(requests.map((r) => r.headers.get('last-event-id'))).toEqual([null, 'evt-1', null])
+})

--- a/test/resumability.test.ts
+++ b/test/resumability.test.ts
@@ -4,7 +4,7 @@ import {firstValueFrom, take, toArray} from 'rxjs'
 import {expect, test} from 'vitest'
 
 import {getClient, projectHost} from './client/helpers'
-import {getActiveMock} from './helpers/mockFetch'
+import {getActiveMock, streamBody, streamStall} from './helpers/mockFetch'
 
 const sse = (body: string) => ({status: 200, body, headers: {'Content-Type': 'text/event-stream'}})
 const oauthClient = (setup: OAuthTokenSetup) => getClient({token: setup})
@@ -73,13 +73,27 @@ test('given a listener with a string token, when the reconnect is rejected with 
   expect(getActiveMock().getRequests()).toHaveLength(2)
 })
 
-test('given a listener whose token has expired, when the reconnect is rejected with a 401, then the EventSource closes and a refreshed one opens without Last-Event-ID', async () => {
-  getActiveMock()
-    .scope(projectHost())
+test('given a resumable listener whose token has expired, when the reconnect is rejected with a 401, then the refreshed EventSource resumes from the last event id', async () => {
+  const scope = getActiveMock().scope(projectHost())
+  scope
     .on('GET', '/v1/data/listen/foo')
-    .respond(sse(`retry: 1\n\n` + encode({event: 'mutation', id: 'evt-1', data: '{}'})))
+    .respond(
+      sse(
+        `retry: 1\n\n` +
+          encode({event: 'welcome', data: JSON.stringify({listenerName: 'foo-1'})}) +
+          encode({event: 'mutation', id: 'evt-1', data: '{}'}),
+      ),
+    )
     .respond({status: 401, body: 'Unauthorized'})
-    .respond(sse(encode({event: 'mutation', id: 'evt-2', data: '{}'})))
+  scope.on('GET', '/v1/data/listen/foo', {headers: {'Last-Event-ID': 'evt-1'}}).respond({
+    status: 200,
+    headers: {'Content-Type': 'text/event-stream'},
+    body: streamBody(
+      encode({event: 'welcomeback', data: JSON.stringify({listenerName: 'foo-2'})}) +
+        encode({event: 'mutation', id: 'evt-2', data: '{}'}),
+      streamStall(),
+    ),
+  })
 
   let currentToken = 'expired'
   const client = oauthClient({
@@ -87,7 +101,20 @@ test('given a listener whose token has expired, when the reconnect is rejected w
     refresh: async () => (currentToken = 'fresh'),
   })
 
-  expect(await firstValueFrom(client.listen('*').pipe(take(2), toArray()))).toHaveLength(2)
+  expect(
+    await firstValueFrom(
+      client
+        .listen('*', {}, {enableResume: true, events: ['welcome', 'welcomeback', 'reconnect', 'mutation']})
+        .pipe(take(6), toArray()),
+    ),
+  ).toEqual([
+    {type: 'welcome', listenerName: 'foo-1'},
+    {type: 'mutation'},
+    {type: 'reconnect'},
+    {type: 'reconnect'},
+    {type: 'welcomeback', listenerName: 'foo-2'},
+    {type: 'mutation'},
+  ])
 
   const requests = getActiveMock().getRequests()
   expect(requests.map((r) => r.headers.get('authorization'))).toEqual([
@@ -95,6 +122,5 @@ test('given a listener whose token has expired, when the reconnect is rejected w
     'Bearer expired',
     'Bearer fresh',
   ])
-  // Last-Event-ID survives the lib's own reconnect (2nd request) but not ours (3rd)
-  expect(requests.map((r) => r.headers.get('last-event-id'))).toEqual([null, 'evt-1', null])
+  expect(requests.map((r) => r.headers.get('last-event-id'))).toEqual([null, 'evt-1', 'evt-1'])
 })


### PR DESCRIPTION
## Description

Apps authenticating with short-lived OAuth access tokens would have to catch 401s, refresh, and re-create clients themselves which is annoying for everyone involved.

This lets the client own that instead: configure `auth.oauth` with an `OAuthTokenSetup` and requests, live streams, and uploads stay authenticated across token rotations without the app noticing. When a token genuinely can't be refreshed because the session is over then the app gets a single `onAuthError` signal to send the user back through login, instead of scattered 401s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication across HTTP, uploads, and long-lived SSE connections, including refresh deduplication and 401/reconnect semantics that affect session security.
> 
> **Overview**
> Adds **`auth.oauth`** (`OAuthTokenSetup` with `getToken`, `refresh`, optional `getExpiresAt` / `onAuthError`) as an alternative to a static `token`, with config validation that the two cannot be combined.
> 
> A new **`oauthRefreshHandler`** wraps the normal request pipeline: proactive refresh before expiry, **single-flight** `refresh()` across concurrent callers, **one automatic retry** on 401 for fetch-based APIs, and **`onAuthError`** when refresh fails. The same setup is wired into paths that skip the default handler—**asset uploads** (fetch and XHR), **`listen` / `live` EventSource** (Bearer resolved per fetch, including reconnects), plus **401-driven reconnect** with token refresh and **`Last-Event-ID`** resume so SSE can continue after auth recovery.
> 
> Uploads **do not auto-retry** after 401 (body may be consumed); they still refresh so a caller retry gets a new token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371fd57f9cbaf16159c5021c1a6d0403b01075bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->