### PR TITLE
docs: fix collaboration comments organizationId configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2632,7 +2632,7 @@ Read and write comments on documents in an organization resource. Available on `
 
 #### Configuration
 
-Comments are organization-scoped. The client needs an `organizationId`, plus either a `resource` or `projectId` and `dataset`:
+Comments are organization-scoped. The client needs `collaboration.organizationId`, plus either a `resource` or `projectId` and `dataset`:
 
 ```js
 import {createClient} from '@sanity/client'
@@ -2641,7 +2641,9 @@ const client = createClient({
   apiVersion: '2026-07-18',
   token: 'valid-token',
   useCdn: false,
-  organizationId: 'your-organization-id',
+  collaboration: {
+    organizationId: 'your-organization-id',
+  },
   resource: {
     type: 'canvas',
     id: 'your-canvas-id',
@@ -2649,7 +2651,7 @@ const client = createClient({
 })
 ```
 
-A project-based client only needs `organizationId` added; the dataset resource is derived from `projectId` and `dataset`:
+A project-based client only needs `collaboration.organizationId` added; the dataset resource is derived from `projectId` and `dataset`:
 
 ```js
 const client = createClient({
@@ -2658,7 +2660,9 @@ const client = createClient({
   apiVersion: '2026-07-18',
   token: 'valid-token',
   useCdn: false,
-  organizationId: 'your-organization-id',
+  collaboration: {
+    organizationId: 'your-organization-id',
+  },
 })
 ```
 


### PR DESCRIPTION
### Description

This PR fixes an incorrect top-level `organizationId` in the Collaboration Comments client README. Comments config expects `collaboration.organizationId`, matching the real client API and the error thrown when it is missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **Collaboration Comments API** configuration section in `README.md` so examples match the real client shape: organization scope is set via **`collaboration.organizationId`**, not a top-level **`organizationId`**.
> 
> Both documented `createClient` setups (resource-based canvas client and project/dataset client) now nest the org id under **`collaboration`**, and the prose calls out **`collaboration.organizationId`** consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8449f531c2f21bca904a2192b5f9c161c2cfa0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->